### PR TITLE
c++ / mojo changes for 'external window mode'

### DIFF
--- a/services/ui/demo/manifest.json
+++ b/services/ui/demo/manifest.json
@@ -4,7 +4,7 @@
   "interface_provider_specs": {
     "service_manager:connector": {
       "requires": {
-        "ui": [ "window_manager", "window_tree_host_factory" ]
+        "ui": [ "window_manager", "window_tree_host_factory_registrar" ]
       }
     }
   }

--- a/services/ui/demo/mus_demo_external.cc
+++ b/services/ui/demo/mus_demo_external.cc
@@ -22,18 +22,12 @@ namespace {
 class WindowTreeDataExternal : public WindowTreeData {
  public:
   // Creates a new window tree host associated to the WindowTreeData.
-  WindowTreeDataExternal(mojom::WindowTreeHostFactory* factory,
-                         mojom::WindowTreeClientPtr tree_client,
+  WindowTreeDataExternal(aura::WindowTreeClient* window_tree_client,
                          int square_size)
       : WindowTreeData(square_size) {
-    // TODO(tonikitoo,fwang): Extend the API to allow creating WindowTreeHost
-    // using the WindowTreeClient.
-    factory->CreateWindowTreeHost(MakeRequest(&host_), std::move(tree_client));
+    SetWindowTreeHost(
+        base::MakeUnique<aura::WindowTreeHostMus>(window_tree_client));
   }
-
- private:
-  // Holds the Mojo pointer to the window tree host.
-  mojom::WindowTreeHostPtr host_;
 
   DISALLOW_COPY_AND_ASSIGN(WindowTreeDataExternal);
 };
@@ -50,9 +44,7 @@ MusDemoExternal::~MusDemoExternal() {}
 
 std::unique_ptr<aura::WindowTreeClient>
 MusDemoExternal::CreateWindowTreeClient() {
-  return base::MakeUnique<aura::WindowTreeClient>(
-      context()->connector(), this, nullptr,
-      MakeRequest(&window_tree_client_mojo_));
+  return base::MakeUnique<aura::WindowTreeClient>(context()->connector(), this);
 }
 
 void MusDemoExternal::OnStartImpl() {
@@ -67,38 +59,31 @@ void MusDemoExternal::OnStartImpl() {
     }
   }
 
-  // TODO(tonikitoo,fwang): Extend the WindowTreeClient API to allow connection
-  // to the window tree host factory using window_tree_client().
-  context()->connector()->BindInterface(ui::mojom::kServiceName,
-                                        &window_tree_host_factory_);
+  window_tree_client()->ConnectViaWindowTreeHostFactory();
 
   // TODO(tonikitoo,fwang): Implement management of displays in external mode.
   // For now, a fake display is created in order to work around an assertion in
   // aura::GetDeviceScaleFactorFromDisplay().
   AddPrimaryDisplay(display::Display(0));
 
-  // The number of windows to open is specified by number_of_windows_. The
-  // windows are opened sequentially (the first one here and the others after
-  // each call to OnEmbed) to ensure that the WindowTreeHostMus passed to
-  // OnEmbed corresponds to the WindowTreeDataExternal::host_ created in
-  // OpenNewWindow.
+  // TODO(tonikitoo,fwang): New windows can be launched without need to wait
+  // the respective ::OnEmbed call of the previous instance.
   OpenNewWindow();
 }
 
 void MusDemoExternal::OpenNewWindow() {
-  // TODO(tonikitoo,fwang): Extend the WindowTreeClient API to allow creation
-  // of window tree host. Then pass window_tree_client() here and remove
-  // window_tree_host_factory_ and window_tree_client_mojo_. Currently
-  // window_tree_client_mojo_ is only initialized once so this is incorrect when
-  // kNumberOfWindows > 1.
   AppendWindowTreeData(base::MakeUnique<WindowTreeDataExternal>(
-      window_tree_host_factory_.get(), std::move(window_tree_client_mojo_),
+      window_tree_client(),
       GetSquareSizeForWindow(initialized_windows_count_)));
 }
 
 void MusDemoExternal::OnEmbed(
     std::unique_ptr<aura::WindowTreeHostMus> window_tree_host) {
-  InitWindowTreeData(std::move(window_tree_host));
+  DCHECK(!window_tree_host);
+
+  // TODO: Clean up WindowTreeClientDelegate::OnEmbed API so that it passes
+  // no ownership of WindowTreeHostMus instance.
+  InitWindowTreeData(nullptr);
   initialized_windows_count_++;
 
   // Open the next window until the requested number of windows is reached.

--- a/services/ui/demo/mus_demo_external.h
+++ b/services/ui/demo/mus_demo_external.h
@@ -32,8 +32,6 @@ class MusDemoExternal : public MusDemo {
   void OnEmbed(std::unique_ptr<aura::WindowTreeHostMus> window_tree_host) final;
   void OnEmbedRootDestroyed(aura::WindowTreeHostMus* window_tree_host) final;
 
-  mojom::WindowTreeHostFactoryPtr window_tree_host_factory_;
-  mojom::WindowTreeClientPtr window_tree_client_mojo_;
   size_t initialized_windows_count_ = 0;
 
   size_t number_of_windows_ = 1;

--- a/services/ui/demo/window_tree_data.cc
+++ b/services/ui/demo/window_tree_data.cc
@@ -68,10 +68,11 @@ aura::Window* WindowTreeData::bitmap_window() {
 
 void WindowTreeData::Init(
     std::unique_ptr<aura::WindowTreeHostMus> window_tree_host) {
-  window_tree_host->InitHost();
-  window_tree_host->Show();
-  // Take ownership of the WTH.
-  window_tree_host_ = std::move(window_tree_host);
+  if (window_tree_host) {
+    window_tree_host->InitHost();
+    window_tree_host->Show();
+    SetWindowTreeHost(std::move(window_tree_host));
+  }
 
   // Initialize the window for the bitmap.
   window_delegate_ = new aura_extra::ImageWindowDelegate();

--- a/services/ui/demo/window_tree_data.h
+++ b/services/ui/demo/window_tree_data.h
@@ -27,10 +27,16 @@ class WindowTreeData {
 
   // Initializes the window tree host and start drawing frames.
   void Init(std::unique_ptr<aura::WindowTreeHostMus> window_tree_host);
-  bool IsInitialized() const { return !!window_tree_host_; }
+  bool IsInitialized() const { return window_delegate_; }
 
   const aura::WindowTreeHostMus* WindowTreeHost() const {
     return window_tree_host_.get();
+  }
+
+ protected:
+  void SetWindowTreeHost(
+      std::unique_ptr<aura::WindowTreeHostMus> window_tree_host) {
+    window_tree_host_ = std::move(window_tree_host);
   }
 
  private:

--- a/services/ui/manifest.json
+++ b/services/ui/manifest.json
@@ -61,6 +61,9 @@
         ],
         "window_tree_host_factory": [
           "ui::mojom::WindowTreeHostFactory"
+        ],
+        "window_tree_host_factory_registrar": [
+          "ui::mojom::WindowTreeHostFactoryRegistrar"
         ]
       },
       "requires": {

--- a/services/ui/public/interfaces/window_tree_host.mojom
+++ b/services/ui/public/interfaces/window_tree_host.mojom
@@ -17,9 +17,31 @@ interface WindowTreeHost {
   SetTitle(string title);
 };
 
+// WindowTreeHostFactoryRegistrar is the entry point to obtain a
+// WindowTreeHostFactory instance in 'external window mode'.
+// Callers also obtain a mojo handle to the unique ws::WindowTree instance,
+// on the server-side.
+//
+// NOTE: WindowTreeHostFactoryRegistrar::Register and
+// WindowTreeHostFactory::CreatePlatformWindow are put on separate interfaces,
+// so that the interface containing ::CreatePlatformWindow is obtained by
+// calling ::Register. That eliminates the possibility of ::CreatePlatformWindow
+// being called before ::Register.
+interface WindowTreeHostFactoryRegistrar {
+   Register(WindowTreeHostFactory& window_tree_host_factory,
+            WindowTree& tree_request,
+            WindowTreeClient client);
+};
+
+// WindowTreeHostFactory triggers the creation of WindowTreeHost instances.
 interface WindowTreeHostFactory {
   // Creates a new WindowTreeHost. |tree_client| is queried for the
   // WindowManager.
   CreateWindowTreeHost(WindowTreeHost& window_tree_host,
                        WindowTreeClient tree_client);
+
+  // Creates a new WindowTreeHost in 'external window mode'.
+  // One WindowTree/WindowTreeClient pair can serve one or more WindowTreeHost
+  // instances.
+  CreatePlatformWindow(WindowTreeHost& window_tree_host, uint32 client_id);
 };

--- a/services/ui/service.cc
+++ b/services/ui/service.cc
@@ -40,6 +40,7 @@
 #include "services/ui/ws/window_tree_binding.h"
 #include "services/ui/ws/window_tree_factory.h"
 #include "services/ui/ws/window_tree_host_factory.h"
+#include "services/ui/ws/window_tree_host_factory_registrar.h"
 #include "ui/base/platform_window_defaults.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "ui/base/ui_base_paths.h"
@@ -207,7 +208,8 @@ bool Service::OnConnect(const service_manager::ServiceInfo& remote_info,
   registry->AddInterface<mojom::IMEServer>(this);
   registry->AddInterface<mojom::UserAccessManager>(this);
   registry->AddInterface<mojom::UserActivityMonitor>(this);
-  registry->AddInterface<WindowTreeHostFactory>(this);
+  registry->AddInterface<mojom::WindowTreeHostFactory>(this);
+  registry->AddInterface<mojom::WindowTreeHostFactoryRegistrar>(this);
   registry->AddInterface<mojom::WindowManagerWindowTreeFactory>(this);
   registry->AddInterface<mojom::WindowTreeFactory>(this);
   registry
@@ -353,6 +355,15 @@ void Service::Create(const service_manager::Identity& remote_identity,
         window_server_.get(), remote_identity.user_id()));
   }
   user_state->window_tree_host_factory->AddBinding(std::move(request));
+}
+
+void Service::Create(const service_manager::Identity& remote_identity,
+                     mojom::WindowTreeHostFactoryRegistrarRequest request) {
+  AddUserIfNecessary(remote_identity);
+  mojo::MakeStrongBinding(base::MakeUnique<ws::WindowTreeHostFactoryRegistrar>(
+                              window_server_.get(), remote_identity.user_id()),
+                          std::move(request));
+  window_server_->SetInExternalWindowMode();
 }
 
 void Service::Create(

--- a/services/ui/service.h
+++ b/services/ui/service.h
@@ -75,6 +75,8 @@ class Service
       public service_manager::InterfaceFactory<mojom::WindowTreeFactory>,
       public service_manager::InterfaceFactory<mojom::WindowTreeHostFactory>,
       public service_manager::InterfaceFactory<
+          mojom::WindowTreeHostFactoryRegistrar>,
+      public service_manager::InterfaceFactory<
           discardable_memory::mojom::DiscardableSharedMemoryManager>,
       public service_manager::InterfaceFactory<mojom::WindowServerTest> {
  public:
@@ -156,6 +158,10 @@ class Service
   // service_manager::InterfaceFactory<mojom::WindowTreeHostFactory>:
   void Create(const service_manager::Identity& remote_identity,
               mojom::WindowTreeHostFactoryRequest request) override;
+
+  // service_manager::InterfaceFactory<mojom::WindowTreeHostFactoryRegistrar>:
+  void Create(const service_manager::Identity& remote_identity,
+              mojom::WindowTreeHostFactoryRegistrarRequest request) override;
 
   // service_manager::InterfaceFactory<
   //    discardable_memory::mojom::DiscardableSharedMemoryManager>:

--- a/services/ui/ws/BUILD.gn
+++ b/services/ui/ws/BUILD.gn
@@ -108,6 +108,8 @@ static_library("lib") {
     "window_tree_factory.h",
     "window_tree_host_factory.cc",
     "window_tree_host_factory.h",
+    "window_tree_host_factory_registrar.cc",
+    "window_tree_host_factory_registrar.h",
   ]
 
   deps = [

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -196,7 +196,29 @@ void Display::SetTitle(const std::string& title) {
   platform_display_->SetTitle(base::UTF8ToUTF16(title));
 }
 
+void Display::InitDisplayRoot() {
+  DCHECK(window_server_->IsInExternalWindowMode());
+  DCHECK(binding_);
+
+  external_mode_root_ = base::MakeUnique<WindowManagerDisplayRoot>(this);
+  // TODO(tonikitoo): Code still has assumptions that even in external window
+  // mode make 'window_manager_display_root_map_' needed.
+  window_manager_display_root_map_[service_manager::mojom::kRootUserID] =
+      external_mode_root_.get();
+
+  ServerWindow* server_window = external_mode_root_->root();
+  WindowTree* window_tree = window_server_->GetTreeForExternalWindowMode();
+  window_tree->AddRoot(server_window);
+  window_tree->DoOnEmbed(nullptr /*mojom::WindowTreePtr*/, server_window);
+
+  display_manager()->OnDisplayUpdate(display_);
+}
+
 void Display::InitWindowManagerDisplayRoots() {
+  // Tests can create ws::Display instances directly, by-passing
+  // WindowTreeHostFactory.
+  // TODO(tonikitoo): Check if with the introduction of 'external window mode'
+  // this path is still needed.
   if (binding_) {
     std::unique_ptr<WindowManagerDisplayRoot> display_root_ptr(
         new WindowManagerDisplayRoot(this));
@@ -262,12 +284,22 @@ ServerWindow* Display::GetRootWindow() {
 
 void Display::OnAcceleratedWidgetAvailable() {
   display_manager()->OnDisplayAcceleratedWidgetAvailable(this);
-  InitWindowManagerDisplayRoots();
+
+  if (window_server_->IsInExternalWindowMode())
+    InitDisplayRoot();
+  else
+    InitWindowManagerDisplayRoots();
 }
 
 void Display::OnEvent(const ui::Event& event) {
+  // TODO(tonikitoo): Current WindowManagerDisplayRoot class is misnamed, since
+  // in external window mode a non-WindowManager specific 'DisplayRoot' is also
+  // needed.
+  // Bits of WindowManagerState also should be factored out and made available
+  // in external window mode, so that event handling is functional.
+  // htts://crbug.com/701129
   WindowManagerDisplayRoot* display_root = GetActiveWindowManagerDisplayRoot();
-  if (display_root)
+  if (display_root && display_root->window_manager_state())
     display_root->window_manager_state()->ProcessEvent(event, GetId());
   window_server_
       ->GetUserActivityMonitorForUser(
@@ -277,7 +309,7 @@ void Display::OnEvent(const ui::Event& event) {
 
 void Display::OnNativeCaptureLost() {
   WindowManagerDisplayRoot* display_root = GetActiveWindowManagerDisplayRoot();
-  if (display_root)
+  if (display_root && display_root->window_manager_state())
     display_root->window_manager_state()->SetCapture(nullptr, kInvalidClientId);
 }
 
@@ -360,7 +392,7 @@ void Display::OnFocusChanged(FocusControllerChangeSource change_source,
 
   // WindowManagers are always notified of focus changes.
   WindowManagerDisplayRoot* display_root = GetActiveWindowManagerDisplayRoot();
-  if (display_root) {
+  if (display_root && display_root->window_manager_state()) {
     WindowTree* wm_tree = display_root->window_manager_state()->window_tree();
     if (wm_tree != owning_tree_old && wm_tree != embedded_tree_old &&
         wm_tree != owning_tree_new && wm_tree != embedded_tree_new) {

--- a/services/ui/ws/display.h
+++ b/services/ui/ws/display.h
@@ -162,7 +162,11 @@ class Display : public PlatformDisplayDelegate,
   using WindowManagerDisplayRootMap =
       std::map<UserId, WindowManagerDisplayRoot*>;
 
-  // Inits the necessary state once the display is ready.
+  // Inits the display root once the display is ready in
+  // 'external window mode'.
+  void InitDisplayRoot();
+
+  // Inits the necessary WindowManager state once the display is ready.
   void InitWindowManagerDisplayRoots();
 
   // Creates the set of WindowManagerDisplayRoots from the
@@ -217,6 +221,8 @@ class Display : public PlatformDisplayDelegate,
   cc::LocalSurfaceIdAllocator allocator_;
 
   WindowManagerDisplayRootMap window_manager_display_root_map_;
+
+  std::unique_ptr<WindowManagerDisplayRoot> external_mode_root_;
 
   DISALLOW_COPY_AND_ASSIGN(Display);
 };

--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -193,6 +193,12 @@ WindowTree* WindowServer::GetTreeWithClientName(
   return nullptr;
 }
 
+WindowTree* WindowServer::GetTreeForExternalWindowMode() {
+  DCHECK_LE(1u, tree_map_.size());
+  DCHECK(IsInExternalWindowMode());
+  return tree_map_.begin()->second.get();
+}
+
 ServerWindow* WindowServer::GetWindow(const WindowId& id) {
   // kInvalidClientId is used for Display and WindowManager nodes.
   if (id.client_id == kInvalidClientId) {
@@ -581,7 +587,7 @@ void WindowServer::FinishOperation() {
 void WindowServer::UpdateNativeCursorFromMouseLocation(ServerWindow* window) {
   WindowManagerDisplayRoot* display_root =
       display_manager_->GetWindowManagerDisplayRoot(window);
-  if (display_root) {
+  if (display_root && display_root->window_manager_state()) {
     EventDispatcher* event_dispatcher =
         display_root->window_manager_state()->event_dispatcher();
     event_dispatcher->UpdateCursorProviderByLastKnownLocation();
@@ -593,7 +599,7 @@ void WindowServer::UpdateNativeCursorFromMouseLocation(ServerWindow* window) {
 void WindowServer::UpdateNativeCursorIfOver(ServerWindow* window) {
   WindowManagerDisplayRoot* display_root =
       display_manager_->GetWindowManagerDisplayRoot(window);
-  if (!display_root)
+  if (!display_root || !display_root->window_manager_state())
     return;
 
   EventDispatcher* event_dispatcher =
@@ -667,7 +673,7 @@ void WindowServer::OnWindowHierarchyChanged(ServerWindow* window,
 
   WindowManagerDisplayRoot* display_root =
       display_manager_->GetWindowManagerDisplayRoot(window);
-  if (display_root)
+  if (display_root && display_root->window_manager_state())
     display_root->window_manager_state()
         ->ReleaseCaptureBlockedByAnyModalWindow();
 
@@ -746,7 +752,7 @@ void WindowServer::OnWindowVisibilityChanged(ServerWindow* window) {
 
   WindowManagerDisplayRoot* display_root =
       display_manager_->GetWindowManagerDisplayRoot(window);
-  if (display_root)
+  if (display_root && display_root->window_manager_state())
     display_root->window_manager_state()->ReleaseCaptureBlockedByModalWindow(
         window);
 }

--- a/services/ui/ws/window_server.h
+++ b/services/ui/ws/window_server.h
@@ -27,6 +27,7 @@
 #include "services/ui/ws/user_id_tracker.h"
 #include "services/ui/ws/user_id_tracker_observer.h"
 #include "services/ui/ws/window_manager_window_tree_factory_set.h"
+#include "services/ui/ws/window_tree_host_factory.h"
 
 namespace ui {
 namespace ws {
@@ -100,6 +101,8 @@ class WindowServer : public ServerWindowDelegate,
 
   WindowTree* GetTreeWithClientName(const std::string& client_name);
 
+  WindowTree* GetTreeForExternalWindowMode();
+
   size_t num_trees() const { return tree_map_.size(); }
 
   // Returns the Window identified by |id|.
@@ -136,11 +139,20 @@ class WindowServer : public ServerWindowDelegate,
     return &window_manager_window_tree_factory_set_;
   }
 
+  void set_window_tree_host_factory(
+      std::unique_ptr<WindowTreeHostFactory> factory) {
+    DCHECK(factory);
+    window_tree_host_factory_ = std::move(factory);
+  }
+
   // Sets focus to |window|. Returns true if |window| already has focus, or
   // focus was successfully changed. Returns |false| if |window| is not a valid
   // window to receive focus.
   bool SetFocusedWindow(ServerWindow* window);
   ServerWindow* GetFocusedWindow();
+
+  void SetInExternalWindowMode() { in_external_window_mode = true; }
+  bool IsInExternalWindowMode() const { return in_external_window_mode; }
 
   void SetHighContrastMode(const UserId& user, bool enabled);
 
@@ -380,12 +392,16 @@ class WindowServer : public ServerWindowDelegate,
 
   WindowManagerWindowTreeFactorySet window_manager_window_tree_factory_set_;
 
+  std::unique_ptr<WindowTreeHostFactory> window_tree_host_factory_;
+
   cc::SurfaceId root_surface_id_;
 
   mojo::Binding<cc::mojom::DisplayCompositorClient>
       display_compositor_client_binding_;
   // State for rendering into a Surface.
   cc::mojom::DisplayCompositorPtr display_compositor_;
+
+  bool in_external_window_mode = false;
 
   DISALLOW_COPY_AND_ASSIGN(WindowServer);
 };

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -100,7 +100,34 @@ void WindowTree::Init(std::unique_ptr<WindowTreeBinding> binding,
   if (roots_.empty())
     return;
 
+  DoOnEmbed(std::move(tree), nullptr /*ServerWindow*/);
+}
+
+void WindowTree::DoOnEmbed(mojom::WindowTreePtr tree,
+                           ServerWindow* root_window) {
+  bool in_external_window_mode = !!root_window;
+  if (in_external_window_mode) {
+    DCHECK(!tree);
+    CHECK_LE(1u, roots_.size());
+
+    Display* display = GetDisplay(root_window);
+    int64_t display_id =
+        display ? display->GetId() : display::kInvalidDisplayId;
+
+    ClientWindowId window_id;
+    IsWindowKnown(root_window, &window_id);
+
+    const bool drawn =
+        root_window->parent() && root_window->parent()->IsDrawn();
+    client()->OnEmbed(id_, WindowToWindowData(root_window),
+                      nullptr /*mojom::WindowTreePtr*/, display_id,
+                      window_id.id, drawn);
+    return;
+  }
+
   std::vector<const ServerWindow*> to_send;
+
+  DCHECK(!root_window);
   CHECK_EQ(1u, roots_.size());
   const ServerWindow* root = *roots_.begin();
   GetUnknownWindowsFrom(root, &to_send);
@@ -187,6 +214,22 @@ void WindowTree::PrepareForWindowServerShutdown() {
   binding_->ResetClientForShutdown();
   if (window_manager_internal_)
     window_manager_internal_ = binding_->GetWindowManager();
+}
+
+void WindowTree::AddRoot(const ServerWindow* root) {
+  DCHECK(pending_client_id_ != kInvalidClientId);
+
+  const ClientWindowId client_window_id(pending_client_id_);
+  DCHECK_EQ(0u, client_id_to_window_id_map_.count(client_window_id));
+
+  client_id_to_window_id_map_[client_window_id] = root->id();
+  window_id_to_client_id_map_[root->id()] = client_window_id;
+  pending_client_id_ = kInvalidClientId;
+
+  roots_.insert(root);
+
+  Display* display = GetDisplay(root);
+  DCHECK(display);
 }
 
 void WindowTree::AddRootForWindowManager(const ServerWindow* root) {
@@ -2105,7 +2148,7 @@ bool WindowTree::IsWindowCreatedByWindowManager(
   // WindowManager attached, the window manager didn't create this window.
   const WindowManagerDisplayRoot* display_root =
       GetWindowManagerDisplayRoot(window);
-  if (!display_root)
+  if (!display_root || !display_root->window_manager_state())
     return false;
 
   return display_root->window_manager_state()->window_tree()->id() ==

--- a/services/ui/ws/window_tree.h
+++ b/services/ui/ws/window_tree.h
@@ -149,9 +149,19 @@ class WindowTree : public mojom::WindowTree,
   WindowServer* window_server() { return window_server_; }
   const WindowServer* window_server() const { return window_server_; }
 
+  void WillCreateRootDisplay(uint32_t transport_window_id) {
+    pending_client_id_ = transport_window_id;
+  }
+
+  // Calls WindowTreeClient::OnEmbed.
+  void DoOnEmbed(mojom::WindowTreePtr tree, ServerWindow* root);
+
   // Called from ~WindowServer. Reset WindowTreeClient so that it no longer gets
   // any messages.
   void PrepareForWindowServerShutdown();
+
+  // Adds a new root to this tree.
+  void AddRoot(const ServerWindow* root);
 
   // Adds a new root to this tree. This is only valid for window managers.
   void AddRootForWindowManager(const ServerWindow* root);
@@ -581,6 +591,8 @@ class WindowTree : public mojom::WindowTree,
   std::unique_ptr<WaitingForTopLevelWindowInfo>
       waiting_for_top_level_window_info_;
   bool embedder_intercepts_events_ = false;
+
+  uint32_t pending_client_id_ = kInvalidClientId;
 
   DISALLOW_COPY_AND_ASSIGN(WindowTree);
 };

--- a/services/ui/ws/window_tree_host_factory.cc
+++ b/services/ui/ws/window_tree_host_factory.cc
@@ -8,6 +8,7 @@
 #include "services/ui/ws/display.h"
 #include "services/ui/ws/display_binding.h"
 #include "services/ui/ws/window_server.h"
+#include "services/ui/ws/window_tree.h"
 
 namespace ui {
 namespace ws {
@@ -40,6 +41,27 @@ void WindowTreeHostFactory::CreateWindowTreeHost(
 
   display::Display display(1, metrics.bounds_in_pixels);
   ws_display->SetDisplay(display);
+
+  ws_display->Init(metrics, std::move(display_binding));
+}
+
+void WindowTreeHostFactory::CreatePlatformWindow(
+    mojom::WindowTreeHostRequest tree_host_request,
+    Id transport_window_id) {
+  WindowTree* tree = window_server_->GetTreeForExternalWindowMode();
+  tree->WillCreateRootDisplay(transport_window_id);
+
+  Display* ws_display = new Display(window_server_);
+
+  std::unique_ptr<DisplayBindingImpl> display_binding(
+      new DisplayBindingImpl(std::move(tree_host_request), ws_display, user_id_,
+                             nullptr, window_server_));
+
+  // Provide an initial size for the WindowTreeHost.
+  display::ViewportMetrics metrics;
+  metrics.bounds_in_pixels = gfx::Rect(1024, 768);
+  metrics.device_scale_factor = 1.0f;
+  metrics.ui_scale_factor = 1.0f;
 
   ws_display->Init(metrics, std::move(display_binding));
 }

--- a/services/ui/ws/window_tree_host_factory.h
+++ b/services/ui/ws/window_tree_host_factory.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 #include "mojo/public/cpp/bindings/binding_set.h"
+#include "services/ui/common/types.h"
 #include "services/ui/public/interfaces/window_tree_host.mojom.h"
 #include "services/ui/ws/user_id.h"
 
@@ -27,6 +28,8 @@ class WindowTreeHostFactory : public mojom::WindowTreeHostFactory {
   // mojom::WindowTreeHostFactory implementation.
   void CreateWindowTreeHost(mojom::WindowTreeHostRequest host,
                             mojom::WindowTreeClientPtr tree_client) override;
+  void CreatePlatformWindow(mojom::WindowTreeHostRequest tree_host_request,
+                            Id client_id) override;
 
   WindowServer* window_server_;
   const UserId user_id_;

--- a/services/ui/ws/window_tree_host_factory_registrar.cc
+++ b/services/ui/ws/window_tree_host_factory_registrar.cc
@@ -1,0 +1,54 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "services/ui/ws/window_tree_host_factory_registrar.h"
+
+#include "services/ui/ws/default_access_policy.h"
+#include "services/ui/ws/window_server.h"
+#include "services/ui/ws/window_tree.h"
+#include "services/ui/ws/window_tree_host_factory.h"
+
+namespace ui {
+namespace ws {
+
+WindowTreeHostFactoryRegistrar::WindowTreeHostFactoryRegistrar(
+    WindowServer* window_server,
+    const UserId& user_id)
+    : window_server_(window_server), user_id_(user_id) {}
+
+WindowTreeHostFactoryRegistrar::~WindowTreeHostFactoryRegistrar() {}
+
+void WindowTreeHostFactoryRegistrar::Register(
+    mojom::WindowTreeHostFactoryRequest host_factory_request,
+    mojom::WindowTreeRequest tree_request,
+    mojom::WindowTreeClientPtr tree_client) {
+  std::unique_ptr<WindowTreeHostFactory> host_factory(
+      new WindowTreeHostFactory(window_server_, user_id_));
+
+  host_factory->AddBinding(std::move(host_factory_request));
+
+  std::unique_ptr<ws::WindowTree> tree(
+      new ws::WindowTree(window_server_, user_id_, nullptr /*ServerWindow*/,
+                         base::WrapUnique(new DefaultAccessPolicy)));
+
+  std::unique_ptr<ws::DefaultWindowTreeBinding> tree_binding(
+      new ws::DefaultWindowTreeBinding(tree.get(), window_server_,
+                                       std::move(tree_request),
+                                       std::move(tree_client)));
+
+  // Pass nullptr as mojom::WindowTreePtr (3rd parameter), because in external
+  // window mode, the WindowTreePtr is created on the aura/WindowTreeClient
+  // side.
+  //
+  // NOTE: This call to ::AddTree calls ::Init. However, it will not trigger a
+  // ::OnEmbed call because the WindowTree instance was created above passing
+  // 'nullptr' as the ServerWindow, hence there is no 'root' yet.
+  window_server_->AddTree(std::move(tree), std::move(tree_binding),
+                          nullptr /*mojom::WindowTreePtr*/);
+
+  window_server_->set_window_tree_host_factory(std::move(host_factory));
+}
+
+}  // namespace ws
+}  // namespace ui

--- a/services/ui/ws/window_tree_host_factory_registrar.h
+++ b/services/ui/ws/window_tree_host_factory_registrar.h
@@ -1,0 +1,39 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SERVICES_UI_WS_WINDOW_TREE_HOST_FACTORY_REGISTRAR_H_
+#define SERVICES_UI_WS_WINDOW_TREE_HOST_FACTORY_REGISTRAR_H_
+
+#include "services/ui/public/interfaces/window_tree_host.mojom.h"
+#include "services/ui/ws/user_id.h"
+
+namespace ui {
+namespace ws {
+
+class WindowServer;
+
+class WindowTreeHostFactoryRegistrar
+    : public mojom::WindowTreeHostFactoryRegistrar {
+ public:
+  WindowTreeHostFactoryRegistrar(WindowServer* window_server,
+                                 const UserId& user_id);
+  ~WindowTreeHostFactoryRegistrar() override;
+
+  const UserId& user_id() const { return user_id_; }
+
+ private:
+  void Register(mojom::WindowTreeHostFactoryRequest,
+                mojom::WindowTreeRequest tree_request,
+                mojom::WindowTreeClientPtr tree_client) override;
+
+  WindowServer* window_server_;
+  const UserId user_id_;
+
+  DISALLOW_COPY_AND_ASSIGN(WindowTreeHostFactoryRegistrar);
+};
+
+}  // namespace ws
+}  // namespace ui
+
+#endif  // SERVICES_UI_WS_WINDOW_TREE_HOST_FACTORY_REGISTRAR_H_

--- a/ui/aura/mus/window_tree_client.h
+++ b/ui/aura/mus/window_tree_client.h
@@ -21,6 +21,7 @@
 #include "mojo/public/cpp/bindings/associated_binding.h"
 #include "mojo/public/cpp/bindings/strong_binding.h"
 #include "services/ui/public/interfaces/window_tree.mojom.h"
+#include "services/ui/public/interfaces/window_tree_host.mojom.h"
 #include "ui/aura/aura_export.h"
 #include "ui/aura/client/transient_window_client_observer.h"
 #include "ui/aura/mus/capture_synchronizer_delegate.h"
@@ -110,6 +111,9 @@ class AURA_EXPORT WindowTreeClient
 
   // Establishes the connection by way of the WindowTreeFactory.
   void ConnectViaWindowTreeFactory();
+
+  // Establishes the connection by way of the WindowTreeFactoryHost.
+  void ConnectViaWindowTreeHostFactory();
 
   // Establishes the connection by way of WindowManagerWindowTreeFactory.
   void ConnectAsWindowManager();
@@ -232,6 +236,9 @@ class AURA_EXPORT WindowTreeClient
       WindowMusType window_mus_type,
       const ui::mojom::WindowData& window_data,
       int64_t display_id);
+
+  void ConfigureWindowDataFromServer(WindowTreeHostMus* window_tree_host,
+                                     const ui::mojom::WindowData& window_data);
 
   WindowMus* NewWindowFromWindowData(WindowMus* parent,
                                      const ui::mojom::WindowData& window_data);
@@ -543,6 +550,8 @@ class AURA_EXPORT WindowTreeClient
 
   bool has_pointer_watcher_ = false;
 
+  bool in_external_window_mode_ = false;
+
   // The current change id for the client.
   uint32_t current_move_loop_change_ = 0u;
 
@@ -570,6 +579,9 @@ class AURA_EXPORT WindowTreeClient
   // If |compositor_context_factory_| is installed on Env, then this is the
   // ContextFactory that was set on Env originally.
   ui::ContextFactory* initial_context_factory_ = nullptr;
+
+  ui::mojom::WindowTreeHostFactoryPtr window_tree_host_factory_ptr_;
+
   base::WeakPtrFactory<WindowTreeClient> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(WindowTreeClient);


### PR DESCRIPTION
This CL is the first step towards having 'external window mode' support
in Mus. The existing MusDemo is adapted to test the functionality,
and its respective unit test (mus_demo_unittests) is changed to
exercise  multiple external windows creation in a follow up CL [2].

[2] https://codereview.chromium.org/2715533005/

New code flow:

* MusDemoExternal creates and holds a WindowTreeClient instance.

Note: In Chrome, it also happens in
c/b/ui/views/chrome_browser_main_extra_parts_views.cc,
::ServiceManagerConnectionStarted, when MusClient is created.

* MusDemoExternal calls WindowTreeClient::ConnectViaWindowTreeHostFactory.
This "enters" WindowTreeClient in 'external window mode', and
creates a WindowTreeHostFactoryRegistrar instance.
Through this object, WindowTreeHostFactoryRegistrar::Register is
called, creating WindowTree and WindowTreeHostFactory instances on
the server side, and acquiring WindowTree and
WindowTreeHostFactory mojo handles on the client side.

Note: In external window mode, the WindowTree and WindowTreeHostFactory
are unique instances, serving 0 or 'n' WindowTreeHostMus instances.

* Yet from MusDemoExternal, WindowTreeHostMus instance(s) are
created, in accordance to the value passed to command line
parameter --external-window-count, or 1 by default.

Note: In Chrome, this happens in
c/b/ui/views/frame/browser_frame_mus.cc, ::GetWidgetParams when
DesktopWindowTreeHostMus is created for each outer platform window.

WindowTreeHostMus ctor takes a WindowTreeClient instance which
works as a "window tree host delegate".

* During the creation chain of WindowTreeHostMus, WindowTreeClient::CreateWindowPortForTopLevel
is called, and this is what calls the newly added method
WindowTreeHostFactory::CreatePlatformWindow, when in 'external
window mode'. That is the entry point of of ws::Display instance
creation.

* In the existing creation flow of ws::Display, the server
actually calls back to the client via WindowTreeClient::OnEmbed
when it is done. In 'external window mode' this callback is kept,
but it passes a 'null' WindowTree object as parameter.
Why? Because in ::ConnectViaWindowTreeHostFactory (above) the
unique WindowTree instance was already created.

* services/ui/ws/window_tree_host_factory_registrar.cc|h:

  This class implements WindowTreeHostFactoryRegistrar class.
  It exposes a ::Register method, that:

    (a) Binds the mojom::WindowTreeHostFactoryRequest
    (b) Binds the mojom::WindowTreeRequest
    (c) Stores the mojom::WindowTreeClientPtr to call out
        WindowTreeClient later on.
    (d) A ws::WindowTree instance is also created here. It ensures
        single WindowTree and WindowTreeClient instances serving
        various WindowTreeHost instances.

  The goal of the WindowTreeHostFactoryRegistrar interface is
  to ensure a WindowTreeHostFactory::CreatePlatformWindow can not
  be called before WindowTreeHostFactory being properly set up.

* services/ui/ws/window_tree_host_factory.cc|h:

  Adds ::CreatePlatformWindow method so that it triggers the
  creation of per-outer-window ws::Display instances in external
  window mode.

TODO (in follow up CLs):

  1) Factor non-specific WindowManager specific bits out of
  ws::WindowManagerState, so that event dispatching code can be
  shared between internal and external window modes.

  2) Rename WindowManagerDisplayRoot since it is used in non-WindowManager
  path.

  3) Clean up mus_demo_external (launch instances in parallel?).

  4) Clean up WindowTreeClient::OnEmbed flow.

  5) Experiment with launching Chrome in external window mode.

BUG=666958

patch from issue 2712203002 at patchset 240001 (http://crrev.com/2712203002#ps240001)