### PR TITLE
Make mus_demo_unittests work with multiple root windows

### DIFF
--- a/ash/mus/app_launch_unittest.cc
+++ b/ash/mus/app_launch_unittest.cc
@@ -14,8 +14,10 @@
 namespace ash {
 namespace mus {
 
-void RunCallback(bool* success, const base::Closure& callback, bool result) {
-  *success = result;
+void RunCallback(uint64_t* root_window_count,
+                 const base::Closure& callback,
+                 uint64_t result) {
+  *root_window_count = result;
   callback.Run();
 }
 
@@ -41,12 +43,12 @@ TEST_F(AppLaunchTest, TestQuickLaunch) {
   connector()->BindInterface(ui::mojom::kServiceName, &test_interface);
 
   base::RunLoop run_loop;
-  bool success = false;
-  test_interface->EnsureClientHasDrawnWindow(
+  uint64_t root_window_count = 0;
+  test_interface->EnsureClientHasDrawnRootWindows(
       mash::quick_launch::mojom::kServiceName,
-      base::Bind(&RunCallback, &success, run_loop.QuitClosure()));
+      base::Bind(&RunCallback, &root_window_count, run_loop.QuitClosure()));
   run_loop.Run();
-  EXPECT_TRUE(success);
+  EXPECT_EQ(1u, root_window_count);
 }
 
 }  // namespace mus

--- a/services/ui/demo/mus_demo_unittests.cc
+++ b/services/ui/demo/mus_demo_unittests.cc
@@ -18,8 +18,10 @@ namespace {
 
 const char kTestAppName[] = "mus_demo_unittests";
 
-void RunCallback(bool* success, const base::Closure& callback, bool result) {
-  *success = result;
+void RunCallback(uint64_t* root_window_count,
+                 const base::Closure& callback,
+                 uint64_t result) {
+  *root_window_count = result;
   callback.Run();
 }
 
@@ -33,6 +35,26 @@ class MusDemoTest : public service_manager::test::ServiceTest {
     ServiceTest::SetUp();
   }
 
+ protected:
+  uint64_t StartDemoAndCountDrawnWindows() {
+    connector()->Connect("mus_demo");
+
+    ::ui::mojom::WindowServerTestPtr test_interface;
+    connector()->BindInterface(ui::mojom::kServiceName, &test_interface);
+
+    base::RunLoop run_loop;
+    uint64_t root_window_count = 0;
+    // TODO(kylechar): Fix WindowServer::CreateTreeForWindowManager so that the
+    // WindowTree has the correct name instead of an empty name.
+    // TODO(tonikitoo,fwang): Also fix the WindowTree name for MusDemoExternal.
+    test_interface->EnsureClientHasDrawnRootWindows(
+        "",  // WindowTree name is empty.
+        base::Bind(&RunCallback, &root_window_count, run_loop.QuitClosure()));
+    run_loop.Run();
+
+    return root_window_count;
+  }
+
  private:
   DISALLOW_COPY_AND_ASSIGN(MusDemoTest);
 };
@@ -40,21 +62,17 @@ class MusDemoTest : public service_manager::test::ServiceTest {
 }  // namespace
 
 TEST_F(MusDemoTest, CheckMusDemoDraws) {
-  connector()->Connect("mus_demo");
-
-  ::ui::mojom::WindowServerTestPtr test_interface;
-  connector()->BindInterface(ui::mojom::kServiceName, &test_interface);
-
-  base::RunLoop run_loop;
-  bool success = false;
-  // TODO(kylechar): Fix WindowServer::CreateTreeForWindowManager so that the
-  // WindowTree has the correct name instead of an empty name.
-  test_interface->EnsureClientHasDrawnWindow(
-      "",  // WindowTree name is empty.
-      base::Bind(&RunCallback, &success, run_loop.QuitClosure()));
-  run_loop.Run();
-  EXPECT_TRUE(success);
+  EXPECT_EQ(1u, StartDemoAndCountDrawnWindows());
 }
+
+#if defined(USE_OZONE) && !defined(OS_CHROMEOS)
+TEST_F(MusDemoTest, CheckMusDemoMultipleWindows) {
+  uint64_t expected_root_window_count = 5;
+  base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
+      "external-window-count", std::to_string(expected_root_window_count));
+  EXPECT_EQ(expected_root_window_count, StartDemoAndCountDrawnWindows());
+}
+#endif  // defined(USE_OZONE) && !defined(OS_CHROMEOS)
 
 }  // namespace demo
 }  // namespace ui

--- a/services/ui/public/interfaces/window_server_test.mojom
+++ b/services/ui/public/interfaces/window_server_test.mojom
@@ -7,7 +7,7 @@ module ui.mojom;
 import "ui/events/mojo/event.mojom";
 
 interface WindowServerTest {
-  EnsureClientHasDrawnWindow(string client_name) => (bool success);
+  EnsureClientHasDrawnRootWindows(string client_name) => (uint64 root_window_count);
 
   // Takes an event and dispatches it as if it came from the native platform.
   // Returns false on bad |display_id| or |event|; returns true if it reaches

--- a/services/ui/ws/window_server_test_impl.h
+++ b/services/ui/ws/window_server_test_impl.h
@@ -5,6 +5,8 @@
 #ifndef SERVICES_UI_WS_WINDOW_SERVER_TEST_IMPL_H_
 #define SERVICES_UI_WS_WINDOW_SERVER_TEST_IMPL_H_
 
+#include <map>
+
 #include "services/ui/public/interfaces/window_server_test.mojom.h"
 
 namespace ui {
@@ -20,18 +22,19 @@ class WindowServerTestImpl : public mojom::WindowServerTest {
 
  private:
   void OnWindowPaint(const std::string& name,
-                     const EnsureClientHasDrawnWindowCallback& cb,
+                     const EnsureClientHasDrawnRootWindowsCallback& cb,
                      ServerWindow* window);
 
   // mojom::WindowServerTest:
-  void EnsureClientHasDrawnWindow(
+  void EnsureClientHasDrawnRootWindows(
       const std::string& client_name,
-      const EnsureClientHasDrawnWindowCallback& callback) override;
+      const EnsureClientHasDrawnRootWindowsCallback& callback) override;
   void DispatchEvent(int64_t display_id,
                      std::unique_ptr<ui::Event> event,
                      const DispatchEventCallback& cb) override;
 
   WindowServer* window_server_;
+  std::map<std::string, unsigned> painted_window_roots_;
 
   DISALLOW_COPY_AND_ASSIGN(WindowServerTestImpl);
 };


### PR DESCRIPTION
WindowServerTestImpl::EnsureClientHasDrawnWindow verifies whether one
root window of the WindowTree is drawn. This currently works well for
mus_demo_unittests because the WindowServer only has a single root
window. However, MusDemo will open multiple root windows in external
mode and hence mus_demo_unittests should really check whether all these
windows are drawn.

BUG=666958

Patch from issue 2715533005 at patchset 80001 (https://codereview.chromium.org/2712203002#ps80001)