### PR TITLE
Ozone wayland request close

### DIFF
--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -335,6 +335,20 @@ void Display::OnBoundsChanged(const gfx::Rect& new_bounds) {
   OnBoundsChangedImpl(new_bounds);
 }
 
+void Display::OnCloseRequest() {
+  DCHECK(window_server_->IsInExternalWindowMode());
+  DCHECK(binding_);
+
+  WindowTree* window_tree = window_server_->GetTreeForExternalWindowMode();
+  WindowManagerDisplayRoot* display_root =
+      window_manager_display_root_map_.begin()->second;
+  ServerWindow* server_window =
+      display_root->window_manager_state()->GetWindowManagerRoot(root_window());
+  ClientWindowId window_id;
+  if (window_tree && window_tree->IsWindowKnown(server_window, &window_id))
+    window_tree->client()->RequestClose(window_id.id);
+}
+
 void Display::OnViewportMetricsChanged(
     const display::ViewportMetrics& metrics) {
   if (root_->bounds().size() == metrics.bounds_in_pixels.size())

--- a/services/ui/ws/display.h
+++ b/services/ui/ws/display.h
@@ -189,6 +189,7 @@ class Display : public PlatformDisplayDelegate,
   void OnAcceleratedWidgetAvailable() override;
   void OnNativeCaptureLost() override;
   void OnBoundsChanged(const gfx::Rect& new_bounds) override;
+  void OnCloseRequest() override;
 
   // FocusControllerDelegate:
   bool CanHaveActiveChildren(ServerWindow* window) const override;

--- a/services/ui/ws/display.h
+++ b/services/ui/ws/display.h
@@ -231,8 +231,6 @@ class Display : public PlatformDisplayDelegate,
 
   WindowManagerDisplayRootMap window_manager_display_root_map_;
 
-  std::unique_ptr<WindowManagerState> external_mode_wm_state_;
-
   DISALLOW_COPY_AND_ASSIGN(Display);
 };
 

--- a/services/ui/ws/platform_display_default.cc
+++ b/services/ui/ws/platform_display_default.cc
@@ -226,10 +226,12 @@ void PlatformDisplayDefault::DispatchEvent(ui::Event* event) {
 }
 
 void PlatformDisplayDefault::OnCloseRequest() {
-  // TODO(tonikitoo): Handle a close request in external window mode. The window
-  // should be closed by the WS and it shouldn't involve ScreenManager.
+#if !defined(USE_OZONE) || defined(CHROMEOS)
   const int64_t display_id = delegate_->GetDisplay().id();
   display::ScreenManager::GetInstance()->RequestCloseDisplay(display_id);
+#else
+  delegate_->OnCloseRequest();
+#endif
 }
 
 void PlatformDisplayDefault::OnClosed() {}

--- a/services/ui/ws/platform_display_delegate.h
+++ b/services/ui/ws/platform_display_delegate.h
@@ -40,6 +40,9 @@ class PlatformDisplayDelegate {
   // Called when the Display is resized.
   virtual void OnBoundsChanged(const gfx::Rect& new_bounds) = 0;
 
+  // Called when the Display is closed (external mode).
+  virtual void OnCloseRequest() = 0;
+
  protected:
   virtual ~PlatformDisplayDelegate() {}
 };

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -900,6 +900,13 @@ void WindowTree::SendToPointerWatcher(const ui::Event& event,
                                    display_id);
 }
 
+WindowManagerState* WindowTree::AppendExternalModeWindowManagerState(
+    std::unique_ptr<WindowManagerState> window_manager_state) {
+  WindowManagerState* state = window_manager_state.get();
+  external_mode_wm_states_.insert(std::move(window_manager_state));
+  return state;
+}
+
 bool WindowTree::ShouldRouteToWindowManager(const ServerWindow* window) const {
   if (window_manager_state_)
     return false;  // We are the window manager, don't route to ourself.

--- a/services/ui/ws/window_tree.h
+++ b/services/ui/ws/window_tree.h
@@ -279,6 +279,9 @@ class WindowTree : public mojom::WindowTree,
                             ServerWindow* target_window,
                             int64_t display_id);
 
+  WindowManagerState* AppendExternalModeWindowManagerState(
+      std::unique_ptr<WindowManagerState> window_manager_state);
+
  private:
   friend class test::WindowTreeTestApi;
 
@@ -591,6 +594,7 @@ class WindowTree : public mojom::WindowTree,
       window_manager_internal_client_binding_;
   mojom::WindowManager* window_manager_internal_;
   std::unique_ptr<WindowManagerState> window_manager_state_;
+  std::set<std::unique_ptr<WindowManagerState>> external_mode_wm_states_;
 
   std::unique_ptr<WaitingForTopLevelWindowInfo>
       waiting_for_top_level_window_info_;


### PR DESCRIPTION
@tonikitoo @msisov I analyzed more carefully the destruction this morning and found two issues. This PR includes a first fixup commit for Antonio's "basic event/mouse support" and a second one implementing the request close itself.

Here are the two issues I found:

1) There is a comment in window_manager_state.h indicating that the "WindowManagerDisplayRoots are not destroyed immediately when the Display is destroyed". Hence it's probably not a good idea that the display owns the window manager state referenced by WindowManagerDisplayRoot::WindowManagerState.  Hence I moved ownership of the (external mode) window manager state to the window tree.

2) Display::~Display used to destroy the whole window tree. This no longer works in external mode where you have several Displays (external mode windows) for the same window tree. Hence this PR make changes so that the window tree is only destroyed when the last Display is removed.