### PR TITLE
Remove null-checks for WindowManagerState

### DIFF
--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -58,17 +58,17 @@ Display::~Display() {
     // or more displays, which correspond to WindowTreeHosts.
     WindowManagerDisplayRoot* display_root =
         window_manager_display_root_map_.begin()->second;
-      WindowTree* tree = display_root->window_manager_state()->window_tree();
-      ServerWindow* root = display_root->root();
-      if (tree) {
-        // Delete the window root corresponding to that display.
-        ClientWindowId root_id;
-        if (tree->IsWindowKnown(root, &root_id))
-          tree->DeleteWindow(root_id);
+    WindowTree* tree = display_root->window_manager_state()->window_tree();
+    ServerWindow* root = display_root->root();
+    if (tree) {
+      // Delete the window root corresponding to that display.
+      ClientWindowId root_id;
+      if (tree->IsWindowKnown(root, &root_id))
+        tree->DeleteWindow(root_id);
 
-        // Destroy the tree once all the roots have been removed.
-        if (tree->roots().empty())
-          window_server_->DestroyTree(tree);
+      // Destroy the tree once all the roots have been removed.
+      if (tree->roots().empty())
+        window_server_->DestroyTree(tree);
     }
   }
 }

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -323,7 +323,7 @@ void Display::OnAcceleratedWidgetAvailable() {
 
 void Display::OnNativeCaptureLost() {
   WindowManagerDisplayRoot* display_root = GetActiveWindowManagerDisplayRoot();
-  if (display_root && display_root->window_manager_state())
+  if (display_root)
     display_root->window_manager_state()->SetCapture(nullptr, kInvalidClientId);
 }
 
@@ -432,7 +432,7 @@ void Display::OnFocusChanged(FocusControllerChangeSource change_source,
 
   // WindowManagers are always notified of focus changes.
   WindowManagerDisplayRoot* display_root = GetActiveWindowManagerDisplayRoot();
-  if (display_root && display_root->window_manager_state()) {
+  if (display_root) {
     WindowTree* wm_tree = display_root->window_manager_state()->window_tree();
     if (wm_tree != owning_tree_old && wm_tree != embedded_tree_old &&
         wm_tree != owning_tree_new && wm_tree != embedded_tree_new) {
@@ -462,7 +462,7 @@ EventDispatchDetails Display::OnEventFromSource(Event* event) {
   // in external window mode, so that event handling is functional.
   // htts://crbug.com/701129
   WindowManagerDisplayRoot* display_root = GetActiveWindowManagerDisplayRoot();
-  if (display_root && display_root->window_manager_state()) {
+  if (display_root) {
     WindowManagerState* wm_state = display_root->window_manager_state();
     wm_state->ProcessEvent(*event, GetId());
   }

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -58,7 +58,6 @@ Display::~Display() {
     // or more displays, which correspond to WindowTreeHosts.
     WindowManagerDisplayRoot* display_root =
         window_manager_display_root_map_.begin()->second;
-    if (display_root->window_manager_state()) {
       WindowTree* tree = display_root->window_manager_state()->window_tree();
       ServerWindow* root = display_root->root();
       if (tree) {
@@ -70,7 +69,6 @@ Display::~Display() {
         // Destroy the tree once all the roots have been removed.
         if (tree->roots().empty())
           window_server_->DestroyTree(tree);
-      }
     }
   }
 }

--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -588,7 +588,7 @@ void WindowServer::FinishOperation() {
 void WindowServer::UpdateNativeCursorFromMouseLocation(ServerWindow* window) {
   WindowManagerDisplayRoot* display_root =
       display_manager_->GetWindowManagerDisplayRoot(window);
-  if (display_root && display_root->window_manager_state()) {
+  if (display_root) {
     EventDispatcher* event_dispatcher =
         display_root->window_manager_state()->event_dispatcher();
     event_dispatcher->UpdateCursorProviderByLastKnownLocation();
@@ -600,7 +600,7 @@ void WindowServer::UpdateNativeCursorFromMouseLocation(ServerWindow* window) {
 void WindowServer::UpdateNativeCursorIfOver(ServerWindow* window) {
   WindowManagerDisplayRoot* display_root =
       display_manager_->GetWindowManagerDisplayRoot(window);
-  if (!display_root || !display_root->window_manager_state())
+  if (!display_root)
     return;
 
   EventDispatcher* event_dispatcher =
@@ -674,7 +674,7 @@ void WindowServer::OnWindowHierarchyChanged(ServerWindow* window,
 
   WindowManagerDisplayRoot* display_root =
       display_manager_->GetWindowManagerDisplayRoot(window);
-  if (display_root && display_root->window_manager_state())
+  if (display_root)
     display_root->window_manager_state()
         ->ReleaseCaptureBlockedByAnyModalWindow();
 
@@ -753,7 +753,7 @@ void WindowServer::OnWindowVisibilityChanged(ServerWindow* window) {
 
   WindowManagerDisplayRoot* display_root =
       display_manager_->GetWindowManagerDisplayRoot(window);
-  if (display_root && display_root->window_manager_state())
+  if (display_root)
     display_root->window_manager_state()->ReleaseCaptureBlockedByModalWindow(
         window);
 }

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -302,8 +302,6 @@ void WindowTree::OnWmMoveDragImageAck() {
 bool WindowTree::SetCapture(const ClientWindowId& client_window_id) {
   ServerWindow* window = GetWindowByClientId(client_window_id);
   WindowManagerDisplayRoot* display_root = GetWindowManagerDisplayRoot(window);
-  if (display_root && !display_root->window_manager_state())
-    return false;
   ServerWindow* current_capture_window =
       display_root ? display_root->window_manager_state()->capture_window()
                    : nullptr;
@@ -321,8 +319,6 @@ bool WindowTree::SetCapture(const ClientWindowId& client_window_id) {
 bool WindowTree::ReleaseCapture(const ClientWindowId& client_window_id) {
   ServerWindow* window = GetWindowByClientId(client_window_id);
   WindowManagerDisplayRoot* display_root = GetWindowManagerDisplayRoot(window);
-  if (display_root && !display_root->window_manager_state())
-    return false;
   ServerWindow* current_capture_window =
       display_root ? display_root->window_manager_state()->capture_window()
                    : nullptr;

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -2214,7 +2214,7 @@ bool WindowTree::IsWindowCreatedByWindowManager(
   // WindowManager attached, the window manager didn't create this window.
   const WindowManagerDisplayRoot* display_root =
       GetWindowManagerDisplayRoot(window);
-  if (!display_root || !display_root->window_manager_state())
+  if (!display_root)
     return false;
 
   return display_root->window_manager_state()->window_tree()->id() ==


### PR DESCRIPTION
Two fixups that remove added null-checks for WindowManagerState.