### PR TITLE
fixup! (TEMP) basic event/mouse support

### DIFF
--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -50,10 +50,11 @@ Display::~Display() {
     focus_controller_.reset();
   }
 
-  if (!binding_) {
-    for (auto& pair : window_manager_display_root_map_)
-      pair.second->window_manager_state()->OnDisplayDestroying(this);
-  } else if (!window_manager_display_root_map_.empty()) {
+  // Notify the window manager state that the display is being destroyed.
+  for (auto& pair : window_manager_display_root_map_)
+    pair.second->window_manager_state()->OnDisplayDestroying(this, !!binding_);
+
+  if (binding_ && !window_manager_display_root_map_.empty()) {
     // If there is a |binding_| then the tree was created specifically for one
     // or more displays, which correspond to WindowTreeHosts.
     WindowManagerDisplayRoot* display_root =

--- a/services/ui/ws/window_manager_state.cc
+++ b/services/ui/ws/window_manager_state.cc
@@ -349,7 +349,8 @@ void WindowManagerState::AddWindowManagerDisplayRoot(
   window_manager_display_roots_.push_back(std::move(display_root));
 }
 
-void WindowManagerState::OnDisplayDestroying(Display* display) {
+void WindowManagerState::OnDisplayDestroying(Display* display,
+                                             bool external_window_mode) {
   if (display->platform_display() == platform_display_with_capture_)
     platform_display_with_capture_ = nullptr;
 
@@ -359,7 +360,8 @@ void WindowManagerState::OnDisplayDestroying(Display* display) {
       (*iter)->root()->AddObserver(this);
       orphaned_window_manager_display_roots_.push_back(std::move(*iter));
       window_manager_display_roots_.erase(iter);
-      window_tree_->OnDisplayDestroying(display->GetId());
+      if (!external_window_mode)
+        window_tree_->OnDisplayDestroying(display->GetId());
       return;
     }
   }

--- a/services/ui/ws/window_manager_state.h
+++ b/services/ui/ws/window_manager_state.h
@@ -183,7 +183,7 @@ class WindowManagerState : public EventDispatcherDelegate,
       std::unique_ptr<WindowManagerDisplayRoot> display_root);
 
   // Called when a Display is deleted.
-  void OnDisplayDestroying(Display* display);
+  void OnDisplayDestroying(Display* display, bool external_window_mode);
 
   // Sets the visibility of all window manager roots windows to |value|.
   void SetAllRootWindowsVisible(bool value);


### PR DESCRIPTION
This makes ui::ws::Display::~Display call
WindowManagerState::OnDisplayDestroying in external mode so that
ui::ws::Display::OnWillDestroyTree does not crash when
ui::ws::WindowManagerState::~WindowManagerState is called afterwards.
This happens in particular in mus_ws_unittests when
ui::ws::WindowServerTestHelper::~WindowServerTestHelper resets the
window server.