### PR TITLE
(TEMP) fixup! c++ / mojo changes for 'external window mode' (#10)

### DIFF
--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -129,6 +129,9 @@ void WindowTree::DoOnEmbed(mojom::WindowTreePtr tree,
 
     ClientWindowId window_id;
     IsWindowKnown(root_window, &window_id);
+    
+    // In external window mode, every platform window is an activation parent.
+    AddActivationParent(window_id);
 
     const bool drawn =
         root_window->parent() && root_window->parent()->IsDrawn();


### PR DESCRIPTION
  -- Make 3-dot menu to be drawn.
    - The problem here is that Display doesn't contain
      an activation parent for a window we want to be focused.
      This is a first try to make it working.