### PR TITLE
 Use WindowServer::IsInExternalWindowMode in WindowTreeState rather than pass a bool parameter

### DIFF
--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -52,7 +52,7 @@ Display::~Display() {
 
   // Notify the window manager state that the display is being destroyed.
   for (auto& pair : window_manager_display_root_map_)
-    pair.second->window_manager_state()->OnDisplayDestroying(this, !!binding_);
+    pair.second->window_manager_state()->OnDisplayDestroying(this);
 
   if (binding_ && !window_manager_display_root_map_.empty()) {
     // If there is a |binding_| then the tree was created specifically for one

--- a/services/ui/ws/window_manager_state.cc
+++ b/services/ui/ws/window_manager_state.cc
@@ -349,8 +349,7 @@ void WindowManagerState::AddWindowManagerDisplayRoot(
   window_manager_display_roots_.push_back(std::move(display_root));
 }
 
-void WindowManagerState::OnDisplayDestroying(Display* display,
-                                             bool external_window_mode) {
+void WindowManagerState::OnDisplayDestroying(Display* display) {
   if (display->platform_display() == platform_display_with_capture_)
     platform_display_with_capture_ = nullptr;
 
@@ -360,7 +359,7 @@ void WindowManagerState::OnDisplayDestroying(Display* display,
       (*iter)->root()->AddObserver(this);
       orphaned_window_manager_display_roots_.push_back(std::move(*iter));
       window_manager_display_roots_.erase(iter);
-      if (!external_window_mode)
+      if (!window_server()->IsInExternalWindowMode())
         window_tree_->OnDisplayDestroying(display->GetId());
       return;
     }

--- a/services/ui/ws/window_manager_state.h
+++ b/services/ui/ws/window_manager_state.h
@@ -183,7 +183,7 @@ class WindowManagerState : public EventDispatcherDelegate,
       std::unique_ptr<WindowManagerDisplayRoot> display_root);
 
   // Called when a Display is deleted.
-  void OnDisplayDestroying(Display* display, bool external_window_mode);
+  void OnDisplayDestroying(Display* display);
 
   // Sets the visibility of all window manager roots windows to |value|.
   void SetAllRootWindowsVisible(bool value);


### PR DESCRIPTION
Use WindowServer::IsInExternalWindowMode in WindowTreeState
rather than pass a bool parameter.