### PR TITLE
Make keyboard minimally functional for non-chrome chrome/mus

### DIFF
--- a/chrome/browser/ui/views/ime_driver/ime_driver_mus.cc
+++ b/chrome/browser/ui/views/ime_driver/ime_driver_mus.cc
@@ -54,7 +54,8 @@ void IMEDriver::StartSession(int32_t session_id,
 #else
   input_method_bindings_[session_id] =
       base::MakeUnique<mojo::Binding<ui::mojom::InputMethod>>(
-          new SimpleInputMethod());
+          new SimpleInputMethod(std::move(details->client)),
+          std::move(details->input_method_request));
 #endif
 }
 

--- a/chrome/browser/ui/views/ime_driver/simple_input_method.cc
+++ b/chrome/browser/ui/views/ime_driver/simple_input_method.cc
@@ -4,7 +4,8 @@
 
 #include "chrome/browser/ui/views/ime_driver/simple_input_method.h"
 
-SimpleInputMethod::SimpleInputMethod() {}
+SimpleInputMethod::SimpleInputMethod(ui::mojom::TextInputClientPtr client)
+    : client_(std::move(client)) {}
 
 SimpleInputMethod::~SimpleInputMethod() {}
 
@@ -14,8 +15,15 @@ void SimpleInputMethod::OnTextInputTypeChanged(
 void SimpleInputMethod::OnCaretBoundsChanged(const gfx::Rect& caret_bounds) {}
 
 void SimpleInputMethod::ProcessKeyEvent(
-    std::unique_ptr<ui::Event> key_event,
+    std::unique_ptr<ui::Event> event,
     const ProcessKeyEventCallback& callback) {
+  DCHECK(event->type() == ui::ET_KEY_PRESSED || event->type() == ui::ET_KEY_RELEASED);
+  DCHECK(event->IsKeyEvent());
+
+  ui::KeyEvent* key_event = event->AsKeyEvent();
+  if (!key_event->is_char() && key_event->type() == ui::ET_KEY_PRESSED)
+    client_->InsertChar(std::move(event));
+
   callback.Run(false);
 }
 

--- a/chrome/browser/ui/views/ime_driver/simple_input_method.h
+++ b/chrome/browser/ui/views/ime_driver/simple_input_method.h
@@ -13,7 +13,7 @@
 // locally.
 class SimpleInputMethod : public ui::mojom::InputMethod {
  public:
-  SimpleInputMethod();
+  explicit SimpleInputMethod(ui::mojom::TextInputClientPtr client);
   ~SimpleInputMethod() override;
 
   // ui::mojom::InputMethod:
@@ -24,6 +24,8 @@ class SimpleInputMethod : public ui::mojom::InputMethod {
   void CancelComposition() override;
 
  private:
+  ui::mojom::TextInputClientPtr client_;
+
   DISALLOW_COPY_AND_ASSIGN(SimpleInputMethod);
 };
 


### PR DESCRIPTION
CL passes a TextInputClientPtr mojo handle to SimpleInputMethod
and uses it to forward handling of basic key events.

Note that we should discuss with @moshayedi what the best way
is to handle non-chromeos mus. Email thread started offline.

TEST=Basic input works, as well as modifiers, and overall keystrokes
(home, end, enter, delete, backspace, etc).

Issue #26