### PR TITLE
Fixing decorations, showing menus and clicking

### DIFF
--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -681,7 +681,15 @@ void WindowTreeClient::ScheduleInFlightBoundsChange(
        window->window_mus_type() == WindowMusType::EMBED_IN_OWNER)) {
     local_surface_id = window->GetOrAllocateLocalSurfaceId(new_bounds.size());
   }
-  tree_->SetWindowBounds(change_id, window->server_id(), new_bounds,
+
+  gfx::Rect newest_bounds = new_bounds;
+  // TODO(msisov): figure out why this stops settings bounds of
+  // ServerWindow for additional windows like menus, but still
+  // doesn't break clicking functionality and still let's
+  // main chrome window to set bounds to 10:10, for example.
+  if (window->window_mus_type() == WindowMusType::EMBED)
+    newest_bounds.set_origin(gfx::Point());
+  tree_->SetWindowBounds(change_id, window->server_id(), newest_bounds,
                          local_surface_id);
 }
 

--- a/ui/platform_window/x11/x11_window_base.cc
+++ b/ui/platform_window/x11/x11_window_base.cc
@@ -27,9 +27,15 @@ namespace ui {
 
 namespace {
 
-const char* kAtomsToCache[] = {"UTF8_STRING",  "WM_DELETE_WINDOW",
-                               "_NET_WM_NAME", "_NET_WM_PID",
-                               "_NET_WM_PING", NULL};
+const char* kAtomsToCache[] = {"UTF8_STRING",
+                               "WM_DELETE_WINDOW",
+                               "_NET_WM_NAME",
+                               "_NET_WM_PID",
+                               "_NET_WM_PING",
+                               "_NET_WM_WINDOW_TYPE_MENU",
+                               "_NET_WM_WINDOW_TYPE_NORMAL",
+                               "_NET_WM_WINDOW_TYPE",
+                               NULL};
 
 XID FindXEventTarget(const XEvent& xev) {
   XID target = xev.xany.window;
@@ -78,6 +84,21 @@ void X11WindowBase::Create() {
   swa.background_pixmap = None;
   swa.bit_gravity = NorthWestGravity;
   swa.override_redirect = UseTestConfigForPlatformWindows();
+
+  ::Atom window_type;
+  // TODO(msisov): pass some sort of Widget::InitParams here in order
+  // to configure X11 windows properly.
+  if (bounds_.width() < 400) {
+    // Setting this to True, doesn't allow X server to set different
+    // properties, e.g. decorations.
+    // TODO(msisov): Investigate further.
+    // https://tronche.com/gui/x/xlib/window/attributes/override-redirect.html
+    swa.override_redirect = True;
+    window_type = atom_cache_.GetAtom("_NET_WM_WINDOW_TYPE_MENU");
+  } else {
+    window_type = atom_cache_.GetAtom("_NET_WM_WINDOW_TYPE_NORMAL");
+  }
+
   xwindow_ =
       XCreateWindow(xdisplay_, xroot_window_, bounds_.x(), bounds_.y(),
                     bounds_.width(), bounds_.height(),
@@ -86,6 +107,10 @@ void X11WindowBase::Create() {
                     InputOutput,
                     CopyFromParent,  // visual
                     CWBackPixmap | CWBitGravity | CWOverrideRedirect, &swa);
+
+  XChangeProperty(
+      xdisplay_, xwindow_, atom_cache_.GetAtom("_NET_WM_WINDOW_TYPE"), XA_ATOM,
+      32, PropModeReplace, reinterpret_cast<unsigned char*>(&window_type), 1);
 
   // Setup XInput event mask.
   long event_mask = ButtonPressMask | ButtonReleaseMask | FocusChangeMask |


### PR DESCRIPTION
Commit 55fa90b is a first attemp to remove decorations from windows and set X11 windows to proper type, which fixes right-click menu (if we don't do so, X server sends FocusOut event immediately and right-click menu is not shown).

Second commit 700b29b is a first attemp to make menus clickable. Description is in the commit.