### PR TITLE
Allow ws to pass display::Display data to Aura/client

### DIFF
--- a/services/ui/display/screen_manager_delegate.h
+++ b/services/ui/display/screen_manager_delegate.h
@@ -7,6 +7,8 @@
 
 #include <stdint.h>
 
+#include "services/ui/ws/user_id.h"
+
 namespace display {
 
 class Display;
@@ -29,6 +31,10 @@ class ScreenManagerDelegate {
 
   // Called when the primary display is changed.
   virtual void OnPrimaryDisplayChanged(int64_t primary_display_id) = 0;
+
+  // In external window mode, query the host system about data (resolution)
+  // of the displays available.
+  virtual void OnHostDisplaysReady(const ui::ws::UserId& user_id) = 0;
 
  protected:
   virtual ~ScreenManagerDelegate() {}

--- a/services/ui/display/screen_manager_ozone_external.cc
+++ b/services/ui/display/screen_manager_ozone_external.cc
@@ -7,7 +7,10 @@
 #include <memory>
 
 #include "services/service_manager/public/cpp/binder_registry.h"
+#include "services/service_manager/public/interfaces/connector.mojom.h"
 #include "ui/display/types/display_constants.h"
+#include "ui/gfx/geometry/dip_util.h"
+#include "ui/ozone/public/ozone_platform.h"
 
 namespace display {
 
@@ -16,14 +19,46 @@ std::unique_ptr<ScreenManager> ScreenManager::Create() {
   return base::MakeUnique<ScreenManagerOzoneExternal>();
 }
 
-ScreenManagerOzoneExternal::ScreenManagerOzoneExternal() {}
+ScreenManagerOzoneExternal::ScreenManagerOzoneExternal()
+    : screen_owned_(base::MakeUnique<ScreenBase>())
+    , screen_(screen_owned_.get())
+    , weak_ptr_factory_(this) {
+  Screen::SetScreenInstance(screen_owned_.get());
+}
 
 ScreenManagerOzoneExternal::~ScreenManagerOzoneExternal() {}
+
+void ScreenManagerOzoneExternal::OnHostDisplaysReady(
+    const std::vector<gfx::Size>& dimensions) {
+  float device_scale_factor = 1.f;
+  if (Display::HasForceDeviceScaleFactor())
+    device_scale_factor = Display::GetForcedDeviceScaleFactor();
+
+  gfx::Size scaled_size =
+      gfx::ConvertSizeToDIP(device_scale_factor, dimensions[0]);
+
+  Display display(next_display_id_++);
+  display.set_bounds(gfx::Rect(scaled_size));
+  display.set_work_area(display.bounds());
+  display.set_device_scale_factor(device_scale_factor);
+
+  screen_->display_list().AddDisplay(display, DisplayList::Type::PRIMARY);
+
+  // TODO(tonikitoo): Before calling out to ScreenManagerDelegate check if
+  // more than one host display is available.
+  delegate_->OnHostDisplaysReady(service_manager::mojom::kRootUserID);
+}
 
 void ScreenManagerOzoneExternal::AddInterfaces(
     service_manager::BinderRegistry* registry) {}
 
-void ScreenManagerOzoneExternal::Init(ScreenManagerDelegate* delegate) {}
+void ScreenManagerOzoneExternal::Init(ScreenManagerDelegate* delegate) {
+  delegate_ = delegate;
+
+  ui::OzonePlatform::GetInstance()->QueryHostDisplaysData(
+      base::Bind(&ScreenManagerOzoneExternal::OnHostDisplaysReady,
+                 weak_ptr_factory_.GetWeakPtr()));
+}
 
 void ScreenManagerOzoneExternal::RequestCloseDisplay(int64_t display_id) {}
 

--- a/services/ui/display/screen_manager_ozone_external.h
+++ b/services/ui/display/screen_manager_ozone_external.h
@@ -7,6 +7,9 @@
 
 #include "services/ui/display/screen_manager.h"
 
+#include "base/memory/weak_ptr.h"
+#include "ui/display/screen_base.h"
+
 namespace display {
 
 // In external window mode, the purpose of having a ScreenManager
@@ -22,10 +25,27 @@ class ScreenManagerOzoneExternal : public ScreenManager {
   ~ScreenManagerOzoneExternal() override;
 
  private:
+  // Callback to be called from the Ozone platform when
+  // host displays' data are ready.
+  void OnHostDisplaysReady(const std::vector<gfx::Size>&);
+
   // ScreenManager.
   void AddInterfaces(service_manager::BinderRegistry* registry) override;
   void Init(ScreenManagerDelegate* delegate) override;
   void RequestCloseDisplay(int64_t display_id) override;
+
+  // A Screen instance is created in the constructor because it might be
+  // accessed early. The ownership of this object will be transfered to
+  // |display_manager_| when that gets initialized.
+  std::unique_ptr<ScreenBase> screen_owned_;
+
+  // Used to add/remove/modify displays.
+  ScreenBase* screen_;
+
+  ScreenManagerDelegate* delegate_ = nullptr;
+  int next_display_id_ = 0;
+
+  base::WeakPtrFactory<ScreenManagerOzoneExternal> weak_ptr_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(ScreenManagerOzoneExternal);
 };

--- a/services/ui/service.cc
+++ b/services/ui/service.cc
@@ -280,7 +280,9 @@ void Service::Create(const service_manager::Identity& remote_identity,
 
 void Service::Create(const service_manager::Identity& remote_identity,
                      mojom::DisplayManagerRequest request) {
-  // DisplayManagerObservers generally expect there to be at least one display.
+  // DisplayManagerObservers generally expect there to be at least one display,
+  // except on LinuxOS+Ozone (external window mode).
+#if !defined(USE_OZONE) || !defined(OS_LINUX)
   if (!window_server_->display_manager()->has_displays()) {
     std::unique_ptr<PendingRequest> pending_request(new PendingRequest);
     pending_request->remote_identity = remote_identity;
@@ -289,6 +291,7 @@ void Service::Create(const service_manager::Identity& remote_identity,
     pending_requests_.push_back(std::move(pending_request));
     return;
   }
+#endif
   window_server_->display_manager()
       ->GetUserDisplayManager(remote_identity.user_id())
       ->AddDisplayManagerBinding(std::move(request));

--- a/services/ui/ws/display_manager.cc
+++ b/services/ui/ws/display_manager.cc
@@ -254,5 +254,12 @@ void DisplayManager::OnPrimaryDisplayChanged(int64_t primary_display_id) {
     pair.second->OnPrimaryDisplayChanged(primary_display_id);
 }
 
+void DisplayManager::OnHostDisplaysReady(const UserId& user_id) {
+  // Valid only for when in external window mode.
+  // For now, mimic the behavior of whether we had received the
+  // frame decoration data from the Window Manager.
+  GetUserDisplayManager(user_id)->OnFrameDecorationValuesChanged();
+}
+
 }  // namespace ws
 }  // namespace ui

--- a/services/ui/ws/display_manager.h
+++ b/services/ui/ws/display_manager.h
@@ -97,6 +97,7 @@ class DisplayManager : public UserIdTrackerObserver,
   void OnDisplayModified(const display::Display& display,
                          const display::ViewportMetrics& metrics) override;
   void OnPrimaryDisplayChanged(int64_t primary_display_id) override;
+  void OnHostDisplaysReady(const UserId& user_id) override;
 
   WindowServer* window_server_;
   UserIdTracker* user_id_tracker_;

--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -546,6 +546,11 @@ cc::mojom::FrameSinkManager* WindowServer::GetFrameSinkManager() {
 bool WindowServer::GetFrameDecorationsForUser(
     const UserId& user_id,
     mojom::FrameDecorationValuesPtr* values) {
+  if (IsInExternalWindowMode()) {
+    *values = mojom::FrameDecorationValues::New().Clone();
+    return true;
+  }
+
   WindowManagerState* window_manager_state =
       window_manager_window_tree_factory_set_.GetWindowManagerStateForUser(
           user_id);

--- a/ui/ozone/platform/x11/ozone_platform_x11.cc
+++ b/ui/ozone/platform/x11/ozone_platform_x11.cc
@@ -105,6 +105,16 @@ class OzonePlatformX11 : public OzonePlatform {
     surface_factory_ozone_ = base::MakeUnique<X11SurfaceFactory>();
   }
 
+  void QueryHostDisplaysData(QueryHostDisplaysDataCallback callback) override {
+    DCHECK(!callback.is_null());
+
+    // TODO(tonikitoo): Add support to multiple displays.
+    XDisplay* display = gfx::GetXDisplay();
+    Screen* screen = DefaultScreenOfDisplay(display);
+    callback.Run(std::vector<gfx::Size>(
+        1, gfx::Size(screen->width, screen->height)));
+  }
+
   base::MessageLoop::Type GetMessageLoopTypeForGpu() override {
     // When Ozone X11 backend is running use an UI loop to grab Expose events.
     // See GLSurfaceGLX and https://crbug.com/326995.

--- a/ui/ozone/public/ozone_platform.cc
+++ b/ui/ozone/public/ozone_platform.cc
@@ -98,6 +98,10 @@ base::MessageLoop::Type OzonePlatform::GetMessageLoopTypeForGpu() {
   return base::MessageLoop::TYPE_DEFAULT;
 }
 
+void OzonePlatform::QueryHostDisplaysData(QueryHostDisplaysDataCallback callback) {
+  NOTREACHED();
+}
+
 void OzonePlatform::AddInterfaces(service_manager::BinderRegistry* registry) {}
 
 }  // namespace ui

--- a/ui/ozone/public/ozone_platform.h
+++ b/ui/ozone/public/ozone_platform.h
@@ -7,8 +7,10 @@
 
 #include <memory>
 
+#include "base/callback_forward.h"
 #include "base/macros.h"
 #include "base/message_loop/message_loop.h"
+#include "ui/gfx/geometry/size.h"
 #include "ui/ozone/ozone_export.h"
 
 namespace display {
@@ -114,6 +116,9 @@ class OZONE_EXPORT OzonePlatform {
       const gfx::Rect& bounds) = 0;
   virtual std::unique_ptr<display::NativeDisplayDelegate>
   CreateNativeDisplayDelegate() = 0;
+
+  using QueryHostDisplaysDataCallback = base::Callback<void(const std::vector<gfx::Size>&)>;
+  virtual void QueryHostDisplaysData(QueryHostDisplaysDataCallback callback);
 
   // Returns the message loop type required for OzonePlatform instance that
   // will be initialized for the GPU process.

--- a/ui/views/mus/screen_mus.cc
+++ b/ui/views/mus/screen_mus.cc
@@ -59,10 +59,7 @@ void ScreenMus::Init(service_manager::Connector* connector) {
   //
   // TODO(rockot): Do something better here. This should not have to block tasks
   // from running on the calling thread. http://crbug.com/594852.
-  bool success = false;
-#if !defined(USE_OZONE) || defined(OS_CHROMEOS)
-  success = display_manager_observer_binding_.WaitForIncomingMethodCall();
-#endif
+  bool success = display_manager_observer_binding_.WaitForIncomingMethodCall();
 
   // The WaitForIncomingMethodCall() should have supplied the set of Displays,
   // unless mus is going down, in which case encountered_error() is true, or the


### PR DESCRIPTION
Change ScreenManagerOzoneExternal to be able to send out display::Display
updates via ws::UserDisplayManager (which will send the display::Display
to the client).

For this, patch extends OzonePlatform with a method that allows
its instances (X11, Wayland, etc) to query the host system its displays
data (resolution only for now).
ScreenManagerOzoneExternal then calls to ws::DisplayManager, which calls to
ws::UserDisplayManager.

In order to allow ws::DisplayManager to get display::Display and not change
ws::Display in external mode, a new hook was added: ::OnHostDisplaysReady.

Wayland support will come in a fixup.

Issue #43