### PR TITLE
fixup! Allow ws to pass display::Display data to Aura/client

### DIFF
--- a/services/ui/service.cc
+++ b/services/ui/service.cc
@@ -312,9 +312,9 @@ void Service::Create(const service_manager::Identity& remote_identity,
 
 void Service::Create(const service_manager::Identity& remote_identity,
                      mojom::DisplayManagerRequest request) {
-// DisplayManagerObservers generally expect there to be at least one display,
-// except on LinuxOS+Ozone (external window mode).
-#if !defined(USE_OZONE) || !defined(OS_LINUX)
+  // DisplayManagerObservers generally expect there to be at least one ws::display,
+  // except on LinuxOS/Ozone (external window mode).
+#if !defined(USE_OZONE) || defined(OS_CHROMEOS)
   if (!window_server_->display_manager()->has_displays()) {
     std::unique_ptr<PendingRequest> pending_request(new PendingRequest);
     pending_request->remote_identity = remote_identity;

--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -547,7 +547,13 @@ bool WindowServer::GetFrameDecorationsForUser(
     const UserId& user_id,
     mojom::FrameDecorationValuesPtr* values) {
   if (IsInExternalWindowMode()) {
-    *values = mojom::FrameDecorationValues::New().Clone();
+    *values = mojom::FrameDecorationValues::New();
+    // '33' was picked up by trial/error and because this is the value
+    // used in ChromeOS/mash builds. The value is used to calculate chrome's
+    // tabstrip height in BrowserNonClientFrameViewMus::GetHeaderHeigh().
+    // TODO(tonikitoo,msisov): Maybe there is some refinement to be done here?
+    // What about maximized_client_area_insets and max_title_bar_button_width?
+    (*values)->normal_client_area_insets = gfx::Insets(33, 0, 0, 0);
     return true;
   }
 


### PR DESCRIPTION
These two CLs fix the display::display CL in a couple of ways.