### PR TITLE
Fix missing window decoration

### DIFF
--- a/chrome/browser/ui/views/frame/browser_non_client_frame_view_factory_views.cc
+++ b/chrome/browser/ui/views/frame/browser_non_client_frame_view_factory_views.cc
@@ -20,7 +20,7 @@ namespace chrome {
 BrowserNonClientFrameView* CreateBrowserNonClientFrameView(
     BrowserFrame* frame,
     BrowserView* browser_view) {
-#if defined(USE_AURA)
+#if defined(USE_AURA) && (!defined(USE_OZONE) || defined(OS_CHROMEOS))
   if (service_manager::ServiceManagerIsRemote()) {
     BrowserNonClientFrameViewMus* frame_view =
         new BrowserNonClientFrameViewMus(frame, browser_view);


### PR DESCRIPTION
CL fixes two issues:

  - missing window decoration on ozone/wayland;

  - missing tapstrip background on x11 (opaque black) and wayland
  (transparent).

The way it fixes it is by using OpaqueBrowserFrameView rather than
BrowserNonClientFrameViewMus as its NonClientFrameView instance.

NonClientFrameView is the class responsible for rendering the
non-webcontent's parts of Chrome.

OpaqueBrowserFrameView is the class used in regular Linux/X11
Chrome builds, It provides support for using both Chrome's builtin
frame decoration (including caption buttons) as well to use the
WindowManager's frame decorations. In Ozone/Linux/Chrome/Mus chrome's
builtin one is being used.

Note that ChromeOS/Mash uses BrowserNonClientFrameViewMus but the
tabstrip background and caption buttons are drawn by Ash in [1].
When used in Ozone/Linux/Chrome/Mus it results in parts of the UI
not being drawn.

[1] ash/frame/default_header_painter.cc

Issue #56
Issue #55