### PR TITLE
fixup! Allow ws to pass display::Display data to Aura/client

### DIFF
--- a/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+++ b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
@@ -74,6 +74,19 @@ class OzonePlatformWayland : public OzonePlatform {
     return base::MakeUnique<display::FakeDisplayDelegate>();
   }
 
+  void QueryHostDisplaysData(QueryHostDisplaysDataCallback callback) override {
+    // On Wayland, the screen dimensions come from WaylandOutput.
+    DCHECK(connection_->PrimaryOutput());
+    if (connection_->PrimaryOutput()) {
+      DCHECK(!callback.is_null());
+      gfx::Rect geometry = connection_->PrimaryOutput()->Geometry();
+      callback.Run(std::vector<gfx::Size>(1, geometry.size()));
+      return;
+    }
+
+    CHECK(false) << "Add support for asynchronous resolution fetch.";
+  }
+
   void InitializeUI(const InitParams& args) override {
     connection_.reset(new WaylandConnection);
     if (!connection_->Initialize())

--- a/ui/ozone/platform/wayland/wayland_connection.cc
+++ b/ui/ozone/platform/wayland/wayland_connection.cc
@@ -196,6 +196,10 @@ void WaylandConnection::Global(void* data,
 
     connection->output_list_.push_back(
         base::WrapUnique(new WaylandOutput(output.release())));
+
+    // By the time the Wayland output is instantiated, it must be able
+    // to receive and process events from the Wayland server.
+    connection->StartProcessingEvents();
   }
 
   connection->ScheduleFlush();


### PR DESCRIPTION
This implements the Wayland bits of the resolution fetch logic (currently supported by ozone/x11).