### PR TITLE
fixup! c++ / mojo changes for 'external window mode'

### DIFF
--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -251,8 +251,6 @@ void Display::InitDisplayRoot() {
 
   window_tree->AddRoot(server_window);
   window_tree->DoOnEmbed(nullptr /*mojom::WindowTreePtr*/, server_window);
-
-  display_manager()->OnDisplayUpdate(display_);
 }
 
 void Display::InitWindowManagerDisplayRoots() {


### PR DESCRIPTION
In external window mode, it makes no sense to call
DisplayManager::OnDisplayUpdate when a ws::Display is
initialized.

First because ws::Display has not information about
display::Display instances. Second because ws::Display::display_
is solely to be used in internal window mode, as per the comment
in the header.