### PR TITLE
fixup! fixup! Allow ws to pass display::Display data to Aura/client

### DIFF
--- a/services/ui/service.cc
+++ b/services/ui/service.cc
@@ -219,13 +219,6 @@ void Service::OnStart() {
     input_device_server_.AddInterface(&registry_);
 
 #if defined(USE_OZONE)
-// TODO(msisov, tonikitoo): figure out how screen_manager_ should be initialized
-// after https://codereview.chromium.org/2829733002
-#if defined(OS_LINUX) && !defined(OS_CHROMEOS)
-  screen_manager_ = display::ScreenManager::Create();
-  screen_manager_->AddInterfaces(&registry_);
-#endif
-
   ui::OzonePlatform::GetInstance()->AddInterfaces(&registry_);
 #endif
 }

--- a/services/ui/ws/window_tree_host_factory_registrar.cc
+++ b/services/ui/ws/window_tree_host_factory_registrar.cc
@@ -6,6 +6,7 @@
 
 #include "services/ui/ws/default_access_policy.h"
 #include "services/ui/ws/window_server.h"
+#include "services/ui/ws/window_server_delegate.h"
 #include "services/ui/ws/window_tree.h"
 #include "services/ui/ws/window_tree_host_factory.h"
 
@@ -50,6 +51,11 @@ void WindowTreeHostFactoryRegistrar::Register(
   window_server_->AddTree(std::move(tree), std::move(tree_binding),
                           nullptr /*mojom::WindowTreePtr*/);
   window_server_->set_window_tree_host_factory(std::move(host_factory));
+
+  // TODO(tonikitoo,msisov): Maybe remove the "window manager" suffix
+  // if the method name?
+  window_server_->delegate()->OnWillCreateTreeForWindowManager(
+      true /*automatically_create_display_roots*/);
 }
 
 }  // namespace ws


### PR DESCRIPTION
During the April/24 rebase, msisov@ hardcoded the ScreenManager creating
in ws::service. This method adds a call to ws::Service::OnWillCreateTreeForWindowManager,
similarly to how internal window mode does.