### PR TITLE
fixup! First attemp to remove decorations from small windows

### DIFF
--- a/services/ui/display/viewport_metrics.h
+++ b/services/ui/display/viewport_metrics.h
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "services/ui/public/interfaces/window_manager_constants.mojom.h"
 #include "ui/gfx/geometry/rect.h"
 
 namespace display {
@@ -17,6 +18,11 @@ struct ViewportMetrics {
   gfx::Rect bounds_in_pixels;
   float device_scale_factor = 0.0f;
   float ui_scale_factor = 0.0f;
+
+  // TODO(tonikitoo,msisov): This is an abuse of ViewportMetrics,
+  // and for upstreaming, we should likely consider renaming ViewportMetrics
+  // to DisplayProperties or so.
+  ui::mojom::WindowType window_type = ui::mojom::WindowType::UNKNOWN;
 };
 
 inline bool operator==(const ViewportMetrics& lhs, const ViewportMetrics& rhs) {

--- a/services/ui/ws/platform_display_default.cc
+++ b/services/ui/ws/platform_display_default.cc
@@ -110,6 +110,12 @@ void PlatformDisplayDefault::SetWindowVisibility(bool visible) {
     platform_window_->Hide();
 }
 
+void PlatformDisplayDefault::GetWindowType(
+    ui::mojom::WindowType* result) {
+  DCHECK(result);
+  *result = metrics_.window_type;
+}
+
 void PlatformDisplayDefault::SetCursorById(mojom::CursorType cursor_id) {
   if (!image_cursors_)
     return;

--- a/services/ui/ws/platform_display_default.h
+++ b/services/ui/ws/platform_display_default.h
@@ -51,6 +51,7 @@ class PlatformDisplayDefault : public PlatformDisplay,
   gfx::AcceleratedWidget GetAcceleratedWidget() const override;
   FrameGenerator* GetFrameGenerator() override;
   void SetWindowVisibility(bool visible) override;
+  void GetWindowType(ui::mojom::WindowType* result) override;
 
  private:
   // Update the root_location of located events to be relative to the origin

--- a/services/ui/ws/window_tree_host_factory.cc
+++ b/services/ui/ws/window_tree_host_factory.cc
@@ -52,6 +52,13 @@ void WindowTreeHostFactory::CreatePlatformWindow(
     metrics.bounds_in_pixels = mojo::ConvertTo<gfx::Rect>(iter->second);
   } else
     metrics.bounds_in_pixels = gfx::Rect(1024, 768);
+
+  iter = properties.find(ui::mojom::WindowManager::kWindowType_InitProperty);
+  if (iter != properties.end()) {
+    metrics.window_type =
+        static_cast<ui::mojom::WindowType>(mojo::ConvertTo<int32_t>(iter->second));
+  }
+
   ws_display->Init(metrics, std::move(display_binding));
 }
 

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -59,10 +59,9 @@ bool WaylandWindow::Initialize() {
   }
   wl_surface_set_user_data(surface_.get(), this);
 
-  // TODO(msisov, tonikitoo): pass params from Widget::InitParams to
-  // WaylandWindow in order to configure this window properly. As of now, use
-  // bounds' width.
-  if (bounds_.width() > 400) {
+  ui::mojom::WindowType window_type;
+  delegate_->GetWindowType(&window_type);
+  if (window_type == ui::mojom::WindowType::WINDOW) {
     static const xdg_surface_listener xdg_surface_listener = {
         &WaylandWindow::Configure, &WaylandWindow::Close,
     };

--- a/ui/platform_window/platform_window_delegate.h
+++ b/ui/platform_window/platform_window_delegate.h
@@ -5,6 +5,7 @@
 #ifndef UI_PLATFORM_WINDOW_PLATFORM_WINDOW_DELEGATE_H_
 #define UI_PLATFORM_WINDOW_PLATFORM_WINDOW_DELEGATE_H_
 
+#include "services/ui/public/interfaces/window_manager_constants.mojom.h"
 #include "ui/gfx/native_widget_types.h"
 
 namespace gfx {
@@ -51,6 +52,11 @@ class PlatformWindowDelegate {
   virtual void OnAcceleratedWidgetDestroyed() = 0;
 
   virtual void OnActivationChanged(bool active) = 0;
+
+  // TODO(tonikitoo,msisov): Adding this method with an out parameter so that
+  // we can have a default implementation here and not need to add stubs to
+  // all subclasses. To be discussed when upstraming.
+  virtual void GetWindowType(ui::mojom::WindowType* result) { }
 };
 
 }  // namespace ui

--- a/ui/platform_window/x11/x11_window_base.cc
+++ b/ui/platform_window/x11/x11_window_base.cc
@@ -86,9 +86,9 @@ void X11WindowBase::Create() {
   swa.override_redirect = UseTestConfigForPlatformWindows();
 
   ::Atom window_type;
-  // TODO(msisov): pass some sort of Widget::InitParams here in order
-  // to configure X11 windows properly.
-  if (bounds_.width() < 400) {
+  ui::mojom::WindowType ui_window_type;
+  delegate_->GetWindowType(&ui_window_type);
+  if (ui_window_type != ui::mojom::WindowType::WINDOW) {
     // Setting this to True, doesn't allow X server to set different
     // properties, e.g. decorations.
     // TODO(msisov): Investigate further.


### PR DESCRIPTION
This method extends the existing ws::DisplayViewport struct to
hold information about the window type as well.
This allows the underlaying window manager to create the proper
host window type.

Implementation helps both the ozone/x11 and ozone/wayland backends.
The former uses a hardcoded value to hide (or not) window manager
window decorations (see the omnibox widget - URL autocompletion).
The later, creates "popups" based on a hardcoded window size.

Note that the method added PlatformWindowDelegate has an out parameter
and a default implementation. This is to avoid an empty method body in
the header, and not to have to add implementations to all classes that
inherit from this PlatformWindowDelegate.

Issue #38