### PR TITLE
Set focus to newly created chrome/mus windows

### DIFF
--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -148,6 +148,12 @@ void WindowTree::DoOnEmbed(mojom::WindowTreePtr tree,
     // In external window mode, every platform window is an activation parent.
     AddActivationParent(window_id);
 
+    // In case of external window mode, when aura/mus sets the initial focus
+    // to the Chrome's server window (WindowManagerDisplayRoot::root_), the
+    // call chain checks either WindowManagerDisplayRoot::root_'s parent window
+    // (Display::root_) is part of the Displayu::activation_parents_ set.
+    display->AddActivationParent(display->root_window());
+
     const bool drawn =
         root_window->parent() && root_window->parent()->IsDrawn();
     client()->OnEmbed(id_, WindowToWindowData(root_window),


### PR DESCRIPTION
Upon creation of the main chrome window (at launch), the user has
manually set focus on Chrome's main window in order be able to interact
with it (either by clicking or something else). By the time focus is actually
set, it is even possible to see that the (builtin) caption bar
(title bar + maximize/restore/minimize buttons above the tabstrip) changes color.
This is not how Chrome on Linux/x11 builds behaves.

It happes because WindowTree::SetFocus is called but fails.

  #1 0x56272b974f2d ui::ws::Display::CanHaveActiveChildren()
  #2 0x56272b978455 ui::ws::FocusController::CanBeActivated()
  #3 0x56272b977e84 ui::ws::FocusController::SetFocusedWindowImpl()
  #4 0x56272b973cbb ui::ws::Display::SetFocusedWindow()
  #5 0x56272b961d5c ui::ws::WindowServer::SetFocusedWindow()
  #6 0x56272b968925 ui::ws::WindowTree::SetFocus()
  #7 0x56272b96de2b ui::ws::WindowTree::SetFocus()
  <<<<<mojo>>>>
  #1 0x562881b42f16 aura::FocusSynchronizer::OnWindowFocused()
  #2 0x56288431cc35 wm::FocusController::SetFocusedWindow()
  #3 0x56288431c501 wm::FocusController::FocusAndActivateWindow()
  #4 0x562884314e5c views::DesktopNativeWidgetAura::HandleActivationChanged()
  #5 0x562881b42d67 aura::FocusSynchronizer::SetActiveFocusClient()
  #6 0x562882b24641 views::DesktopWindowTreeHostMus::Activate()
  #7 0x562882b23fd2 views::DesktopWindowTreeHostMus::ShowWindowWithState()
  #8 0x562884315d7b views::DesktopNativeWidgetAura::ShowWithWindowState()
  #9 0x562881fdb8cb views::Widget::Show()
  #10 0x5628828b6375 BrowserView::Show()
  (..)

WindowTree::SetFocus is called with WindowManagerDisplayRoot::root_, which
is the ServerWindow we embed. It only has Display::root_ as parent, and
Display::CanHaveActiveChildren is not ready for this.

This patch accomodates the limitation of setting focus to this window.

Issue #71