### PR TITLE
Make changes to mus to handle window minimize/maximize/restore properties in external window mode.

### DIFF
--- a/content/renderer/mus/renderer_window_tree_client.cc
+++ b/content/renderer/mus/renderer_window_tree_client.cc
@@ -290,6 +290,10 @@ void RendererWindowTreeClient::OnDragDropDone() {}
 void RendererWindowTreeClient::OnChangeCompleted(uint32_t change_id,
                                                  bool success) {}
 
+void RendererWindowTreeClient::OnWindowStateChanged(
+    uint32_t window_id,
+    ui::mojom::ShowState state) {}
+
 void RendererWindowTreeClient::RequestClose(uint32_t window_id) {}
 
 void RendererWindowTreeClient::GetWindowManager(

--- a/content/renderer/mus/renderer_window_tree_client.h
+++ b/content/renderer/mus/renderer_window_tree_client.h
@@ -163,6 +163,8 @@ class RendererWindowTreeClient : public ui::mojom::WindowTreeClient {
                                   uint32_t action_taken) override;
   void OnDragDropDone() override;
   void OnChangeCompleted(uint32_t change_id, bool success) override;
+  void OnWindowStateChanged(uint32_t window_id,
+                            ui::mojom::ShowState state) override;
   void RequestClose(uint32_t window_id) override;
   void GetWindowManager(
       mojo::AssociatedInterfaceRequest<ui::mojom::WindowManager> internal)

--- a/services/ui/public/interfaces/window_tree.mojom
+++ b/services/ui/public/interfaces/window_tree.mojom
@@ -529,6 +529,10 @@ interface WindowTreeClient {
   // A change initiated from the client has completed. See description of
   // change ids for details.
   OnChangeCompleted(uint32 change_id, bool success);
+  
+  // The WindowManager calls back after the client set proprties to minimize, maximize or restore
+  // the window or after the window is restored back from minimized state by clicking on a tray.
+  OnWindowStateChanged(uint32 window_id, ShowState state);
 
   // The WindowManager is requesting the specified window to close. If the
   // client allows the change it should delete the window.

--- a/services/ui/ws/default_access_policy.cc
+++ b/services/ui/ws/default_access_policy.cc
@@ -117,7 +117,9 @@ bool DefaultAccessPolicy::CanSetWindowBounds(const ServerWindow* window) const {
 
 bool DefaultAccessPolicy::CanSetWindowProperties(
     const ServerWindow* window) const {
-  return WasCreatedByThisClient(window);
+  // TODO(msisov, tonikitoo): resolve policies issues.
+  return WasCreatedByThisClient(window) ||
+         delegate_->HasRootForAccessPolicy(window);
 }
 
 bool DefaultAccessPolicy::CanSetWindowTextInputState(

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -361,6 +361,23 @@ void Display::OnCloseRequest() {
     window_tree->client()->RequestClose(window_id.id);
 }
 
+void Display::OnWindowStateChanged(ui::mojom::ShowState new_state) {
+  if (!window_server_->IsInExternalWindowMode())
+    return;
+
+  WindowTree* window_tree = window_server_->GetTreeForExternalWindowMode();
+  WindowManagerDisplayRoot* display_root =
+      window_manager_display_root_map_.begin()->second;
+  ServerWindow* server_window =
+      display_root->window_manager_state()->GetWindowManagerRoot(root_window());
+  ClientWindowId window_id;
+  // We are calling WindowTreeClient directly from here for the sake not
+  // changing WindowTree for such a simple call, adding less code as possible
+  // downstream.
+  if (window_tree && window_tree->IsWindowKnown(server_window, &window_id))
+    window_tree->client()->OnWindowStateChanged(window_id.id, new_state);
+}
+
 OzonePlatform* Display::GetOzonePlatform() {
 #if defined(USE_OZONE)
   return OzonePlatform::GetInstance();

--- a/services/ui/ws/display.h
+++ b/services/ui/ws/display.h
@@ -193,6 +193,7 @@ class Display : public PlatformDisplayDelegate,
   void OnNativeCaptureLost() override;
   void OnBoundsChanged(const gfx::Rect& new_bounds) override;
   void OnCloseRequest() override;
+  void OnWindowStateChanged(ui::mojom::ShowState new_state) override;
 
   OzonePlatform* GetOzonePlatform() override;
 

--- a/services/ui/ws/platform_display.h
+++ b/services/ui/ws/platform_display.h
@@ -15,6 +15,7 @@
 #include "services/ui/public/interfaces/cursor/cursor.mojom.h"
 #include "ui/events/event_source.h"
 #include "ui/gfx/native_widget_types.h"
+#include "ui/platform_window/platform_window_delegate.h"
 
 namespace ui {
 
@@ -63,6 +64,9 @@ class PlatformDisplay : public ui::EventSource {
 
   // Shows or hides native window.
   virtual void SetWindowVisibility(bool visible) {}
+
+  // Changes state of a native window to minimized, maximized or normal.
+  virtual void SetNativeWindowState(ui::mojom::ShowState state) {}
 
   // Overrides factory for testing. Default (NULL) value indicates regular
   // (non-test) environment.

--- a/services/ui/ws/platform_display_default.cc
+++ b/services/ui/ws/platform_display_default.cc
@@ -112,8 +112,24 @@ void PlatformDisplayDefault::SetWindowVisibility(bool visible) {
     platform_window_->Hide();
 }
 
-void PlatformDisplayDefault::GetWindowType(
-    ui::mojom::WindowType* result) {
+void PlatformDisplayDefault::SetNativeWindowState(ui::mojom::ShowState state) {
+  switch (state) {
+    case (ui::mojom::ShowState::MINIMIZED):
+      platform_window_->ReleaseCapture();
+      platform_window_->Minimize();
+      break;
+    case (ui::mojom::ShowState::MAXIMIZED):
+      platform_window_->Maximize();
+      break;
+    case (ui::mojom::ShowState::NORMAL):
+      platform_window_->Restore();
+      break;
+    default:
+      break;
+  }
+}
+
+void PlatformDisplayDefault::GetWindowType(ui::mojom::WindowType* result) {
   DCHECK(result);
   *result = metrics_.window_type;
 }
@@ -256,7 +272,24 @@ void PlatformDisplayDefault::OnCloseRequest() {
 void PlatformDisplayDefault::OnClosed() {}
 
 void PlatformDisplayDefault::OnWindowStateChanged(
-    ui::PlatformWindowState new_state) {}
+    ui::PlatformWindowState new_state) {
+  ui::mojom::ShowState state;
+  switch (new_state) {
+    case (ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MINIMIZED):
+      state = ui::mojom::ShowState::MINIMIZED;
+      break;
+    case (ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MAXIMIZED):
+      state = ui::mojom::ShowState::MAXIMIZED;
+      break;
+    case (ui::PlatformWindowState::PLATFORM_WINDOW_STATE_NORMAL):
+      state = ui::mojom::ShowState::NORMAL;
+      break;
+    default:
+      // We don't support other states at the moment. Ignore them.
+      return;
+  }
+  delegate_->OnWindowStateChanged(state);
+}
 
 void PlatformDisplayDefault::OnLostCapture() {
   delegate_->OnNativeCaptureLost();

--- a/services/ui/ws/platform_display_default.h
+++ b/services/ui/ws/platform_display_default.h
@@ -51,6 +51,7 @@ class PlatformDisplayDefault : public PlatformDisplay,
   gfx::AcceleratedWidget GetAcceleratedWidget() const override;
   FrameGenerator* GetFrameGenerator() override;
   void SetWindowVisibility(bool visible) override;
+  void SetNativeWindowState(ui::mojom::ShowState state) override;
   void GetWindowType(ui::mojom::WindowType* result) override;
 
  private:

--- a/services/ui/ws/platform_display_delegate.h
+++ b/services/ui/ws/platform_display_delegate.h
@@ -44,6 +44,10 @@ class PlatformDisplayDelegate {
   // Called when the Display is closed (external mode).
   virtual void OnCloseRequest() = 0;
 
+  // Called when the Display is minimized, maximized or restored (external
+  // mode).
+  virtual void OnWindowStateChanged(ui::mojom::ShowState new_state) = 0;
+
   // Allows the OzonePlatform to be overridden, e.g. for tests. Returns null
   // for non-Ozone platforms.
   virtual OzonePlatform* GetOzonePlatform() = 0;

--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -10,6 +10,7 @@
 #include "base/logging.h"
 #include "base/memory/ptr_util.h"
 #include "base/stl_util.h"
+#include "services/ui/public/cpp/property_type_converters.h"
 #include "services/ui/ws/display.h"
 #include "services/ui/ws/display_manager.h"
 #include "services/ui/ws/frame_generator.h"
@@ -702,6 +703,17 @@ void WindowServer::SetNativeWindowVisibility(
   display->SetWindowVisibility(visible);
 }
 
+void WindowServer::SetNativeWindowState(ServerWindow* window,
+                                        ui::mojom::ShowState state) {
+  WindowManagerDisplayRoot* display_root =
+      display_manager_->GetWindowManagerDisplayRoot(window);
+  if (!display_root)
+    return;
+  PlatformDisplay* display = display_root->display()->platform_display();
+  DCHECK(display);
+  display->SetNativeWindowState(state);
+}
+
 ServerWindow* WindowServer::GetRootWindow(const ServerWindow* window) {
   Display* display = display_manager_->GetDisplayContaining(window);
   return display ? display->root_window() : nullptr;
@@ -853,6 +865,12 @@ void WindowServer::OnWindowSharedPropertyChanged(
     ServerWindow* window,
     const std::string& name,
     const std::vector<uint8_t>* new_data) {
+  if (in_external_window_mode &&
+      name == mojom::WindowManager::kShowState_Property) {
+    const int64_t state = mojo::ConvertTo<int64_t>(*new_data);
+    SetNativeWindowState(window, static_cast<ui::mojom::ShowState>(state));
+  }
+
   for (auto& pair : tree_map_) {
     pair.second->ProcessWindowPropertyChanged(window, name, new_data,
                                               IsOperationSource(pair.first));

--- a/services/ui/ws/window_server.h
+++ b/services/ui/ws/window_server.h
@@ -309,6 +309,10 @@ class WindowServer : public ServerWindowDelegate,
   void SetNativeWindowVisibility(WindowManagerDisplayRoot* display_root,
                                  bool visible);
 
+  // Sets a state (minimize/maximize/restore) of a native window (only in
+  // external mode).
+  void SetNativeWindowState(ServerWindow* window, ui::mojom::ShowState state);
+
   // Overridden from ServerWindowDelegate:
   ServerWindow* GetRootWindow(const ServerWindow* window) override;
 

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -1546,6 +1546,36 @@ void WindowTreeClient::OnChangeCompleted(uint32_t change_id, bool success) {
   }
 }
 
+void WindowTreeClient::OnWindowStateChanged(uint32_t window_id,
+                                            ui::mojom::ShowState state) {
+  DCHECK(in_external_window_mode_);
+  WindowMus* window = GetWindowByServerId(window_id);
+  if (!window || !IsRoot(window))
+    return;
+
+  aura::Window* aura_window = window->GetWindow();
+  WindowTreeHostMus* host = GetWindowTreeHostMus(aura_window);
+  ui::WindowShowState show_state;
+  switch (state) {
+    case (ui::mojom::ShowState::MINIMIZED):
+      show_state = ui::SHOW_STATE_MINIMIZED;
+      host->Hide();
+      break;
+    case (ui::mojom::ShowState::MAXIMIZED):
+      show_state = ui::SHOW_STATE_MAXIMIZED;
+      host->Show();
+      break;
+    case (ui::mojom::ShowState::NORMAL):
+      show_state = ui::SHOW_STATE_NORMAL;
+      host->Show();
+      break;
+    default:
+      return;
+  }
+
+  aura_window->SetProperty(aura::client::kShowStateKey, show_state);
+}
+
 void WindowTreeClient::GetWindowManager(
     mojo::AssociatedInterfaceRequest<WindowManager> internal) {
   window_manager_internal_.reset(

--- a/ui/aura/mus/window_tree_client.h
+++ b/ui/aura/mus/window_tree_client.h
@@ -425,6 +425,8 @@ class AURA_EXPORT WindowTreeClient
                                   uint32_t action_taken) override;
   void OnDragDropDone() override;
   void OnChangeCompleted(uint32_t change_id, bool success) override;
+  void OnWindowStateChanged(uint32_t window_id,
+                            ui::mojom::ShowState state) override;
   void RequestClose(uint32_t window_id) override;
   void GetWindowManager(
       mojo::AssociatedInterfaceRequest<WindowManager> internal) override;

--- a/ui/platform_window/x11/x11_window_base.cc
+++ b/ui/platform_window/x11/x11_window_base.cc
@@ -13,6 +13,7 @@
 
 #include "base/strings/utf_string_conversions.h"
 #include "ui/base/platform_window_defaults.h"
+#include "ui/base/x/x11_util.h"
 #include "ui/base/x/x11_window_event_manager.h"
 #include "ui/events/devices/x11/touch_factory_x11.h"
 #include "ui/events/event.h"
@@ -27,11 +28,19 @@ namespace ui {
 
 namespace {
 
+// Constants that are part of EWMH.
+const int k_NET_WM_STATE_ADD = 1;
+const int k_NET_WM_STATE_REMOVE = 0;
+
 const char* kAtomsToCache[] = {"UTF8_STRING",
                                "WM_DELETE_WINDOW",
                                "_NET_WM_NAME",
                                "_NET_WM_PID",
                                "_NET_WM_PING",
+                               "_NET_WM_STATE",
+                               "_NET_WM_STATE_HIDDEN",
+                               "_NET_WM_STATE_MAXIMIZED_HORZ",
+                               "_NET_WM_STATE_MAXIMIZED_VERT",
                                "_NET_WM_WINDOW_TYPE_MENU",
                                "_NET_WM_WINDOW_TYPE_NORMAL",
                                "_NET_WM_WINDOW_TYPE",
@@ -194,7 +203,7 @@ void X11WindowBase::Show() {
 }
 
 void X11WindowBase::Hide() {
-  if (!window_mapped_)
+  if (!window_mapped_ || IsMinimized())
     return;
   XWithdrawWindow(xdisplay_, xwindow_, 0);
   window_mapped_ = false;
@@ -266,11 +275,28 @@ void X11WindowBase::ReleaseCapture() {}
 
 void X11WindowBase::ToggleFullscreen() {}
 
-void X11WindowBase::Maximize() {}
+void X11WindowBase::Maximize() {
+  if (IsMaximized())
+    return;
+  // When we are in the process of requesting to maximize a window, we can
+  // accurately keep track of our restored bounds instead of relying on the
+  // heuristics that are in the PropertyNotify and ConfigureNotify handlers.
+  restored_bounds_in_pixels_ = bounds_;
 
-void X11WindowBase::Minimize() {}
+  SetWMSpecState(true, atom_cache_.GetAtom("_NET_WM_STATE_MAXIMIZED_VERT"),
+                 atom_cache_.GetAtom("_NET_WM_STATE_MAXIMIZED_HORZ"));
+}
 
-void X11WindowBase::Restore() {}
+void X11WindowBase::Minimize() {
+  if (IsMinimized())
+    return;
+  XIconifyWindow(xdisplay_, xwindow_, 0);
+}
+
+void X11WindowBase::Restore() {
+  SetWMSpecState(false, atom_cache_.GetAtom("_NET_WM_STATE_MAXIMIZED_VERT"),
+                 atom_cache_.GetAtom("_NET_WM_STATE_MAXIMIZED_HORZ"));
+}
 
 void X11WindowBase::MoveCursorTo(const gfx::Point& location) {
   XWarpPointer(xdisplay_, None, xroot_window_, 0, 0, 0, 0,
@@ -339,7 +365,84 @@ void X11WindowBase::ProcessXWindowEvent(XEvent* xev) {
       }
       break;
     }
+
+    case PropertyNotify: {
+      ::Atom changed_atom = xev->xproperty.atom;
+      if (changed_atom == atom_cache_.GetAtom("_NET_WM_STATE"))
+        OnWMStateUpdated();
+      break;
+    }
   }
+}
+
+void X11WindowBase::SetWMSpecState(bool enabled, ::Atom state1, ::Atom state2) {
+  XEvent xclient;
+  memset(&xclient, 0, sizeof(xclient));
+  xclient.type = ClientMessage;
+  xclient.xclient.window = xwindow_;
+  xclient.xclient.message_type = atom_cache_.GetAtom("_NET_WM_STATE");
+  xclient.xclient.format = 32;
+  xclient.xclient.data.l[0] =
+      enabled ? k_NET_WM_STATE_ADD : k_NET_WM_STATE_REMOVE;
+  xclient.xclient.data.l[1] = state1;
+  xclient.xclient.data.l[2] = state2;
+  xclient.xclient.data.l[3] = 1;
+  xclient.xclient.data.l[4] = 0;
+
+  XSendEvent(xdisplay_, xroot_window_, False,
+             SubstructureRedirectMask | SubstructureNotifyMask, &xclient);
+}
+
+void X11WindowBase::OnWMStateUpdated() {
+  std::vector<::Atom> atom_list;
+  // Ignore the return value of ui::GetAtomArrayProperty(). Fluxbox removes the
+  // _NET_WM_STATE property when no _NET_WM_STATE atoms are set.
+  ui::GetAtomArrayProperty(xwindow_, "_NET_WM_STATE", &atom_list);
+
+  bool was_minimized = IsMinimized();
+
+  window_properties_.clear();
+  std::copy(atom_list.begin(), atom_list.end(),
+            inserter(window_properties_, window_properties_.begin()));
+
+  // Propagate the window minimization information to the client.
+  bool is_minimized = IsMinimized();
+  ui::PlatformWindowState state;
+  // Check state after minimization/restore.
+  if (is_minimized != was_minimized) {
+    if (is_minimized) {
+      state = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MINIMIZED;
+    } else {
+      // When the window is recovered from minimized state, set state to the
+      // previous state.
+      state = IsMaximized()
+                  ? ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MAXIMIZED
+                  : ui::PlatformWindowState::PLATFORM_WINDOW_STATE_NORMAL;
+    }
+    delegate_->OnWindowStateChanged(state);
+    return;
+  }
+
+  // If it hasn't been a restore or minimize state, then check if the window
+  // has been maximized or restored.
+  state = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_NORMAL;
+  if (IsMaximized())
+    state = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MAXIMIZED;
+  delegate_->OnWindowStateChanged(state);
+}
+
+bool X11WindowBase::HasWMSpecProperty(const char* property) const {
+  return window_properties_.find(atom_cache_.GetAtom(property)) !=
+         window_properties_.end();
+}
+
+bool X11WindowBase::IsMinimized() const {
+  return HasWMSpecProperty("_NET_WM_STATE_HIDDEN");
+}
+
+bool X11WindowBase::IsMaximized() const {
+  return (HasWMSpecProperty("_NET_WM_STATE_MAXIMIZED_VERT") &&
+          HasWMSpecProperty("_NET_WM_STATE_MAXIMIZED_HORZ"));
 }
 
 }  // namespace ui

--- a/ui/platform_window/x11/x11_window_base.h
+++ b/ui/platform_window/x11/x11_window_base.h
@@ -7,6 +7,8 @@
 
 #include <stdint.h>
 
+#include <X11/Xutil.h>
+
 #include "base/callback.h"
 #include "base/macros.h"
 #include "ui/gfx/geometry/rect.h"
@@ -61,6 +63,22 @@ class X11_WINDOW_EXPORT X11WindowBase : public PlatformWindow {
   void ProcessXWindowEvent(XEvent* xev);
 
  private:
+  // Sends a message to the x11 window manager, enabling or disabling the
+  // states |state1| and |state2|.
+  // TODO(msisov, tonikitoo): share this with DesktopWindowTreeHostX11.
+  void SetWMSpecState(bool enabled, ::Atom state1, ::Atom state2);
+
+  // Called when WM_STATE property is changed.
+  void OnWMStateUpdated();
+
+  // Checks if the window manager has set a specific state.
+  // TODO(msisov, tonikitoo): share this with DesktopWindowTreeHostX11.
+  bool HasWMSpecProperty(const char* property) const;
+
+  // TODO(msisov, tonikitoo): share this with DesktopWindowTreeHostX11.
+  bool IsMinimized() const;
+  bool IsMaximized() const;
+
   PlatformWindowDelegate* delegate_;
 
   XDisplay* xdisplay_;
@@ -73,6 +91,12 @@ class X11_WINDOW_EXPORT X11WindowBase : public PlatformWindow {
 
   // The bounds of |xwindow_|.
   gfx::Rect bounds_;
+
+  // The bounds of our window before we were maximized.
+  gfx::Rect restored_bounds_in_pixels_;
+
+  // The window manager state bits.
+  std::set<::Atom> window_properties_;
 
   bool window_mapped_ = false;
 


### PR DESCRIPTION
This patch makes it possible to change states of windows by an event sent from a client or from a server.

The call flow is the following - as soon as WindowTreeClient::SetProperty
is called, new properties are passed to the ServerWindow, which notifies
WindowServer about the changes. The WindowServer checks type of the property
and calls PlatformDisplayDefault::SetNativeWindowState, which
decides whether to minimize/maximize or restore the window.
 
As soon as a native window server receives a request to change a state of
the request window, it processes the call and send a PropertyChanged event,
which is processed and sent upwards to WindowTreeClient::OnWindowStateChanged,
which processes the call and calls WindowTreeHostMus and aura::Window to
change the property if it has not been changed yet and show or hide the window.
   
Issue #75