### PR TITLE
Revive tooltips

### DIFF
--- a/chrome/browser/ui/browser.cc
+++ b/chrome/browser/ui/browser.cc
@@ -2315,8 +2315,8 @@ void Browser::RemoveScheduledUpdatesFor(WebContents* contents) {
 
 StatusBubble* Browser::GetStatusBubble() {
   // In kiosk and exclusive app mode, we want to always hide the status bubble.
-  // if (chrome::IsRunningInAppMode())
-  return NULL;
+  if (chrome::IsRunningInAppMode())
+    return NULL;
 
   return window_ ? window_->GetStatusBubble() : NULL;
 }

--- a/ui/views/corewm/tooltip_controller.cc
+++ b/ui/views/corewm/tooltip_controller.cc
@@ -335,8 +335,8 @@ void TooltipController::UpdateIfRequired() {
 }
 
 void TooltipController::ShowTooltip() {
-  // if (!tooltip_window_)
-  return;
+  if (!tooltip_window_)
+    return;
   gfx::Point widget_loc =
       curr_mouse_loc_ + tooltip_window_->GetBoundsInScreen().OffsetFromOrigin();
   tooltip_->SetText(tooltip_window_, tooltip_text_whitespace_trimmed_,

--- a/ui/views/mus/mus_client.cc
+++ b/ui/views/mus/mus_client.cc
@@ -151,6 +151,12 @@ MusClient::~MusClient() {
 // static
 bool MusClient::ShouldCreateDesktopNativeWidgetAura(
     const Widget::InitParams& init_params) {
+#if defined(USE_AURA) && defined(USE_OZONE) && !defined(OS_CHROMEOS)
+  // For Ozone/Linux desktop builds (Mus code path), we mimic regular
+  // X11/Linux builds on how to create widgets.
+  return false;
+#endif
+
   // TYPE_CONTROL and child widgets require a NativeWidgetAura.
   return init_params.type != Widget::InitParams::TYPE_CONTROL &&
          !init_params.child;


### PR DESCRIPTION
... and various other widgets that were broken: "add/remove/edit bookmark" widget, "zoom in/out" banner upon control +/- press, tooltips, "crash restore" banner upon browser crash, etc