### PR TITLE
(TEMP) Forcebly disable tooltips

### DIFF
--- a/ui/views/corewm/tooltip_controller.cc
+++ b/ui/views/corewm/tooltip_controller.cc
@@ -335,7 +335,7 @@ void TooltipController::UpdateIfRequired() {
 }
 
 void TooltipController::ShowTooltip() {
-  if (!tooltip_window_)
+  //if (!tooltip_window_)
     return;
   gfx::Point widget_loc =
       curr_mouse_loc_ + tooltip_window_->GetBoundsInScreen().OffsetFromOrigin();


### PR DESCRIPTION
It should be reverted when tooltips get functional. Today they
are created as an native window, and bounds are not passed at creation.
We do not suppoer this yet.