### PR TITLE
Fix compilation failures.

### DIFF
--- a/services/ui/ws/platform_display_default_unittest.cc
+++ b/services/ui/ws/platform_display_default_unittest.cc
@@ -57,6 +57,7 @@ class TestPlatformDisplayDelegate : public PlatformDisplayDelegate {
   void OnBoundsChanged(const gfx::Rect& new_bounds) override {}
   void OnCloseRequest() override {}
   void OnNativeCaptureLost() override {}
+  void OnWindowStateChanged(ui::mojom::ShowState new_state) override {}
   OzonePlatform* GetOzonePlatform() override { return ozone_platform_; }
 
  private:

--- a/services/ui/ws/test_utils.cc
+++ b/services/ui/ws/test_utils.cc
@@ -472,6 +472,9 @@ void TestWindowTreeClient::OnChangeCompleted(uint32_t change_id, bool success) {
     tracker_.OnChangeCompleted(change_id, success);
 }
 
+void TestWindowTreeClient::OnWindowStateChanged(uint32_t window_id,
+                                                ::ui::mojom::ShowState state) {}
+
 void TestWindowTreeClient::RequestClose(uint32_t window_id) {}
 
 void TestWindowTreeClient::GetWindowManager(

--- a/services/ui/ws/test_utils.h
+++ b/services/ui/ws/test_utils.h
@@ -520,6 +520,8 @@ class TestWindowTreeClient : public ui::mojom::WindowTreeClient {
                                   uint32_t action_taken) override;
   void OnDragDropDone() override;
   void OnChangeCompleted(uint32_t change_id, bool success) override;
+  void OnWindowStateChanged(uint32_t window_id,
+                            ::ui::mojom::ShowState state) override;
   void RequestClose(uint32_t window_id) override;
   void GetWindowManager(
       mojo::AssociatedInterfaceRequest<mojom::WindowManager> internal) override;

--- a/services/ui/ws/window_tree_client_unittest.cc
+++ b/services/ui/ws/window_tree_client_unittest.cc
@@ -273,6 +273,9 @@ class TestWindowTreeClient : public mojom::WindowTreeClient,
     }
   }
 
+  void OnWindowStateChanged(uint32_t window_id,
+                            ::ui::mojom::ShowState state) override {}
+
   // WindowTreeClient:
   void OnEmbed(
       ClientSpecificId client_id,

--- a/services/ui/ws/window_tree_client_unittest.cc
+++ b/services/ui/ws/window_tree_client_unittest.cc
@@ -276,6 +276,9 @@ class TestWindowTreeClient : public mojom::WindowTreeClient,
   void OnWindowStateChanged(uint32_t window_id,
                             ::ui::mojom::ShowState state) override {}
 
+  void OnNewBoundsFromHostServer(uint32_t window,
+                                 const gfx::Rect& new_bounds) override {}
+
   // WindowTreeClient:
   void OnEmbed(
       ClientSpecificId client_id,


### PR DESCRIPTION
These two patches implement pure methods that I've forgotten to implement, which has caused unittests compilation failures.