### PR TITLE
improve the way we report/react to bounds changes from/to the server.

### DIFF
--- a/content/renderer/mus/renderer_window_tree_client.cc
+++ b/content/renderer/mus/renderer_window_tree_client.cc
@@ -148,10 +148,6 @@ void RendererWindowTreeClient::OnWindowBoundsChanged(
     const base::Optional<cc::LocalSurfaceId>& local_surface_id) {
 }
 
-void RendererWindowTreeClient::OnNewBoundsFromHostServer(
-    ui::Id window_id,
-    const gfx::Rect& new_bounds) {}
-
 void RendererWindowTreeClient::OnClientAreaChanged(
     uint32_t window_id,
     const gfx::Insets& new_client_area,

--- a/content/renderer/mus/renderer_window_tree_client.h
+++ b/content/renderer/mus/renderer_window_tree_client.h
@@ -89,8 +89,6 @@ class RendererWindowTreeClient : public ui::mojom::WindowTreeClient {
       const gfx::Rect& old_bounds,
       const gfx::Rect& new_bounds,
       const base::Optional<cc::LocalSurfaceId>& local_frame_id) override;
-  void OnNewBoundsFromHostServer(ui::Id window_id,
-                                 const gfx::Rect& new_bounds) override;
   void OnClientAreaChanged(
       uint32_t window_id,
       const gfx::Insets& new_client_area,

--- a/services/ui/public/interfaces/window_tree.mojom
+++ b/services/ui/public/interfaces/window_tree.mojom
@@ -377,10 +377,6 @@ interface WindowTreeClient {
                         gfx.mojom.Rect new_bounds,
                         cc.mojom.LocalSurfaceId? local_surface_id);
                         
-  // Invoked when a host server calls back with changed bounds of a native
-  // window.
-  OnNewBoundsFromHostServer(uint32 window, gfx.mojom.Rect new_bounds);            
-
   OnClientAreaChanged(uint32 window_id,
                       gfx.mojom.Insets new_client_area,
                       array<gfx.mojom.Rect> new_additional_client_areas);

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -186,6 +186,20 @@ void Display::SetImeVisibility(ServerWindow* window, bool visible) {
   platform_display_->SetImeVisibility(visible);
 }
 
+void Display::SetBounds(const gfx::Rect& bounds) {
+  platform_display_->SetViewportBounds(bounds);
+
+  if (root_->bounds() == bounds)
+    return;
+
+  root_->SetBounds(bounds, allocator_.GenerateId());
+
+  // WindowManagerDisplayRoot::root_ needs to be at 0,0 position relative
+  // to its parent not to break mouse/touch events.
+  for (auto& pair : window_manager_display_root_map_)
+    pair.second->root()->SetBounds(gfx::Rect(bounds.size()), allocator_.GenerateId());
+}
+
 void Display::OnWillDestroyTree(WindowTree* tree) {
   for (auto it = window_manager_display_root_map_.begin();
        it != window_manager_display_root_map_.end(); ++it) {

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -343,8 +343,11 @@ void Display::OnBoundsChanged(const gfx::Rect& new_bounds) {
     return;
 
   root_->OnNewBoundsFromHostServer(new_bounds);
+
+  // WindowManagerDisplayRoot::root_ needs to be at 0,0 position relative
+  // to its parent not to break mouse/touch events.
   for (auto& pair : window_manager_display_root_map_)
-    pair.second->root()->OnNewBoundsFromHostServer(new_bounds);
+    pair.second->root()->OnNewBoundsFromHostServer(gfx::Rect(new_bounds.size()));
 }
 
 void Display::OnCloseRequest() {

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -336,10 +336,15 @@ void Display::OnNativeCaptureLost() {
 }
 
 void Display::OnBoundsChanged(const gfx::Rect& new_bounds) {
+  if (!window_server_->IsInExternalWindowMode())
+    return;
+
   if (root_->bounds() == new_bounds)
     return;
 
-  OnBoundsChangedInternal(new_bounds);
+  root_->OnNewBoundsFromHostServer(new_bounds);
+  for (auto& pair : window_manager_display_root_map_)
+    pair.second->root()->OnNewBoundsFromHostServer(new_bounds);
 }
 
 void Display::OnCloseRequest() {
@@ -504,12 +509,6 @@ EventDispatchDetails Display::OnEventFromSource(Event* event) {
           window_server_->user_id_tracker()->active_id());
   activity_monitor->OnUserActivity();
   return EventDispatchDetails();
-}
-
-void Display::OnBoundsChangedInternal(const gfx::Rect& new_bounds) {
-  root_->OnNewBoundsFromHostServer(new_bounds);
-  for (auto& pair : window_manager_display_root_map_)
-    pair.second->root()->OnNewBoundsFromHostServer(new_bounds);
 }
 
 }  // namespace ws

--- a/services/ui/ws/display.h
+++ b/services/ui/ws/display.h
@@ -220,8 +220,6 @@ class Display : public PlatformDisplayDelegate,
   // EventSink:
   EventDispatchDetails OnEventFromSource(Event* event) override;
 
-  void OnBoundsChangedInternal(const gfx::Rect& new_bounds);
-
   std::unique_ptr<DisplayBinding> binding_;
   WindowServer* const window_server_;
   std::unique_ptr<ServerWindow> root_;

--- a/services/ui/ws/display.h
+++ b/services/ui/ws/display.h
@@ -142,6 +142,7 @@ class Display : public PlatformDisplayDelegate,
   void UpdateTextInputState(ServerWindow* window,
                             const ui::TextInputState& state);
   void SetImeVisibility(ServerWindow* window, bool visible);
+  void SetBounds(const gfx::Rect& bounds);
 
   // Called just before |tree| is destroyed.
   void OnWillDestroyTree(WindowTree* tree);

--- a/services/ui/ws/platform_display.h
+++ b/services/ui/ws/platform_display.h
@@ -68,6 +68,9 @@ class PlatformDisplay : public ui::EventSource {
   // Changes state of a native window to minimized, maximized or normal.
   virtual void SetNativeWindowState(ui::mojom::ShowState state) {}
 
+  // Sets the bounds of a native window.
+  virtual void SetViewportBounds(const gfx::Rect& rect) {}
+
   // Overrides factory for testing. Default (NULL) value indicates regular
   // (non-test) environment.
   static void set_factory_for_testing(PlatformDisplayFactory* factory) {

--- a/services/ui/ws/platform_display_default.cc
+++ b/services/ui/ws/platform_display_default.cc
@@ -132,6 +132,10 @@ void PlatformDisplayDefault::SetNativeWindowState(ui::mojom::ShowState state) {
   }
 }
 
+void PlatformDisplayDefault::SetViewportBounds(const gfx::Rect& bounds) {
+  platform_window_->SetBounds(bounds);
+}
+
 void PlatformDisplayDefault::GetWindowType(ui::mojom::WindowType* result) {
   DCHECK(result);
   *result = metrics_.window_type;

--- a/services/ui/ws/platform_display_default.h
+++ b/services/ui/ws/platform_display_default.h
@@ -52,6 +52,7 @@ class PlatformDisplayDefault : public PlatformDisplay,
   FrameGenerator* GetFrameGenerator() override;
   void SetWindowVisibility(bool visible) override;
   void SetNativeWindowState(ui::mojom::ShowState state) override;
+  void SetViewportBounds(const gfx::Rect& rect) override;
   void GetWindowType(ui::mojom::WindowType* result) override;
 
  private:

--- a/services/ui/ws/server_window.h
+++ b/services/ui/ws/server_window.h
@@ -91,9 +91,13 @@ class ServerWindow {
                  const base::Optional<cc::LocalSurfaceId>& local_surface_id =
                      base::nullopt);
 
-  // Tells the client to set the bounds from a host window manager, which is a
-  // system wm. This is a reaction to resizes/moves done in the host window
-  // manager window.
+  // This is a wrapper method around SetBounds. It is called when the host
+  // window is resized/moved. It enforces bounds updates to be sent to the server.
+  //
+  // Given that we cap WindowManagerDisplayRoot's root x,y placement to 0,0,
+  // when the position changes but not the size, ::SetBounds would bail out
+  // because bounds are identical. However, it is important to notice the client
+  // of position changes.
   void OnNewBoundsFromHostServer(const gfx::Rect& bounds);
 
   const std::vector<gfx::Rect>& additional_client_areas() const {
@@ -282,6 +286,11 @@ class ServerWindow {
   // Whether this window can be the target in a drag and drop
   // operation. Clients must opt-in to this.
   bool accepts_drops_ = false;
+
+  // Enforce bounds changes to be sent to the client. It works
+  // around the fact that WindowManagerDisplayRoot::root_ position
+  // is cap'ed to 0,0 relative to its parent.
+  bool force_bounds_update_ = false;
 
   base::ObserverList<ServerWindowObserver> observers_;
 

--- a/services/ui/ws/server_window_observer.h
+++ b/services/ui/ws/server_window_observer.h
@@ -51,10 +51,6 @@ class ServerWindowObserver {
                                      const gfx::Rect& old_bounds,
                                      const gfx::Rect& new_bounds) {}
 
-  // Called when a host server wants client to change bounds.
-  virtual void OnNewBoundsFromHostServer(ServerWindow* window,
-                                         const gfx::Rect& new_bounds) {}
-
   virtual void OnWindowClientAreaChanged(
       ServerWindow* window,
       const gfx::Insets& new_client_area,

--- a/services/ui/ws/test_utils.cc
+++ b/services/ui/ws/test_utils.cc
@@ -45,6 +45,7 @@ class TestPlatformDisplay : public PlatformDisplay {
     *cursor_storage_ = cursor;
   }
   void UpdateTextInputState(const ui::TextInputState& state) override {}
+  void SetViewportBounds(const gfx::Rect& rect) override {}
   void SetImeVisibility(bool visible) override {}
   void UpdateViewportMetrics(const display::ViewportMetrics& metrics) override {
     metrics_ = metrics;
@@ -346,10 +347,6 @@ void TestWindowTreeClient::OnWindowBoundsChanged(
   tracker_.OnWindowBoundsChanged(window, std::move(old_bounds),
                                  std::move(new_bounds), local_surface_id);
 }
-
-void TestWindowTreeClient::OnNewBoundsFromHostServer(
-    Id window_id,
-    const gfx::Rect& new_bounds) {}
 
 void TestWindowTreeClient::OnClientAreaChanged(
     uint32_t window_id,

--- a/services/ui/ws/test_utils.h
+++ b/services/ui/ws/test_utils.h
@@ -451,8 +451,6 @@ class TestWindowTreeClient : public ui::mojom::WindowTreeClient {
       const gfx::Rect& old_bounds,
       const gfx::Rect& new_bounds,
       const base::Optional<cc::LocalSurfaceId>& local_surface_id) override;
-  void OnNewBoundsFromHostServer(Id window_id,
-                                 const gfx::Rect& new_bounds) override;
   void OnClientAreaChanged(
       uint32_t window_id,
       const gfx::Insets& new_client_area,

--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -369,15 +369,6 @@ void WindowServer::WindowManagerCreatedTopLevelWindow(
                                              change.client_change_id, window);
 }
 
-void WindowServer::OnNewBoundsFromHostServer(ServerWindow* window,
-                                             const gfx::Rect& new_bounds) {
-  if (in_destructor_)
-    return;
-
-  for (auto& pair : tree_map_)
-    pair.second->OnNewBoundsFromHostServer(window, new_bounds);
-}
-
 void WindowServer::ProcessWindowBoundsChanged(
     const ServerWindow* window,
     const gfx::Rect& old_bounds,

--- a/services/ui/ws/window_server.h
+++ b/services/ui/ws/window_server.h
@@ -327,8 +327,6 @@ class WindowServer : public ServerWindowDelegate,
   void OnWindowBoundsChanged(ServerWindow* window,
                              const gfx::Rect& old_bounds,
                              const gfx::Rect& new_bounds) override;
-  void OnNewBoundsFromHostServer(ServerWindow* window,
-                                 const gfx::Rect& new_bounds) override;
   void OnWindowClientAreaChanged(
       ServerWindow* window,
       const gfx::Insets& new_client_area,

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -790,7 +790,19 @@ void WindowTree::ProcessWindowBoundsChanged(
   ClientWindowId client_window_id;
   if (originated_change || !IsWindowKnown(window, &client_window_id))
     return;
-  client()->OnWindowBoundsChanged(client_window_id.id, old_bounds, new_bounds,
+
+  // In external window mode, we cap the bounds WindowManagerDisplayRoot's
+  // root window to 0,0. So send the bounds of Display's root, which has the
+  // same size but contains the proper window placement (x, y).
+  gfx::Rect newest_bounds = new_bounds;
+  if (window_server_->IsInExternalWindowMode()) {
+    WindowManagerDisplayRoot* display_root =
+        GetWindowManagerDisplayRoot(window);
+    if (display_root && display_root->root() == window)
+      newest_bounds = GetDisplay(window)->root_window()->bounds();
+  }
+
+  client()->OnWindowBoundsChanged(client_window_id.id, old_bounds, newest_bounds,
                                   local_surface_id);
 }
 

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -1643,6 +1643,19 @@ void WindowTree::SetWindowBounds(
   // Only the owner of the window can change the bounds.
   bool success = access_policy_->CanSetWindowBounds(window);
   if (success) {
+    if (window_server_->IsInExternalWindowMode()) {
+      WindowManagerDisplayRoot* display_root =
+          GetWindowManagerDisplayRoot(window);
+      if (window == display_root->root()) {
+        Display* display = GetDisplay(window);
+        DCHECK(display);
+        display->SetBounds(bounds);
+
+        client()->OnChangeCompleted(change_id, success);
+        return;
+      }
+    }
+
     Operation op(this, window_server_, OperationType::SET_WINDOW_BOUNDS);
     window->SetBounds(bounds, local_surface_id);
   } else {

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -772,15 +772,6 @@ void WindowTree::ClientJankinessChanged(WindowTree* tree) {
   }
 }
 
-void WindowTree::OnNewBoundsFromHostServer(const ServerWindow* window,
-                                           const gfx::Rect& new_bounds) {
-  ClientWindowId client_window_id;
-  if (!IsWindowKnown(window, &client_window_id))
-    return;
-
-  client()->OnNewBoundsFromHostServer(client_window_id.id, new_bounds);
-}
-
 void WindowTree::ProcessWindowBoundsChanged(
     const ServerWindow* window,
     const gfx::Rect& old_bounds,

--- a/services/ui/ws/window_tree.h
+++ b/services/ui/ws/window_tree.h
@@ -233,10 +233,6 @@ class WindowTree : public mojom::WindowTree,
   // window(s).
   void ClientJankinessChanged(WindowTree* tree);
 
-  // Called when a host server triggers to change bounds of the client.
-  void OnNewBoundsFromHostServer(const ServerWindow* window,
-                                 const gfx::Rect& new_bounds);
-
   // The following methods are invoked after the corresponding change has been
   // processed. They do the appropriate bookkeeping and update the client as
   // necessary.

--- a/services/ui/ws/window_tree_client_unittest.cc
+++ b/services/ui/ws/window_tree_client_unittest.cc
@@ -276,9 +276,6 @@ class TestWindowTreeClient : public mojom::WindowTreeClient,
   void OnWindowStateChanged(uint32_t window_id,
                             ::ui::mojom::ShowState state) override {}
 
-  void OnNewBoundsFromHostServer(uint32_t window,
-                                 const gfx::Rect& new_bounds) override {}
-
   // WindowTreeClient:
   void OnEmbed(
       ClientSpecificId client_id,

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -1178,17 +1178,6 @@ void WindowTreeClient::OnWindowBoundsChanged(
   SetWindowBoundsFromServer(window, new_bounds, local_surface_id);
 }
 
-void WindowTreeClient::OnNewBoundsFromHostServer(Id window_id,
-                                                 const gfx::Rect& new_bounds) {
-  WindowMus* window = GetWindowByServerId(window_id);
-  if (!window || !IsRoot(window))
-    return;
-
-  // WindowTreeHost expects bounds to be in pixels.
-  WindowTreeHostMus* host = GetWindowTreeHostMus(window);
-  host->SetBoundsInPixels(new_bounds);
-}
-
 void WindowTreeClient::OnClientAreaChanged(
     uint32_t window_id,
     const gfx::Insets& new_client_area,

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -709,14 +709,7 @@ void WindowTreeClient::ScheduleInFlightBoundsChange(
     synchronizing_with_child_on_next_frame_ = true;
   }
 
-  gfx::Rect newest_bounds = new_bounds;
-  // TODO(msisov): figure out why this stops settings bounds of
-  // ServerWindow for additional windows like menus, but still
-  // doesn't break clicking functionality and still let's
-  // main chrome window to set bounds to 10:10, for example.
-  if (window->window_mus_type() == WindowMusType::EMBED)
-    newest_bounds.set_origin(gfx::Point());
-  tree_->SetWindowBounds(change_id, window->server_id(), newest_bounds,
+  tree_->SetWindowBounds(change_id, window->server_id(), new_bounds,
                          local_surface_id);
 }
 

--- a/ui/aura/mus/window_tree_client.h
+++ b/ui/aura/mus/window_tree_client.h
@@ -355,8 +355,6 @@ class AURA_EXPORT WindowTreeClient
       const gfx::Rect& old_bounds,
       const gfx::Rect& new_bounds,
       const base::Optional<cc::LocalSurfaceId>& local_surface_id) override;
-  void OnNewBoundsFromHostServer(Id window_id,
-                                 const gfx::Rect& new_bounds) override;
   void OnClientAreaChanged(
       uint32_t window_id,
       const gfx::Insets& new_client_area,


### PR DESCRIPTION
This is a set of 4 patches that changes a bit the way we report bounds change from the server to the client, and also how we react to them, when coming from the client.

In the end, it allows us to remove some custom methods we added (most of the OnNewBoundsFromHostServer family), and also start the browser at the default size, as per regular chromium code path: WindowSizer::DetermineWindowBoundsAndShowState.