### PR TITLE
Support starting chromium with URL on Linux/Ozone build

### DIFF
--- a/content/app/content_service_manager_main_delegate.cc
+++ b/content/app/content_service_manager_main_delegate.cc
@@ -85,7 +85,11 @@ bool ContentServiceManagerMainDelegate::ShouldLaunchAsServiceProcess(
 void ContentServiceManagerMainDelegate::AdjustServiceProcessCommandLine(
     const service_manager::Identity& identity,
     base::CommandLine* command_line) {
+  base::CommandLine::StringVector args_without_switches;
   if (identity.name() == mojom::kPackagedServicesServiceName) {
+    // Ensure other arguments like URL are not lost.
+    args_without_switches = command_line->GetArgs();
+
     // When launching the browser process, ensure that we don't inherit any
     // process type flag. When content embeds Service Manager, a process with no
     // type is launched as a browser process.
@@ -98,6 +102,11 @@ void ContentServiceManagerMainDelegate::AdjustServiceProcessCommandLine(
 
   content_main_params_.delegate->AdjustServiceProcessCommandLine(identity,
                                                                  command_line);
+
+  // Append other arguments back to |command_line| after the second call to
+  // delegate as long as it can still remove all the arguments without switches.
+  for (const auto& arg : args_without_switches)
+    command_line->AppendArg(arg);
 }
 
 bool ContentServiceManagerMainDelegate::


### PR DESCRIPTION
This patch makes it possible to run chrome the following way:
./chromium [URL]

By default, service delegate removes all the not known flags, commands
among the ones, which it was intented to remove. That is why
URL is removed as well. This patch preserve URL and adds it
after delegate has done it job.