### PR TITLE
fixup! Handle window minimize/maximize/restore in external window mode

### DIFF
--- a/services/ui/ws/platform_display_default.cc
+++ b/services/ui/ws/platform_display_default.cc
@@ -128,6 +128,7 @@ void PlatformDisplayDefault::SetNativeWindowState(ui::mojom::ShowState state) {
       platform_window_->ToggleFullscreen();
       break;
     case (ui::mojom::ShowState::NORMAL):
+    case (ui::mojom::ShowState::DEFAULT):
       platform_window_->Restore();
       break;
     default:

--- a/ui/ozone/platform/wayland/wayland_window.h
+++ b/ui/ozone/platform/wayland/wayland_window.h
@@ -97,6 +97,11 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
   // Creates a popup window, which is visible as a menu window.
   void CreatePopupWindow();
 
+  // TODO(msisov, tonikitoo): share this with X11WindowBase.
+  bool IsMinimized();
+  bool IsMaximized();
+  bool IsFullScreen();
+
   PlatformWindowDelegate* delegate_;
   WaylandConnection* connection_;
   WaylandWindow* parent_window_ = nullptr;
@@ -111,6 +116,10 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
   uint32_t pending_configure_serial_;
   bool has_pointer_focus_ = false;
   bool has_keyboard_focus_ = false;
+
+  bool is_minimized_ = false;
+  bool is_maximized_ = false;
+  bool is_fullscreen_ = false;
 
   DISALLOW_COPY_AND_ASSIGN(WaylandWindow);
 };


### PR DESCRIPTION
Fix Wayland minimize/maximize/restore/fullscreen modes.
It's still bogus and doesn't work correctly as long as wayland
makes windows to be misplaced after unmaximize or unfullscreen.
What is more, this patch adds support to handle events from client only.
Events like restoring a window from a tray are not supported yet.

Issue #75 