### PR TITLE
fixup! Handle OnBoundsChange in external mode.

### DIFF
--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -1637,7 +1637,7 @@ void WindowTree::SetWindowBounds(
     if (window_server_->IsInExternalWindowMode()) {
       WindowManagerDisplayRoot* display_root =
           GetWindowManagerDisplayRoot(window);
-      if (window == display_root->root()) {
+      if (display_root && window == display_root->root()) {
         Display* display = GetDisplay(window);
         DCHECK(display);
         display->SetBounds(bounds);


### PR DESCRIPTION
Null check 'display_root'. This fixes mus_demo (and our
buildbot) as well as 'Developers tools'.

Issue #86