### PR TITLE
Fix ozone_unittests

### DIFF
--- a/ui/ozone/platform/wayland/fake_server.cc
+++ b/ui/ozone/platform/wayland/fake_server.cc
@@ -195,6 +195,16 @@ void UnsetMaximized(wl_client* client, wl_resource* resource) {
       ->UnsetMaximized();
 }
 
+void SetFullScreen(wl_client* client, wl_resource* resource, wl_resource *output) {
+  static_cast<MockXdgSurface*>(wl_resource_get_user_data(resource))
+      ->SetFullScreen();
+}
+
+void UnsetFullScreen(wl_client* client, wl_resource* resource) {
+  static_cast<MockXdgSurface*>(wl_resource_get_user_data(resource))
+      ->UnsetFullScreen();
+}
+
 void SetMinimized(wl_client* client, wl_resource* resource) {
   static_cast<MockXdgSurface*>(wl_resource_get_user_data(resource))
       ->SetMinimized();
@@ -212,8 +222,8 @@ const struct xdg_surface_interface xdg_surface_impl = {
     nullptr,           // set_window_geometry
     &SetMaximized,     // set_maximized
     &UnsetMaximized,   // set_unmaximized
-    nullptr,           // set_fullscreen
-    nullptr,           // unset_fullscreen
+    &SetFullScreen, // set_fullscreen
+    &UnsetFullScreen, // unset_fullscreen
     &SetMinimized,     // set_minimized
 };
 

--- a/ui/ozone/platform/wayland/fake_server.h
+++ b/ui/ozone/platform/wayland/fake_server.h
@@ -50,6 +50,8 @@ class MockXdgSurface : public ServerObject {
   MOCK_METHOD1(AckConfigure, void(uint32_t serial));
   MOCK_METHOD0(SetMaximized, void());
   MOCK_METHOD0(UnsetMaximized, void());
+  MOCK_METHOD0(SetFullScreen, void());
+  MOCK_METHOD0(UnsetFullScreen, void());
   MOCK_METHOD0(SetMinimized, void());
 
  private:

--- a/ui/ozone/platform/wayland/wayland_window_unittest.cc
+++ b/ui/ozone/platform/wayland/wayland_window_unittest.cc
@@ -55,9 +55,11 @@ TEST_F(WaylandWindowTest, SetTitle) {
   window.SetTitle(base::ASCIIToUTF16("hello"));
 }
 
-TEST_F(WaylandWindowTest, Maximize) {
+TEST_F(WaylandWindowTest, MaximizeAndRestore) {
   EXPECT_CALL(*xdg_surface, SetMaximized());
+  EXPECT_CALL(*xdg_surface, UnsetMaximized());
   window.Maximize();
+  window.Restore();
 }
 
 TEST_F(WaylandWindowTest, Minimize) {
@@ -65,8 +67,20 @@ TEST_F(WaylandWindowTest, Minimize) {
   window.Minimize();
 }
 
-TEST_F(WaylandWindowTest, Restore) {
+TEST_F(WaylandWindowTest, SetFullScreenAndRestore) {
+  EXPECT_CALL(*xdg_surface, SetFullScreen());
+  EXPECT_CALL(*xdg_surface, UnsetFullScreen());
+  window.ToggleFullscreen();
+  window.Restore();
+}
+
+TEST_F(WaylandWindowTest, SetMaximizedFullScreenAndRestore) {
+  EXPECT_CALL(*xdg_surface, SetFullScreen());
+  EXPECT_CALL(*xdg_surface, UnsetFullScreen());
+  EXPECT_CALL(*xdg_surface, SetMaximized());
   EXPECT_CALL(*xdg_surface, UnsetMaximized());
+  window.Maximize();
+  window.ToggleFullscreen();
   window.Restore();
 }
 


### PR DESCRIPTION
Implement SetFullScreen, UnSetFullScreen and fix maximize unitttest as well by calling maximize first and restore then as long as unmaximize will not be called if a window is not in maximize state.