### PR TITLE
Adapt to upstream commit "Mus: Turn on surface synchronization"

### DIFF
--- a/ash/mus/non_client_frame_controller_unittest.cc
+++ b/ash/mus/non_client_frame_controller_unittest.cc
@@ -128,6 +128,11 @@ TEST_F(NonClientFrameControllerTest, ContentRegionNotDrawnForClient) {
   const gfx::Rect kTileBounds(gfx::Point(tile_x, tile_y), tile_size);
   ui::Compositor* compositor = widget->GetCompositor();
 
+  // Give the ui::Compositor a LocalSurfaceId so that it does not defer commit
+  // when a draw is scheduled.
+  cc::LocalSurfaceId local_surface_id(1, base::UnguessableToken::Create());
+  compositor->SetLocalSurfaceId(local_surface_id);
+
   // Without the window visible, there should be a tile for the wallpaper at
   // (tile_x, tile_y) of size |tile_size|.
   compositor->ScheduleDraw();

--- a/ash/test/ash_test_base.cc
+++ b/ash/test/ash_test_base.cc
@@ -144,6 +144,21 @@ AshTestBase::~AshTestBase() {
       << "You have overridden TearDown but never called AshTestBase::TearDown";
 }
 
+void AshTestBase::UnblockCompositors() {
+  // In order for frames to be generated, a cc::LocalSurfaceId must be given to
+  // the ui::Compositor. Normally that cc::LocalSurfaceId comes from the window
+  // server but in unit tests, there is no window server so we just make up a
+  // cc::LocalSurfaceId to allow the layer compositor to make forward progress.
+  if (Shell::GetAshConfig() == Config::MUS ||
+      Shell::GetAshConfig() == Config::MASH) {
+    aura::Window::Windows root_windows = Shell::GetAllRootWindows();
+    for (aura::Window* root : root_windows) {
+      cc::LocalSurfaceId id(1, base::UnguessableToken::Create());
+      root->GetHost()->compositor()->SetLocalSurfaceId(id);
+    }
+  }
+}
+
 void AshTestBase::SetUp() {
   setup_called_ = true;
 
@@ -162,6 +177,8 @@ void AshTestBase::SetUp() {
   if (Shell::GetAshConfig() == Config::CLASSIC)
     Shell::Get()->cursor_manager()->EnableMouseEvents();
 
+  UnblockCompositors();
+
   // Changing GestureConfiguration shouldn't make tests fail. These values
   // prevent unexpected events from being generated during tests. Such as
   // delayed events which create race conditions on slower tests.
@@ -175,6 +192,11 @@ void AshTestBase::SetUp() {
 void AshTestBase::TearDown() {
   teardown_called_ = true;
   Shell::Get()->session_controller()->NotifyChromeTerminating();
+
+  // Some tasks are blocked on progress by the layer compositor. The layer
+  // compositor might be blocked if created during a unit test.
+  UnblockCompositors();
+
   // Flush the message loop to finish pending release tasks.
   RunAllPendingInMessageLoop();
 
@@ -217,7 +239,6 @@ display::Display::Rotation AshTestBase::GetCurrentInternalDisplayRotation() {
   return GetActiveDisplayRotation(display::Display::InternalDisplayId());
 }
 
-// static
 void AshTestBase::UpdateDisplay(const std::string& display_specs) {
   if (!Shell::ShouldEnableSimplifiedDisplayManagement()) {
     ash_test_helper_->UpdateDisplayForMash(display_specs);
@@ -225,6 +246,7 @@ void AshTestBase::UpdateDisplay(const std::string& display_specs) {
     display::test::DisplayManagerTestApi(Shell::Get()->display_manager())
         .UpdateDisplay(display_specs);
   }
+  UnblockCompositors();
 }
 
 aura::Window* AshTestBase::CurrentContext() {

--- a/ash/test/ash_test_base.h
+++ b/ash/test/ash_test_base.h
@@ -64,6 +64,10 @@ class AshTestBase : public testing::Test {
   AshTestBase();
   ~AshTestBase() override;
 
+  // Give all ui::Compositors a valid cc::LocalSurfaceId so that they can
+  // unblock cc::LayerTreeHost.
+  void UnblockCompositors();
+
   // testing::Test:
   void SetUp() override;
   void TearDown() override;

--- a/components/exo/surface.cc
+++ b/components/exo/surface.cc
@@ -185,10 +185,6 @@ class CustomWindowTargeter : public aura::WindowTargeter {
 ////////////////////////////////////////////////////////////////////////////////
 // Surface, public:
 
-// TODO(fsamuel): exo should not use context_factory_private. Instead, we should
-// request a CompositorFrameSink from the aura::Window. Setting up the
-// BeginFrame hierarchy should be an internal implementation detail of aura or
-// mus in aura-mus.
 Surface::Surface() : window_(new aura::Window(new CustomWindowDelegate(this))) {
   window_->SetType(aura::client::WINDOW_TYPE_CONTROL);
   window_->SetName("ExoSurface");
@@ -808,6 +804,10 @@ void Surface::UpdateSurface(bool full_damage) {
   }
 
   content_size_ = layer_size;
+  // We need update window_'s bounds with content size, because the
+  // CompositorFrameSink may not update the window's size base the size of
+  // the lastest submitted CompositorFrame.
+  window_->SetBounds(gfx::Rect(window_->bounds().origin(), content_size_));
   // TODO(jbauman): Figure out how this interacts with the pixel size of
   // CopyOutputRequests on the layer.
   gfx::Size contents_surface_size = layer_size;

--- a/components/viz/client/client_compositor_frame_sink.cc
+++ b/components/viz/client/client_compositor_frame_sink.cc
@@ -32,7 +32,8 @@ ClientCompositorFrameSink::ClientCompositorFrameSink(
       compositor_frame_sink_info_(std::move(compositor_frame_sink_info)),
       client_request_(std::move(client_request)),
       client_binding_(this),
-      enable_surface_synchronization_(enable_surface_synchronization) {
+      enable_surface_synchronization_(enable_surface_synchronization),
+      weak_factory_(this) {
   DETACH_FROM_THREAD(thread_checker_);
 }
 
@@ -49,11 +50,18 @@ ClientCompositorFrameSink::ClientCompositorFrameSink(
       compositor_frame_sink_info_(std::move(compositor_frame_sink_info)),
       client_request_(std::move(client_request)),
       client_binding_(this),
-      enable_surface_synchronization_(enable_surface_synchronization) {
+      enable_surface_synchronization_(enable_surface_synchronization),
+      weak_factory_(this) {
   DETACH_FROM_THREAD(thread_checker_);
 }
 
 ClientCompositorFrameSink::~ClientCompositorFrameSink() {}
+
+base::WeakPtr<ClientCompositorFrameSink>
+ClientCompositorFrameSink::GetWeakPtr() {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  return weak_factory_.GetWeakPtr();
+}
 
 bool ClientCompositorFrameSink::BindToClient(
     cc::CompositorFrameSinkClient* client) {
@@ -89,6 +97,7 @@ void ClientCompositorFrameSink::DetachFromClient() {
 
 void ClientCompositorFrameSink::SetLocalSurfaceId(
     const cc::LocalSurfaceId& local_surface_id) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   DCHECK(local_surface_id.is_valid());
   DCHECK(enable_surface_synchronization_);
   local_surface_id_ = local_surface_id;

--- a/components/viz/client/client_compositor_frame_sink.h
+++ b/components/viz/client/client_compositor_frame_sink.h
@@ -6,6 +6,7 @@
 #define COMPONENTS_VIZ_CLIENT_CLIENT_COMPOSITOR_FRAME_SINK_H_
 
 #include "base/macros.h"
+#include "base/memory/weak_ptr.h"
 #include "cc/ipc/mojo_compositor_frame_sink.mojom.h"
 #include "cc/output/compositor_frame_sink.h"
 #include "cc/output/context_provider.h"
@@ -46,6 +47,8 @@ class ClientCompositorFrameSink
 
   ~ClientCompositorFrameSink() override;
 
+  base::WeakPtr<ClientCompositorFrameSink> GetWeakPtr();
+
   // cc::CompositorFrameSink implementation.
   bool BindToClient(cc::CompositorFrameSinkClient* client) override;
   void DetachFromClient() override;
@@ -76,6 +79,8 @@ class ClientCompositorFrameSink
   mojo::Binding<cc::mojom::MojoCompositorFrameSinkClient> client_binding_;
   THREAD_CHECKER(thread_checker_);
   const bool enable_surface_synchronization_;
+
+  base::WeakPtrFactory<ClientCompositorFrameSink> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(ClientCompositorFrameSink);
 };

--- a/content/browser/compositor/reflector_impl_unittest.cc
+++ b/content/browser/compositor/reflector_impl_unittest.cc
@@ -143,7 +143,8 @@ class ReflectorImplTest : public testing::Test {
             compositor_task_runner_.get())));
     compositor_.reset(new ui::Compositor(
         context_factory_private->AllocateFrameSinkId(), context_factory,
-        context_factory_private, compositor_task_runner_.get()));
+        context_factory_private, compositor_task_runner_.get(),
+        false /* enable_surface_synchronization */));
     compositor_->SetAcceleratedWidget(gfx::kNullAcceleratedWidget);
 
     auto context_provider = cc::TestContextProvider::Create();

--- a/content/browser/compositor/software_browser_compositor_output_surface_unittest.cc
+++ b/content/browser/compositor/software_browser_compositor_output_surface_unittest.cc
@@ -103,7 +103,8 @@ void SoftwareBrowserCompositorOutputSurfaceTest::SetUp() {
 
   compositor_.reset(new ui::Compositor(
       context_factory_private->AllocateFrameSinkId(), context_factory,
-      context_factory_private, message_loop_.task_runner().get()));
+      context_factory_private, message_loop_.task_runner().get(),
+      false /* enable_surface_synchronization */));
   compositor_->SetAcceleratedWidget(gfx::kNullAcceleratedWidget);
 }
 

--- a/content/browser/compositor/software_output_device_ozone_unittest.cc
+++ b/content/browser/compositor/software_output_device_ozone_unittest.cc
@@ -94,9 +94,10 @@ void SoftwareOutputDeviceOzoneTest::SetUp() {
   const gfx::Size size(500, 400);
   window_ = ui::OzonePlatform::GetInstance()->CreatePlatformWindow(
       &window_delegate_, gfx::Rect(size));
-  compositor_.reset(new ui::Compositor(cc::FrameSinkId(1, 1), context_factory,
-                                       nullptr,
-                                       base::ThreadTaskRunnerHandle::Get()));
+  compositor_.reset(
+      new ui::Compositor(cc::FrameSinkId(1, 1), context_factory, nullptr,
+                         base::ThreadTaskRunnerHandle::Get(),
+                         false /* enable_surface_synchronization */));
   compositor_->SetAcceleratedWidget(window_delegate_.GetAcceleratedWidget());
   compositor_->SetScaleAndSize(1.0f, size);
 

--- a/content/browser/renderer_host/browser_compositor_view_mac.mm
+++ b/content/browser/renderer_host/browser_compositor_view_mac.mm
@@ -102,7 +102,8 @@ RecyclableCompositorMac::RecyclableCompositorMac()
       compositor_(content::GetContextFactoryPrivate()->AllocateFrameSinkId(),
                   content::GetContextFactory(),
                   content::GetContextFactoryPrivate(),
-                  ui::WindowResizeHelperMac::Get()->task_runner()) {
+                  ui::WindowResizeHelperMac::Get()->task_runner(),
+                  false /* enable_surface_synchronization */) {
   compositor_.SetAcceleratedWidget(
       accelerated_widget_mac_->accelerated_widget());
   Suspend();

--- a/content/renderer/gpu/render_widget_compositor.cc
+++ b/content/renderer/gpu/render_widget_compositor.cc
@@ -225,6 +225,11 @@ gfx::Size CalculateDefaultTileSize(float initial_device_scale_factor,
   return gfx::Size(default_tile_size, default_tile_size);
 }
 
+bool IsRunningInMash() {
+  const base::CommandLine* cmdline = base::CommandLine::ForCurrentProcess();
+  return cmdline->HasSwitch(switches::kIsRunningInMash);
+}
+
 // Check cc::BrowserControlsState, and blink::WebBrowserControlsState
 // are kept in sync.
 static_assert(int(blink::kWebBrowserControlsBoth) == int(cc::BOTH),
@@ -423,6 +428,7 @@ cc::LayerTreeSettings RenderWidgetCompositor::GenerateLayerTreeSettings(
   settings.initial_debug_state.SetRecordRenderingStats(
       cmd.HasSwitch(cc::switches::kEnableGpuBenchmarking));
   settings.enable_surface_synchronization =
+      IsRunningInMash() ||
       cmd.HasSwitch(cc::switches::kEnableSurfaceSynchronization);
 
   if (cmd.HasSwitch(cc::switches::kSlowDownRasterScaleFactor)) {

--- a/content/renderer/mus/renderer_window_tree_client.cc
+++ b/content/renderer/mus/renderer_window_tree_client.cc
@@ -83,9 +83,7 @@ void RendererWindowTreeClient::RequestCompositorFrameSinkInternal(
   cc::mojom::MojoCompositorFrameSinkClientPtr client;
   cc::mojom::MojoCompositorFrameSinkClientRequest client_request =
       mojo::MakeRequest(&client);
-  bool enable_surface_synchronization =
-      base::CommandLine::ForCurrentProcess()->HasSwitch(
-          cc::switches::kEnableSurfaceSynchronization);
+  constexpr bool enable_surface_synchronization = true;
   auto frame_sink = base::MakeUnique<viz::ClientCompositorFrameSink>(
       std::move(context_provider), nullptr /* worker_context_provider */,
       gpu_memory_buffer_manager, nullptr /* shared_bitmap_manager */,

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -359,13 +359,13 @@ void Display::OnBoundsChanged(const gfx::Rect& new_bounds) {
   if (root_->bounds() == new_bounds)
     return;
 
-  root_->OnNewBoundsFromHostServer(new_bounds);
+  root_->SetBounds(new_bounds, allocator_.GenerateId());
 
   // WindowManagerDisplayRoot::root_ needs to be at 0,0 position relative
   // to its parent not to break mouse/touch events.
   for (auto& pair : window_manager_display_root_map_)
-    pair.second->root()->OnNewBoundsFromHostServer(
-        gfx::Rect(new_bounds.size()));
+    pair.second->root()->SetBounds(
+        gfx::Rect(new_bounds.size()), allocator_.GenerateId());
 }
 
 void Display::OnCloseRequest() {

--- a/services/ui/ws/server_window.cc
+++ b/services/ui/ws/server_window.cc
@@ -177,8 +177,7 @@ void ServerWindow::StackChildAtTop(ServerWindow* child) {
 void ServerWindow::SetBounds(
     const gfx::Rect& bounds,
     const base::Optional<cc::LocalSurfaceId>& local_surface_id) {
-  if (bounds_ == bounds && current_local_surface_id_ == local_surface_id &&
-      !force_bounds_update_)
+  if (bounds_ == bounds && current_local_surface_id_ == local_surface_id)
     return;
 
   current_local_surface_id_ = local_surface_id;
@@ -187,11 +186,6 @@ void ServerWindow::SetBounds(
   bounds_ = bounds;
   for (auto& observer : observers_)
     observer.OnWindowBoundsChanged(this, old_bounds, bounds);
-}
-
-void ServerWindow::OnNewBoundsFromHostServer(const gfx::Rect& bounds) {
-  base::AutoReset<bool> scoped_force_bounds_update(&force_bounds_update_, true);
-  SetBounds(bounds);
 }
 
 void ServerWindow::SetClientArea(

--- a/services/ui/ws/server_window.h
+++ b/services/ui/ws/server_window.h
@@ -91,16 +91,6 @@ class ServerWindow {
                  const base::Optional<cc::LocalSurfaceId>& local_surface_id =
                      base::nullopt);
 
-  // This is a wrapper method around SetBounds. It is called when the host
-  // window is resized/moved. It enforces bounds updates to be sent to the
-  // server.
-  //
-  // Given that we cap WindowManagerDisplayRoot's root x,y placement to 0,0,
-  // when the position changes but not the size, ::SetBounds would bail out
-  // because bounds are identical. However, it is important to notice the client
-  // of position changes.
-  void OnNewBoundsFromHostServer(const gfx::Rect& bounds);
-
   const std::vector<gfx::Rect>& additional_client_areas() const {
     return additional_client_areas_;
   }
@@ -287,11 +277,6 @@ class ServerWindow {
   // Whether this window can be the target in a drag and drop
   // operation. Clients must opt-in to this.
   bool accepts_drops_ = false;
-
-  // Enforce bounds changes to be sent to the client. It works
-  // around the fact that WindowManagerDisplayRoot::root_ position
-  // is cap'ed to 0,0 relative to its parent.
-  bool force_bounds_update_ = false;
 
   base::ObserverList<ServerWindowObserver> observers_;
 

--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -948,10 +948,9 @@ void WindowServer::OnSurfaceCreated(const cc::SurfaceInfo& surface_info) {
 
   HandleTemporaryReferenceForNewSurface(surface_info.id(), window);
 
-  if (!window->parent())
-    return;
-
-  WindowTree* window_tree = GetTreeWithId(window->parent()->id().client_id);
+  // We always use the owner of the window's id (even for an embedded window),
+  // because an embedded window's id is allocated by the parent's window tree.
+  WindowTree* window_tree = GetTreeWithId(window->id().client_id);
   if (window_tree)
     window_tree->ProcessWindowSurfaceChanged(window, surface_info);
 }

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -1028,14 +1028,9 @@ void WindowTree::ProcessTransientWindowRemoved(
 void WindowTree::ProcessWindowSurfaceChanged(
     ServerWindow* window,
     const cc::SurfaceInfo& surface_info) {
-  ServerWindow* parent_window = window->parent();
-  ClientWindowId client_window_id, parent_client_window_id;
-  if (!IsWindowKnown(window, &client_window_id) ||
-      !IsWindowKnown(parent_window, &parent_client_window_id) ||
-      !created_window_map_.count(parent_window->id())) {
+  ClientWindowId client_window_id;
+  if (!IsWindowKnown(window, &client_window_id))
     return;
-  }
-
   client()->OnWindowSurfaceChanged(client_window_id.id, surface_info);
 }
 

--- a/services/ui/ws/window_tree_client_unittest.cc
+++ b/services/ui/ws/window_tree_client_unittest.cc
@@ -2200,46 +2200,78 @@ TEST_F(WindowTreeClientTest, SurfaceIdPropagation) {
 
   // Establish the second client at 1,100.
   ASSERT_NO_FATAL_FAILURE(EstablishSecondClientWithRoot(window_1_100));
+  changes2()->clear();
 
   // 1,100 is the id in the wt_client1's id space. The new client should see
   // 2,1 (the server id).
   const Id window_1_100_in_ws2 = BuildWindowId(client_id_1(), 1);
   EXPECT_EQ(window_1_100_in_ws2, wt_client2()->root_window_id());
 
+  // Submit a CompositorFrame to window_1_100_in_ws2 (the embedded window in
+  // wt2) and make sure the server gets it.
+  {
+    cc::mojom::MojoCompositorFrameSinkPtr surface_ptr;
+    cc::mojom::MojoCompositorFrameSinkClientRequest client_request;
+    cc::mojom::MojoCompositorFrameSinkClientPtr surface_client_ptr;
+    client_request = mojo::MakeRequest(&surface_client_ptr);
+    wt2()->AttachCompositorFrameSink(window_1_100_in_ws2,
+                                     mojo::MakeRequest(&surface_ptr),
+                                     std::move(surface_client_ptr));
+    cc::CompositorFrame compositor_frame;
+    std::unique_ptr<cc::RenderPass> render_pass = cc::RenderPass::Create();
+    gfx::Rect frame_rect(0, 0, 100, 100);
+    render_pass->SetNew(1, frame_rect, frame_rect, gfx::Transform());
+    compositor_frame.render_pass_list.push_back(std::move(render_pass));
+    compositor_frame.metadata.device_scale_factor = 1.f;
+    compositor_frame.metadata.begin_frame_ack =
+        cc::BeginFrameAck(0, 1, 1, true);
+    cc::LocalSurfaceId local_surface_id(1, base::UnguessableToken::Create());
+    surface_ptr->SubmitCompositorFrame(local_surface_id,
+                                       std::move(compositor_frame));
+  }
+  // Make sure the parent connection gets the surface ID.
+  wt_client1()->WaitForChangeCount(1);
+  // Verify that the submitted frame is for |window_2_101|.
+  EXPECT_EQ(window_1_100_in_ws2,
+            changes1()->back().surface_id.frame_sink_id().client_id());
+  changes1()->clear();
+
   // The first window created in the second client gets a server id of 2,1
   // regardless of the id the client uses.
   const Id window_2_101 = wt_client2()->NewWindow(101);
   ASSERT_TRUE(wt_client2()->AddWindow(window_1_100_in_ws2, window_2_101));
-  const Id window_2_101_in_ws1 = BuildWindowId(client_id_2(), 1);
+  const Id window_2_101_in_ws2 = BuildWindowId(client_id_2(), 1);
   wt_client1()->WaitForChangeCount(1);
-  EXPECT_EQ("HierarchyChanged window=" + IdToString(window_2_101_in_ws1) +
+  EXPECT_EQ("HierarchyChanged window=" + IdToString(window_2_101_in_ws2) +
                 " old_parent=null new_parent=" + IdToString(window_1_100),
             SingleChangeToDescription(*changes1()));
-  changes1()->clear();
-
-  // Submit a CompositorFrame to window_2_101 and make sure server gets it.
-  cc::mojom::MojoCompositorFrameSinkPtr surface_ptr;
-  cc::mojom::MojoCompositorFrameSinkClientRequest client_request;
-  cc::mojom::MojoCompositorFrameSinkClientPtr surface_client_ptr;
-  client_request = mojo::MakeRequest(&surface_client_ptr);
-  wt2()->AttachCompositorFrameSink(window_2_101,
-                                   mojo::MakeRequest(&surface_ptr),
-                                   std::move(surface_client_ptr));
-  cc::CompositorFrame compositor_frame;
-  std::unique_ptr<cc::RenderPass> render_pass = cc::RenderPass::Create();
-  gfx::Rect frame_rect(0, 0, 100, 100);
-  render_pass->SetNew(1, frame_rect, frame_rect, gfx::Transform());
-  compositor_frame.render_pass_list.push_back(std::move(render_pass));
-  compositor_frame.metadata.device_scale_factor = 1.f;
-  compositor_frame.metadata.begin_frame_ack = cc::BeginFrameAck(0, 1, 1, true);
-  cc::LocalSurfaceId local_surface_id(1, base::UnguessableToken::Create());
-  surface_ptr->SubmitCompositorFrame(local_surface_id,
-                                     std::move(compositor_frame));
+  // Submit a CompositorFrame to window_2_101_in_ws2 (a regular window in
+  // wt2) and make sure client gets it.
+  {
+    cc::mojom::MojoCompositorFrameSinkPtr surface_ptr;
+    cc::mojom::MojoCompositorFrameSinkClientRequest client_request;
+    cc::mojom::MojoCompositorFrameSinkClientPtr surface_client_ptr;
+    client_request = mojo::MakeRequest(&surface_client_ptr);
+    wt2()->AttachCompositorFrameSink(window_2_101,
+                                     mojo::MakeRequest(&surface_ptr),
+                                     std::move(surface_client_ptr));
+    cc::CompositorFrame compositor_frame;
+    std::unique_ptr<cc::RenderPass> render_pass = cc::RenderPass::Create();
+    gfx::Rect frame_rect(0, 0, 100, 100);
+    render_pass->SetNew(1, frame_rect, frame_rect, gfx::Transform());
+    compositor_frame.render_pass_list.push_back(std::move(render_pass));
+    compositor_frame.metadata.device_scale_factor = 1.f;
+    compositor_frame.metadata.begin_frame_ack =
+        cc::BeginFrameAck(0, 1, 1, true);
+    cc::LocalSurfaceId local_surface_id(2, base::UnguessableToken::Create());
+    surface_ptr->SubmitCompositorFrame(local_surface_id,
+                                       std::move(compositor_frame));
+  }
   // Make sure the parent connection gets the surface ID.
-  wt_client1()->WaitForChangeCount(1);
+  wt_client2()->WaitForChangeCount(1);
   // Verify that the submitted frame is for |window_2_101|.
-  EXPECT_EQ(window_2_101_in_ws1,
-            changes1()->back().surface_id.frame_sink_id().client_id());
+  EXPECT_EQ(window_2_101_in_ws2,
+            changes2()->back().surface_id.frame_sink_id().client_id());
 }
 
 // Verifies when an unknown window with a known child is added to a hierarchy

--- a/ui/aura/DEPS
+++ b/ui/aura/DEPS
@@ -1,4 +1,5 @@
 include_rules = [
+  "+cc/base",
   "+cc/output",
   "+cc/surfaces",
   "+mojo/common",

--- a/ui/aura/local/window_port_local.cc
+++ b/ui/aura/local/window_port_local.cc
@@ -129,11 +129,6 @@ void WindowPortLocal::OnSurfaceChanged(const cc::SurfaceId& surface_id,
                                        const gfx::Size& surface_size) {
   DCHECK_EQ(surface_id.frame_sink_id(), frame_sink_id_);
   local_surface_id_ = surface_id.local_surface_id();
-  // The bounds must be updated before switching to the new surface, because
-  // the layer may be mirrored, in which case a surface change causes the
-  // mirror layer to update its surface using the latest bounds.
-  window_->layer()->SetBounds(
-      gfx::Rect(window_->layer()->bounds().origin(), surface_size));
   cc::SurfaceInfo surface_info(surface_id, 1.0f, surface_size);
   scoped_refptr<cc::SurfaceReferenceFactory> reference_factory =
       aura::Env::GetInstance()

--- a/ui/aura/mus/window_mus.h
+++ b/ui/aura/mus/window_mus.h
@@ -90,7 +90,6 @@ class AURA_EXPORT WindowMus {
       const cc::FrameSinkId& frame_sink_id) = 0;
   virtual const cc::LocalSurfaceId& GetOrAllocateLocalSurfaceId(
       const gfx::Size& new_size) = 0;
-  virtual void SetPrimarySurfaceInfo(const cc::SurfaceInfo& surface_info) = 0;
   virtual void SetFallbackSurfaceInfo(const cc::SurfaceInfo& surface_info) = 0;
   // The window was deleted on the server side. DestroyFromServer() should
   // result in deleting |this|.
@@ -127,6 +126,8 @@ class AURA_EXPORT WindowMus {
   virtual void OnTransientRestackDone(WindowMus* window) = 0;
 
   virtual void NotifyEmbeddedAppDisconnected() = 0;
+
+  virtual bool HasLocalCompositorFrameSink() = 0;
 
  private:
   // Just for set_server_id(), which other places should not call.

--- a/ui/aura/mus/window_port_mus.cc
+++ b/ui/aura/mus/window_port_mus.cc
@@ -8,6 +8,7 @@
 #include "components/viz/client/local_surface_id_provider.h"
 #include "ui/aura/client/aura_constants.h"
 #include "ui/aura/client/transient_window_client.h"
+#include "ui/aura/env.h"
 #include "ui/aura/mus/client_surface_embedder.h"
 #include "ui/aura/mus/property_converter.h"
 #include "ui/aura/mus/window_tree_client.h"
@@ -95,7 +96,7 @@ void WindowPortMus::Embed(
   window_tree_client_->Embed(window_, std::move(client), flags, callback);
 }
 
-std::unique_ptr<cc::CompositorFrameSink>
+std::unique_ptr<viz::ClientCompositorFrameSink>
 WindowPortMus::RequestCompositorFrameSink(
     scoped_refptr<cc::ContextProvider> context_provider,
     gpu::GpuMemoryBufferManager* gpu_memory_buffer_manager) {
@@ -115,7 +116,7 @@ WindowPortMus::RequestCompositorFrameSink(
       enable_surface_synchronization);
   window_tree_client_->AttachCompositorFrameSink(
       server_id(), std::move(sink_request), std::move(client));
-  return std::move(compositor_frame_sink);
+  return compositor_frame_sink;
 }
 
 WindowPortMus::ServerChangeIdType WindowPortMus::ScheduleChange(
@@ -306,18 +307,25 @@ const cc::LocalSurfaceId& WindowPortMus::GetOrAllocateLocalSurfaceId(
   if (frame_sink_id_.is_valid())
     UpdatePrimarySurfaceInfo();
 
-  return local_surface_id_;
-}
+  if (local_compositor_frame_sink_)
+    local_compositor_frame_sink_->SetLocalSurfaceId(local_surface_id_);
 
-void WindowPortMus::SetPrimarySurfaceInfo(const cc::SurfaceInfo& surface_info) {
-  primary_surface_info_ = surface_info;
-  UpdateClientSurfaceEmbedder();
-  if (window_->delegate())
-    window_->delegate()->OnWindowSurfaceChanged(surface_info);
+  return local_surface_id_;
 }
 
 void WindowPortMus::SetFallbackSurfaceInfo(
     const cc::SurfaceInfo& surface_info) {
+  if (!frame_sink_id_.is_valid()) {
+    // |primary_surface_info_| shold not be valid, since we didn't know the
+    // |frame_sink_id_|.
+    DCHECK(!primary_surface_info_.is_valid());
+    frame_sink_id_ = surface_info.id().frame_sink_id();
+    UpdatePrimarySurfaceInfo();
+  }
+
+  // The frame sink id should never be changed.
+  DCHECK_EQ(surface_info.id().frame_sink_id(), frame_sink_id_);
+
   fallback_surface_info_ = surface_info;
   UpdateClientSurfaceEmbedder();
 }
@@ -426,6 +434,10 @@ void WindowPortMus::NotifyEmbeddedAppDisconnected() {
     observer.OnEmbeddedAppDisconnected(window_);
 }
 
+bool WindowPortMus::HasLocalCompositorFrameSink() {
+  return !!local_compositor_frame_sink_;
+}
+
 void WindowPortMus::OnPreInit(Window* window) {
   window_ = window;
   window_tree_client_->OnWindowMusCreated(this);
@@ -521,12 +533,17 @@ void WindowPortMus::OnPropertyChanged(const void* key,
 
 std::unique_ptr<cc::CompositorFrameSink>
 WindowPortMus::CreateCompositorFrameSink() {
-  // TODO(penghuang): Implement it for Mus.
-  return nullptr;
+  DCHECK_EQ(window_mus_type(), WindowMusType::LOCAL);
+  DCHECK(!local_compositor_frame_sink_);
+  auto frame_sink = RequestCompositorFrameSink(
+      nullptr,
+      aura::Env::GetInstance()->context_factory()->GetGpuMemoryBufferManager());
+  local_compositor_frame_sink_ = frame_sink->GetWeakPtr();
+  return std::move(frame_sink);
 }
 
 cc::SurfaceId WindowPortMus::GetSurfaceId() const {
-  // TODO(penghuang): Implement it for Mus.
+  // This is only used by WindowPortLocal in unit tests.
   return cc::SurfaceId();
 }
 
@@ -535,28 +552,31 @@ void WindowPortMus::OnWillHideNativeWindow() {
 }
 
 void WindowPortMus::UpdatePrimarySurfaceInfo() {
-  bool embeds_surface =
-      window_mus_type() == WindowMusType::TOP_LEVEL_IN_WM ||
-      window_mus_type() == WindowMusType::EMBED_IN_OWNER ||
-      window_mus_type() == WindowMusType::DISPLAY_MANUALLY_CREATED;
-  if (!embeds_surface)
+  if (window_mus_type() != WindowMusType::TOP_LEVEL_IN_WM &&
+      window_mus_type() != WindowMusType::EMBED_IN_OWNER &&
+      window_mus_type() != WindowMusType::DISPLAY_MANUALLY_CREATED &&
+      window_mus_type() != WindowMusType::LOCAL) {
     return;
+  }
 
   if (!frame_sink_id_.is_valid() || !local_surface_id_.is_valid())
     return;
 
-  SetPrimarySurfaceInfo(cc::SurfaceInfo(
+  primary_surface_info_ = cc::SurfaceInfo(
       cc::SurfaceId(frame_sink_id_, local_surface_id_),
-      ScaleFactorForDisplay(window_), last_surface_size_in_pixels_));
+      ScaleFactorForDisplay(window_), last_surface_size_in_pixels_);
+  UpdateClientSurfaceEmbedder();
+  if (window_->delegate())
+    window_->delegate()->OnWindowSurfaceChanged(primary_surface_info_);
 }
 
 void WindowPortMus::UpdateClientSurfaceEmbedder() {
-  bool embeds_surface =
-      window_mus_type() == WindowMusType::TOP_LEVEL_IN_WM ||
-      window_mus_type() == WindowMusType::EMBED_IN_OWNER ||
-      window_mus_type() == WindowMusType::DISPLAY_MANUALLY_CREATED;
-  if (!embeds_surface)
+  if (window_mus_type() != WindowMusType::TOP_LEVEL_IN_WM &&
+      window_mus_type() != WindowMusType::EMBED_IN_OWNER &&
+      window_mus_type() != WindowMusType::DISPLAY_MANUALLY_CREATED &&
+      window_mus_type() != WindowMusType::LOCAL) {
     return;
+  }
 
   if (!client_surface_embedder_) {
     client_surface_embedder_ = base::MakeUnique<ClientSurfaceEmbedder>(

--- a/ui/aura/mus/window_port_mus.cc
+++ b/ui/aura/mus/window_port_mus.cc
@@ -105,13 +105,14 @@ WindowPortMus::RequestCompositorFrameSink(
   cc::mojom::MojoCompositorFrameSinkClientPtr client;
   cc::mojom::MojoCompositorFrameSinkClientRequest client_request =
       mojo::MakeRequest(&client);
+  constexpr bool enable_surface_synchronization = true;
   auto compositor_frame_sink = base::MakeUnique<viz::ClientCompositorFrameSink>(
       std::move(context_provider), nullptr /* worker_context_provider */,
       gpu_memory_buffer_manager, nullptr /* shared_bitmap_manager */,
       nullptr /* synthetic_begin_frame_source */, std::move(sink_info),
       std::move(client_request),
       base::MakeUnique<viz::DefaultLocalSurfaceIdProvider>(),
-      window_tree_client_->enable_surface_synchronization_);
+      enable_surface_synchronization);
   window_tree_client_->AttachCompositorFrameSink(
       server_id(), std::move(sink_request), std::move(client));
   return std::move(compositor_frame_sink);
@@ -298,14 +299,12 @@ const cc::LocalSurfaceId& WindowPortMus::GetOrAllocateLocalSurfaceId(
   local_surface_id_ = local_surface_id_allocator_.GenerateId();
   last_surface_size_in_pixels_ = surface_size_in_pixels;
 
-  // If surface synchronization is enabled and the FrameSinkId is available,
-  // then immediately embed the SurfaceId. The newly generated frame by the
-  // embedder will block in the display compositor until the child submits a
-  // corresponding CompositorFrame or a deadline hits.
-  if (window_tree_client_->enable_surface_synchronization_ &&
-      frame_sink_id_.is_valid()) {
+  // If the FrameSinkId is available, then immediately embed the SurfaceId.
+  // The newly generated frame by the embedder will block in the display
+  // compositor until the child submits a corresponding CompositorFrame or a
+  // deadline hits.
+  if (frame_sink_id_.is_valid())
     UpdatePrimarySurfaceInfo();
-  }
 
   return local_surface_id_;
 }
@@ -540,7 +539,7 @@ void WindowPortMus::UpdatePrimarySurfaceInfo() {
       window_mus_type() == WindowMusType::TOP_LEVEL_IN_WM ||
       window_mus_type() == WindowMusType::EMBED_IN_OWNER ||
       window_mus_type() == WindowMusType::DISPLAY_MANUALLY_CREATED;
-  if (!embeds_surface || !window_tree_client_->enable_surface_synchronization_)
+  if (!embeds_surface)
     return;
 
   if (!frame_sink_id_.is_valid() || !local_surface_id_.is_valid())
@@ -552,8 +551,10 @@ void WindowPortMus::UpdatePrimarySurfaceInfo() {
 }
 
 void WindowPortMus::UpdateClientSurfaceEmbedder() {
-  bool embeds_surface = window_mus_type() == WindowMusType::TOP_LEVEL_IN_WM ||
-                        window_mus_type() == WindowMusType::EMBED_IN_OWNER;
+  bool embeds_surface =
+      window_mus_type() == WindowMusType::TOP_LEVEL_IN_WM ||
+      window_mus_type() == WindowMusType::EMBED_IN_OWNER ||
+      window_mus_type() == WindowMusType::DISPLAY_MANUALLY_CREATED;
   if (!embeds_surface)
     return;
 

--- a/ui/aura/mus/window_port_mus.h
+++ b/ui/aura/mus/window_port_mus.h
@@ -24,6 +24,10 @@
 #include "ui/gfx/geometry/rect.h"
 #include "ui/platform_window/mojo/text_input_state.mojom.h"
 
+namespace viz {
+class ClientCompositorFrameSink;
+}
+
 namespace aura {
 
 class ClientSurfaceEmbedder;
@@ -76,7 +80,7 @@ class AURA_EXPORT WindowPortMus : public WindowPort, public WindowMus {
              uint32_t flags,
              const ui::mojom::WindowTree::EmbedCallback& callback);
 
-  std::unique_ptr<cc::CompositorFrameSink> RequestCompositorFrameSink(
+  std::unique_ptr<viz::ClientCompositorFrameSink> RequestCompositorFrameSink(
       scoped_refptr<cc::ContextProvider> context_provider,
       gpu::GpuMemoryBufferManager* gpu_memory_buffer_manager);
 
@@ -223,7 +227,6 @@ class AURA_EXPORT WindowPortMus : public WindowPort, public WindowMus {
   void SetFrameSinkIdFromServer(const cc::FrameSinkId& frame_sink_id) override;
   const cc::LocalSurfaceId& GetOrAllocateLocalSurfaceId(
       const gfx::Size& surface_size_in_pixels) override;
-  void SetPrimarySurfaceInfo(const cc::SurfaceInfo& surface_info) override;
   void SetFallbackSurfaceInfo(const cc::SurfaceInfo& surface_info) override;
   void DestroyFromServer() override;
   void AddTransientChildFromServer(WindowMus* child) override;
@@ -239,6 +242,7 @@ class AURA_EXPORT WindowPortMus : public WindowPort, public WindowMus {
   void PrepareForTransientRestack(WindowMus* window) override;
   void OnTransientRestackDone(WindowMus* window) override;
   void NotifyEmbeddedAppDisconnected() override;
+  bool HasLocalCompositorFrameSink() override;
 
   // WindowPort:
   void OnPreInit(Window* window) override;
@@ -285,6 +289,11 @@ class AURA_EXPORT WindowPortMus : public WindowPort, public WindowMus {
   gfx::Size last_surface_size_in_pixels_;
 
   ui::CursorData cursor_;
+
+  // When a frame sink is created
+  // for a local aura::Window, we need keep a weak ptr of it, so we can update
+  // the local surface id when necessary.
+  base::WeakPtr<viz::ClientCompositorFrameSink> local_compositor_frame_sink_;
 
   DISALLOW_COPY_AND_ASSIGN(WindowPortMus);
 };

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -737,7 +737,8 @@ void WindowTreeClient::ScheduleInFlightBoundsChange(
   base::Optional<cc::LocalSurfaceId> local_surface_id;
   if (window->window_mus_type() == WindowMusType::TOP_LEVEL_IN_WM ||
       window->window_mus_type() == WindowMusType::EMBED_IN_OWNER ||
-      window->window_mus_type() == WindowMusType::DISPLAY_MANUALLY_CREATED) {
+      window->window_mus_type() == WindowMusType::DISPLAY_MANUALLY_CREATED ||
+      window->HasLocalCompositorFrameSink()) {
     local_surface_id = window->GetOrAllocateLocalSurfaceId(new_bounds.size());
     synchronizing_with_child_on_next_frame_ = true;
   }

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -255,9 +255,6 @@ WindowTreeClient::WindowTreeClient(
           discardable_shared_memory_manager_.get());
     }
   }
-  enable_surface_synchronization_ =
-      base::CommandLine::ForCurrentProcess()->HasSwitch(
-          cc::switches::kEnableSurfaceSynchronization);
 }
 
 WindowTreeClient::~WindowTreeClient() {
@@ -644,9 +641,6 @@ void WindowTreeClient::OnEmbedImpl(
 void WindowTreeClient::OnSetDisplayRootDone(
     Id window_id,
     const base::Optional<cc::LocalSurfaceId>& local_surface_id) {
-  if (!enable_surface_synchronization_)
-    return;
-
   // The only way SetDisplayRoot() should fail is if we've done something wrong.
   CHECK(local_surface_id.has_value());
   WindowMus* window = GetWindowByServerId(window_id);
@@ -698,8 +692,7 @@ void WindowTreeClient::SetWindowBoundsFromServer(
   if (IsRoot(window)) {
     // WindowTreeHost expects bounds to be in pixels.
     GetWindowTreeHostMus(window)->SetBoundsFromServer(revert_bounds_in_pixels);
-    if (enable_surface_synchronization_ && local_surface_id &&
-        local_surface_id->is_valid()) {
+    if (local_surface_id && local_surface_id->is_valid()) {
       ui::Compositor* compositor = window->GetWindow()->GetHost()->compositor();
       compositor->SetLocalSurfaceId(*local_surface_id);
     }
@@ -1487,18 +1480,13 @@ void WindowTreeClient::OnWindowSurfaceChanged(
   WindowMus* window = GetWindowByServerId(window_id);
   if (!window)
     return;
-  if (enable_surface_synchronization_) {
-    // If surface synchronization is enabled, and the parent is informed
-    // of a child's surface then that surface ID is guaranteed to be available
-    // in the display compositor so we set it as the fallback. If surface
-    // synchronization is enabled, the primary SurfaceInfo is created by the
-    // embedder, and the LocalSurfaceId is allocated by the embedder.
-    window->SetFallbackSurfaceInfo(surface_info);
-  } else {
-    // If surface synchronization is disabled, fallback SurfaceInfos are never
-    // used.
-    window->SetPrimarySurfaceInfo(surface_info);
-  }
+
+  // If the parent is informed of a child's surface then that surface ID is
+  // guaranteed to be available in the display compositor so we set it as the
+  // fallback. If surface synchronization is enabled, the primary SurfaceInfo
+  // is created by the embedder, and the LocalSurfaceId is allocated by the
+  // embedder.
+  window->SetFallbackSurfaceInfo(surface_info);
 }
 
 void WindowTreeClient::OnDragDropStart(

--- a/ui/aura/mus/window_tree_client.h
+++ b/ui/aura/mus/window_tree_client.h
@@ -606,8 +606,6 @@ class AURA_EXPORT WindowTreeClient
 
   bool in_destructor_;
 
-  bool enable_surface_synchronization_ = false;
-
   // A mapping to shared memory that is one 32 bit integer long. The window
   // server uses this to let us synchronously read the cursor location.
   mojo::ScopedSharedBufferMapping cursor_location_mapping_;

--- a/ui/aura/window_tree_host.cc
+++ b/ui/aura/window_tree_host.cc
@@ -4,8 +4,10 @@
 
 #include "ui/aura/window_tree_host.h"
 
+#include "base/command_line.h"
 #include "base/threading/thread_task_runner_handle.h"
 #include "base/trace_event/trace_event.h"
+#include "cc/base/switches.h"
 #include "ui/aura/client/capture_client.h"
 #include "ui/aura/client/cursor_client.h"
 #include "ui/aura/env.h"
@@ -257,12 +259,16 @@ void WindowTreeHost::CreateCompositor(const cc::FrameSinkId& frame_sink_id) {
   DCHECK(context_factory);
   ui::ContextFactoryPrivate* context_factory_private =
       Env::GetInstance()->context_factory_private();
-  compositor_.reset(
-      new ui::Compositor((!context_factory_private || frame_sink_id.is_valid())
-                             ? frame_sink_id
-                             : context_factory_private->AllocateFrameSinkId(),
-                         context_factory, context_factory_private,
-                         base::ThreadTaskRunnerHandle::Get()));
+  bool enable_surface_synchronization =
+      aura::Env::GetInstance()->mode() == aura::Env::Mode::MUS ||
+      base::CommandLine::ForCurrentProcess()->HasSwitch(
+          cc::switches::kEnableSurfaceSynchronization);
+  compositor_.reset(new ui::Compositor(
+      (!context_factory_private || frame_sink_id.is_valid())
+          ? frame_sink_id
+          : context_factory_private->AllocateFrameSinkId(),
+      context_factory, context_factory_private,
+      base::ThreadTaskRunnerHandle::Get(), enable_surface_synchronization));
   if (!dispatcher()) {
     window()->Init(ui::LAYER_NOT_DRAWN);
     window()->set_host(this);

--- a/ui/compositor/compositor.cc
+++ b/ui/compositor/compositor.cc
@@ -52,7 +52,8 @@ namespace ui {
 Compositor::Compositor(const cc::FrameSinkId& frame_sink_id,
                        ui::ContextFactory* context_factory,
                        ui::ContextFactoryPrivate* context_factory_private,
-                       scoped_refptr<base::SingleThreadTaskRunner> task_runner)
+                       scoped_refptr<base::SingleThreadTaskRunner> task_runner,
+                       bool enable_surface_synchronization)
     : context_factory_(context_factory),
       context_factory_private_(context_factory_private),
       frame_sink_id_(frame_sink_id),
@@ -125,8 +126,7 @@ Compositor::Compositor(const cc::FrameSinkId& frame_sink_id,
 
   settings.initial_debug_state.SetRecordRenderingStats(
       command_line->HasSwitch(cc::switches::kEnableGpuBenchmarking));
-  settings.enable_surface_synchronization =
-      command_line->HasSwitch(cc::switches::kEnableSurfaceSynchronization);
+  settings.enable_surface_synchronization = enable_surface_synchronization;
 
   settings.use_zero_copy = IsUIZeroCopyEnabled();
 

--- a/ui/compositor/compositor.h
+++ b/ui/compositor/compositor.h
@@ -186,7 +186,8 @@ class COMPOSITOR_EXPORT Compositor
   Compositor(const cc::FrameSinkId& frame_sink_id,
              ui::ContextFactory* context_factory,
              ui::ContextFactoryPrivate* context_factory_private,
-             scoped_refptr<base::SingleThreadTaskRunner> task_runner);
+             scoped_refptr<base::SingleThreadTaskRunner> task_runner,
+             bool enable_surface_synchronization);
   ~Compositor() override;
 
   ui::ContextFactory* context_factory() { return context_factory_; }

--- a/ui/compositor/compositor_unittest.cc
+++ b/ui/compositor/compositor_unittest.cc
@@ -39,7 +39,8 @@ class CompositorTest : public testing::Test {
 
     compositor_.reset(new ui::Compositor(
         context_factory_private->AllocateFrameSinkId(), context_factory,
-        context_factory_private, CreateTaskRunner()));
+        context_factory_private, CreateTaskRunner(),
+        false /* enable_surface_synchronization */));
     compositor_->SetAcceleratedWidget(gfx::kNullAcceleratedWidget);
   }
 

--- a/ui/compositor/layer_owner_unittest.cc
+++ b/ui/compositor/layer_owner_unittest.cc
@@ -78,9 +78,10 @@ void LayerOwnerTestWithCompositor::SetUp() {
   ui::InitializeContextFactoryForTests(false, &context_factory,
                                        &context_factory_private);
 
-  compositor_.reset(new ui::Compositor(
-      context_factory_private->AllocateFrameSinkId(), context_factory,
-      context_factory_private, task_runner));
+  compositor_.reset(
+      new ui::Compositor(context_factory_private->AllocateFrameSinkId(),
+                         context_factory, context_factory_private, task_runner,
+                         false /* enable_surface_synchronization */));
   compositor_->SetAcceleratedWidget(gfx::kNullAcceleratedWidget);
 }
 

--- a/ui/compositor/test/test_compositor_host_android.cc
+++ b/ui/compositor/test/test_compositor_host_android.cc
@@ -22,7 +22,8 @@ class TestCompositorHostAndroid : public TestCompositorHost {
       ui::ContextFactoryPrivate* context_factory_private) {
     compositor_.reset(new ui::Compositor(
         context_factory_private->AllocateFrameSinkId(), context_factory,
-        context_factory_private, base::ThreadTaskRunnerHandle::Get()));
+        context_factory_private, base::ThreadTaskRunnerHandle::Get(),
+        false /* enable_surface_synchronization */));
     // TODO(sievers): Support onscreen here.
     compositor_->SetAcceleratedWidget(gfx::kNullAcceleratedWidget);
     compositor_->SetScaleAndSize(1.0f,

--- a/ui/compositor/test/test_compositor_host_mac.mm
+++ b/ui/compositor/test/test_compositor_host_mac.mm
@@ -111,7 +111,8 @@ TestCompositorHostMac::TestCompositorHostMac(
       compositor_(context_factory_private->AllocateFrameSinkId(),
                   context_factory,
                   context_factory_private,
-                  base::ThreadTaskRunnerHandle::Get()),
+                  base::ThreadTaskRunnerHandle::Get(),
+                  false /* enable_surface_synchronization */),
       window_(nil) {}
 
 TestCompositorHostMac::~TestCompositorHostMac() {

--- a/ui/compositor/test/test_compositor_host_ozone.cc
+++ b/ui/compositor/test/test_compositor_host_ozone.cc
@@ -83,7 +83,8 @@ TestCompositorHostOzone::TestCompositorHostOzone(
       compositor_(context_factory_private->AllocateFrameSinkId(),
                   context_factory,
                   context_factory_private,
-                  base::ThreadTaskRunnerHandle::Get()) {}
+                  base::ThreadTaskRunnerHandle::Get(),
+                  false /* enable_surface_synchronization */) {}
 
 TestCompositorHostOzone::~TestCompositorHostOzone() {}
 

--- a/ui/compositor/test/test_compositor_host_win.cc
+++ b/ui/compositor/test/test_compositor_host_win.cc
@@ -23,7 +23,8 @@ class TestCompositorHostWin : public TestCompositorHost,
     Init(NULL, bounds);
     compositor_.reset(new ui::Compositor(
         context_factory_private->AllocateFrameSinkId(), context_factory,
-        context_factory_private, base::ThreadTaskRunnerHandle::Get()));
+        context_factory_private, base::ThreadTaskRunnerHandle::Get(),
+        false /* enable_surface_synchronization */));
     compositor_->SetAcceleratedWidget(hwnd());
     compositor_->SetScaleAndSize(1.0f, GetSize());
   }

--- a/ui/compositor/test/test_compositor_host_x11.cc
+++ b/ui/compositor/test/test_compositor_host_x11.cc
@@ -57,7 +57,8 @@ TestCompositorHostX11::TestCompositorHostX11(
       compositor_(context_factory_private_->AllocateFrameSinkId(),
                   context_factory_,
                   context_factory_private_,
-                  base::ThreadTaskRunnerHandle::Get()) {}
+                  base::ThreadTaskRunnerHandle::Get(),
+                  false /* enable_surface_synchronization */) {}
 
 TestCompositorHostX11::~TestCompositorHostX11() {}
 

--- a/ui/display/manager/display_manager.h
+++ b/ui/display/manager/display_manager.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 
+#include "base/callback.h"
 #include "base/compiler_specific.h"
 #include "base/gtest_prod_util.h"
 #include "base/macros.h"
@@ -488,6 +489,8 @@ class DISPLAY_MANAGER_EXPORT DisplayManager
   Display::Rotation registered_internal_display_rotation_ = Display::ROTATE_0;
 
   bool unified_desktop_enabled_ = false;
+
+  base::Closure created_mirror_window_;
 
   base::ObserverList<DisplayObserver> observers_;
 

--- a/ui/views/cocoa/bridged_native_widget.mm
+++ b/ui/views/cocoa/bridged_native_widget.mm
@@ -1275,7 +1275,8 @@ void BridgedNativeWidget::CreateCompositor() {
   compositor_widget_.reset(new ui::AcceleratedWidgetMac());
   compositor_.reset(new ui::Compositor(
       context_factory_private->AllocateFrameSinkId(), context_factory,
-      context_factory_private, GetCompositorTaskRunner()));
+      context_factory_private, GetCompositorTaskRunner(),
+      false /* enable_surface_synchronization */));
   compositor_->SetAcceleratedWidget(compositor_widget_->accelerated_widget());
   compositor_widget_->SetNSView(this);
 }


### PR DESCRIPTION
This CL fixes out SetBounds implementation, removes custom methods, and allows us to work with 'surface synchronization' enabled (default).

It also reverts two local reverts we have currently in ozone-wayland-dev. In the next rebase round, we can just drop the revert pairs altogether.