### PR TITLE
Handle events for interactive drag and resize of native windows.

### DIFF
--- a/services/ui/public/interfaces/window_tree.mojom
+++ b/services/ui/public/interfaces/window_tree.mojom
@@ -296,6 +296,11 @@ interface WindowTree {
   // on it, pass the cursor location at the start of the move.
   PerformWindowMove(uint32 change_id, uint32 window_id, MoveLoopSource source,
                     gfx.mojom.Point cursor);
+                    
+  // Tells the native window manager to start interactive move or resize of the
+  // window. Once window's bounds are changed during the move or resize, those
+  // are propagated to aura in a normal way.
+  PerformNativeWindowDragOrResize(uint32 window_id, uint32 hittest);
 
   // Tells the window manager to cancel any in progress window move started with
   // StartWindowMove() and to revert the window bounds to how they were.

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -433,6 +433,10 @@ ServerWindow* Display::GetActiveRootWindow() {
   return nullptr;
 }
 
+void Display::PerformNativeWindowDragOrResize(uint32_t hittest) {
+  platform_display_->PerformNativeWindowDragOrResize(hittest);
+}
+
 bool Display::CanHaveActiveChildren(ServerWindow* window) const {
   return window && activation_parents_.Contains(window);
 }

--- a/services/ui/ws/display.h
+++ b/services/ui/ws/display.h
@@ -166,6 +166,10 @@ class Display : public PlatformDisplayDelegate,
   // Returns the root window of the active user.
   ServerWindow* GetActiveRootWindow();
 
+  // Tells the window manager to start interactive move or resize based on
+  // the |hittest|, which can be move, top, left and etc.
+  void PerformNativeWindowDragOrResize(uint32_t hittest);
+
  private:
   friend class test::DisplayTestApi;
 

--- a/services/ui/ws/platform_display.h
+++ b/services/ui/ws/platform_display.h
@@ -79,6 +79,10 @@ class PlatformDisplay : public ui::EventSource {
     PlatformDisplay::factory_ = factory;
   }
 
+  // Tells the window manager to start interactive move or resize based on
+  // the |hittest|.
+  virtual void PerformNativeWindowDragOrResize(uint32_t hittest) {}
+
  private:
   // Static factory instance (always NULL for non-test).
   static PlatformDisplayFactory* factory_;

--- a/services/ui/ws/platform_display_default.cc
+++ b/services/ui/ws/platform_display_default.cc
@@ -141,6 +141,10 @@ void PlatformDisplayDefault::GetWindowType(ui::mojom::WindowType* result) {
   *result = metrics_.window_type;
 }
 
+void PlatformDisplayDefault::PerformNativeWindowDragOrResize(uint32_t hittest) {
+  platform_window_->PerformNativeWindowDragOrResize(hittest);
+}
+
 void PlatformDisplayDefault::SetCursor(const ui::CursorData& cursor_data) {
   if (!image_cursors_)
     return;

--- a/services/ui/ws/platform_display_default.h
+++ b/services/ui/ws/platform_display_default.h
@@ -54,6 +54,7 @@ class PlatformDisplayDefault : public PlatformDisplay,
   void SetWindowVisibility(bool visible) override;
   void SetNativeWindowState(ui::mojom::ShowState state) override;
   void GetWindowType(ui::mojom::WindowType* result) override;
+  void PerformNativeWindowDragOrResize(uint32_t hittest) override;
 
  private:
   // ui::PlatformWindowDelegate:

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -2230,6 +2230,18 @@ void WindowTree::PerformWindowMove(uint32_t change_id,
       source, cursor);
 }
 
+void WindowTree::PerformNativeWindowDragOrResize(Id window_id,
+                                                 uint32_t hittest) {
+  ServerWindow* window = GetWindowByClientId(ClientWindowId(window_id));
+  WindowManagerDisplayRoot* display_root = GetWindowManagerDisplayRoot(window);
+  if (!display_root) {
+    // The window isn't parented. There's nothing to do.
+    DVLOG(1) << "PerformNativeWindowDragOrResize failed (window unparented)";
+    return;
+  }
+  display_root->display()->PerformNativeWindowDragOrResize(hittest);
+}
+
 void WindowTree::CancelWindowMove(Id window_id) {
   ServerWindow* window = GetWindowByClientId(ClientWindowId(window_id));
   if (!window) {

--- a/services/ui/ws/window_tree.h
+++ b/services/ui/ws/window_tree.h
@@ -523,6 +523,7 @@ class WindowTree : public mojom::WindowTree,
                          Id window_id,
                          ui::mojom::MoveLoopSource source,
                          const gfx::Point& cursor) override;
+  void PerformNativeWindowDragOrResize(Id window_id, uint32_t hittest) override;
   void CancelWindowMove(Id window_id) override;
 
   // mojom::WindowManagerClient:

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -2093,6 +2093,13 @@ void WindowTreeClient::OnWindowTreeHostPerformWindowMove(
                            source, cursor_location);
 }
 
+void WindowTreeClient::OnWindowTreeHostPerformNativeWindowDragOrResize(
+    WindowTreeHostMus* window_tree_host,
+    int hittest) {
+  WindowMus* window_mus = WindowMus::Get(window_tree_host->window());
+  tree_->PerformNativeWindowDragOrResize(window_mus->server_id(), hittest);
+}
+
 void WindowTreeClient::OnWindowTreeHostCancelWindowMove(
     WindowTreeHostMus* window_tree_host) {
   tree_->CancelWindowMove(

--- a/ui/aura/mus/window_tree_client.h
+++ b/ui/aura/mus/window_tree_client.h
@@ -525,6 +525,9 @@ class AURA_EXPORT WindowTreeClient
       ui::mojom::MoveLoopSource mus_source,
       const gfx::Point& cursor_location,
       const base::Callback<void(bool)>& callback) override;
+  void OnWindowTreeHostPerformNativeWindowDragOrResize(
+      WindowTreeHostMus* window_tree_host,
+      int hittest) override;
   void OnWindowTreeHostCancelWindowMove(
       WindowTreeHostMus* window_tree_host) override;
   void OnWindowTreeHostMoveCursorToDisplayLocation(

--- a/ui/aura/mus/window_tree_host_mus.cc
+++ b/ui/aura/mus/window_tree_host_mus.cc
@@ -147,6 +147,10 @@ void WindowTreeHostMus::PerformWindowMove(
       this, mus_source, cursor_location, callback);
 }
 
+void WindowTreeHostMus::PerformNativeWindowDragOrResize(int hittest) {
+  delegate_->OnWindowTreeHostPerformNativeWindowDragOrResize(this, hittest);
+}
+
 void WindowTreeHostMus::CancelWindowMove() {
   delegate_->OnWindowTreeHostCancelWindowMove(this);
 }

--- a/ui/aura/mus/window_tree_host_mus.h
+++ b/ui/aura/mus/window_tree_host_mus.h
@@ -76,6 +76,10 @@ class AURA_EXPORT WindowTreeHostMus : public aura::WindowTreeHostPlatform {
                          const gfx::Point& cursor_location,
                          const base::Callback<void(bool)>& callback);
 
+  // Tells the native window manager to start interactive drag or resize of a
+  // window.
+  void PerformNativeWindowDragOrResize(int hittest);
+
   // Tells the window manager to abort any current move initiated by
   // PerformWindowMove().
   void CancelWindowMove();

--- a/ui/aura/mus/window_tree_host_mus_delegate.h
+++ b/ui/aura/mus/window_tree_host_mus_delegate.h
@@ -67,6 +67,12 @@ class AURA_EXPORT WindowTreeHostMusDelegate {
       const gfx::Point& cursor_location,
       const base::Callback<void(bool)>& callback) = 0;
 
+  // Called to tell the native window manager to start interactive drag or
+  // resize of a window.
+  virtual void OnWindowTreeHostPerformNativeWindowDragOrResize(
+      WindowTreeHostMus* window_tree_host,
+      int hittest) = 0;
+
   // Called to cancel a move loop.
   virtual void OnWindowTreeHostCancelWindowMove(
       WindowTreeHostMus* window_tree_host) = 0;

--- a/ui/aura/test/mus/test_window_tree.cc
+++ b/ui/aura/test/mus/test_window_tree.cc
@@ -318,6 +318,9 @@ void TestWindowTree::PerformWindowMove(uint32_t change_id,
   OnChangeReceived(change_id);
 }
 
+void TestWindowTree::PerformNativeWindowDragOrResize(Id window_id,
+                                                     uint32_t hittest) {}
+
 void TestWindowTree::CancelWindowMove(uint32_t window_id) {}
 
 }  // namespace aura

--- a/ui/aura/test/mus/test_window_tree.h
+++ b/ui/aura/test/mus/test_window_tree.h
@@ -213,6 +213,7 @@ class TestWindowTree : public ui::mojom::WindowTree {
                          uint32_t window_id,
                          ui::mojom::MoveLoopSource source,
                          const gfx::Point& cursor_location) override;
+  void PerformNativeWindowDragOrResize(Id window_id, uint32_t hittest) override;
   void CancelWindowMove(uint32_t window_id) override;
 
   struct AckedEvent {

--- a/ui/ozone/platform/headless/headless_window.cc
+++ b/ui/ozone/platform/headless/headless_window.cc
@@ -76,4 +76,6 @@ PlatformImeController* HeadlessWindow::GetPlatformImeController() {
   return nullptr;
 }
 
+void HeadlessWindow::PerformNativeWindowDragOrResize(uint32_t hittest) {}
+
 }  // namespace ui

--- a/ui/ozone/platform/headless/headless_window.h
+++ b/ui/ozone/platform/headless/headless_window.h
@@ -44,6 +44,7 @@ class HeadlessWindow : public PlatformWindow {
   void MoveCursorTo(const gfx::Point& location) override;
   void ConfineCursorToBounds(const gfx::Rect& bounds) override;
   PlatformImeController* GetPlatformImeController() override;
+  void PerformNativeWindowDragOrResize(uint32_t hittest) override;
 
  private:
   PlatformWindowDelegate* delegate_;

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -8,6 +8,7 @@
 
 #include "base/bind.h"
 #include "base/strings/utf_string_conversions.h"
+#include "ui/base/hit_test.h"
 #include "ui/events/event.h"
 #include "ui/events/ozone/events_ozone.h"
 #include "ui/ozone/platform/wayland/wayland_connection.h"
@@ -16,6 +17,42 @@
 namespace ui {
 
 namespace {
+
+// Identifies the direction of the "hittest" for Wayland.
+bool IdentifyDirection(int hittest, int* direction) {
+  DCHECK(direction);
+  *direction = -1;
+  switch (hittest) {
+    case HTBOTTOM:
+      *direction = xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_BOTTOM;
+      break;
+    case HTBOTTOMLEFT:
+      *direction = xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_BOTTOM_LEFT;
+      break;
+    case HTBOTTOMRIGHT:
+      *direction =
+          xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_BOTTOM_RIGHT;
+      break;
+    case HTLEFT:
+      *direction = xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_LEFT;
+      break;
+    case HTRIGHT:
+      *direction = xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_RIGHT;
+      break;
+    case HTTOP:
+      *direction = xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_TOP;
+      break;
+    case HTTOPLEFT:
+      *direction = xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_TOP_LEFT;
+      break;
+    case HTTOPRIGHT:
+      *direction = xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_TOP_RIGHT;
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
 
 static WaylandWindow* g_current_capture_ = nullptr;
 
@@ -258,6 +295,18 @@ void WaylandWindow::ConfineCursorToBounds(const gfx::Rect& bounds) {
 PlatformImeController* WaylandWindow::GetPlatformImeController() {
   NOTIMPLEMENTED();
   return nullptr;
+}
+
+void WaylandWindow::PerformNativeWindowDragOrResize(uint32_t hittest) {
+  if (hittest == HTCAPTION) {
+    xdg_surface_move(xdg_surface_.get(), connection_->seat(),
+                     connection_->serial());
+  } else {
+    int direction;
+    if (IdentifyDirection(hittest, &direction))
+      xdg_surface_resize(xdg_surface_.get(), connection_->seat(),
+                         connection_->serial(), direction);
+  }
 }
 
 bool WaylandWindow::CanDispatchEvent(const PlatformEvent& native_event) {

--- a/ui/ozone/platform/wayland/wayland_window.h
+++ b/ui/ozone/platform/wayland/wayland_window.h
@@ -69,6 +69,7 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
   void MoveCursorTo(const gfx::Point& location) override;
   void ConfineCursorToBounds(const gfx::Rect& bounds) override;
   PlatformImeController* GetPlatformImeController() override;
+  void PerformNativeWindowDragOrResize(uint32_t hittest) override;
 
   // PlatformEventDispatcher
   bool CanDispatchEvent(const PlatformEvent& event) override;

--- a/ui/platform_window/platform_window.h
+++ b/ui/platform_window/platform_window.h
@@ -62,6 +62,10 @@ class PlatformWindow {
   // The PlatformImeController is owned by the PlatformWindow, the ownership is
   // not transferred.
   virtual PlatformImeController* GetPlatformImeController() = 0;
+
+  // The window manager starts interactive drag or resize of a window based on
+  // the |hittest|.
+  virtual void PerformNativeWindowDragOrResize(uint32_t hittest) = 0;
 };
 
 }  // namespace ui

--- a/ui/platform_window/stub/stub_window.cc
+++ b/ui/platform_window/stub/stub_window.cc
@@ -78,4 +78,6 @@ PlatformImeController* StubWindow::GetPlatformImeController() {
   return nullptr;
 }
 
+void StubWindow::PerformNativeWindowDragOrResize(uint32_t hittest) {}
+
 }  // namespace ui

--- a/ui/platform_window/stub/stub_window.h
+++ b/ui/platform_window/stub/stub_window.h
@@ -41,6 +41,7 @@ class STUB_WINDOW_EXPORT StubWindow : NON_EXPORTED_BASE(public PlatformWindow) {
   void MoveCursorTo(const gfx::Point& location) override;
   void ConfineCursorToBounds(const gfx::Rect& bounds) override;
   PlatformImeController* GetPlatformImeController() override;
+  void PerformNativeWindowDragOrResize(uint32_t hittest) override;
 
   PlatformWindowDelegate* delegate_;
   gfx::Rect bounds_;

--- a/ui/platform_window/x11/x11_window_base.cc
+++ b/ui/platform_window/x11/x11_window_base.cc
@@ -306,6 +306,10 @@ PlatformImeController* X11WindowBase::GetPlatformImeController() {
   return nullptr;
 }
 
+void X11WindowBase::PerformNativeWindowDragOrResize(uint32_t hittest) {
+  NOTIMPLEMENTED();
+}
+
 bool X11WindowBase::IsEventForXWindow(const XEvent& xev) const {
   return xwindow_ != None && FindXEventTarget(xev) == xwindow_;
 }

--- a/ui/platform_window/x11/x11_window_base.h
+++ b/ui/platform_window/x11/x11_window_base.h
@@ -47,6 +47,7 @@ class X11_WINDOW_EXPORT X11WindowBase : public PlatformWindow {
   void MoveCursorTo(const gfx::Point& location) override;
   void ConfineCursorToBounds(const gfx::Rect& bounds) override;
   PlatformImeController* GetPlatformImeController() override;
+  void PerformNativeWindowDragOrResize(uint32_t hittest) override;
 
  protected:
   void Destroy();

--- a/ui/views/BUILD.gn
+++ b/ui/views/BUILD.gn
@@ -637,7 +637,11 @@ component("views") {
         sources += [ "widget/desktop_aura/desktop_window_tree_host_ozone.cc" ]
       }
       if (is_linux) {
-        sources += [ "style/platform_style_linux.cc" ]
+        sources += [
+          "style/platform_style_linux.cc",
+          "widget/desktop_aura/window_event_filter.cc",
+          "widget/desktop_aura/window_event_filter.h",
+        ]
       }
     }
   }

--- a/ui/views/mus/desktop_window_tree_host_mus.h
+++ b/ui/views/mus/desktop_window_tree_host_mus.h
@@ -123,6 +123,7 @@ class VIEWS_MUS_EXPORT DesktopWindowTreeHostMus
   bool ShouldUpdateWindowTransparency() const override;
   bool ShouldUseDesktopNativeCursorManager() const override;
   bool ShouldCreateVisibilityController() const override;
+  void PerformNativeWindowDragOrResize(int hittest) override;
 
   // MusClientObserver:
   void OnWindowManagerFrameValuesChanged() override;
@@ -156,6 +157,8 @@ class VIEWS_MUS_EXPORT DesktopWindowTreeHostMus
   bool is_active_ = false;
 
   std::unique_ptr<wm::CursorManager> cursor_manager_;
+
+  std::unique_ptr<ui::EventHandler> non_client_window_event_filter_;
 
   bool auto_update_client_area_ = true;
 

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host.h
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host.h
@@ -170,6 +170,10 @@ class VIEWS_EXPORT DesktopWindowTreeHost {
 
   // Returns whether a VisibilityController should be created.
   virtual bool ShouldCreateVisibilityController() const = 0;
+
+  // Tells the native window manager to start interactive drag or resize of a
+  // window.
+  virtual void PerformNativeWindowDragOrResize(int hittest) = 0;
 };
 
 }  // namespace views

--- a/ui/views/widget/desktop_aura/window_event_filter.cc
+++ b/ui/views/widget/desktop_aura/window_event_filter.cc
@@ -1,0 +1,144 @@
+// Copyright (c) 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/views/widget/desktop_aura/window_event_filter.h"
+
+#include "services/ui/public/interfaces/window_manager_constants.mojom.h"
+#include "ui/aura/client/aura_constants.h"
+#include "ui/aura/window.h"
+#include "ui/aura/window_delegate.h"
+#include "ui/aura/window_tree_host.h"
+#include "ui/base/hit_test.h"
+#include "ui/display/display.h"
+#include "ui/display/screen.h"
+#include "ui/events/event.h"
+#include "ui/events/event_utils.h"
+#include "ui/gfx/x/x11_atom_cache.h"
+#include "ui/gfx/x/x11_types.h"
+#include "ui/views/linux_ui/linux_ui.h"
+#include "ui/views/widget/desktop_aura/desktop_window_tree_host.h"
+#include "ui/views/widget/native_widget_aura.h"
+#include "ui/views/widget/widget.h"
+
+namespace views {
+
+WindowEventFilter::WindowEventFilter(DesktopWindowTreeHost* window_tree_host)
+    : window_tree_host_(window_tree_host), click_component_(HTNOWHERE) {}
+
+WindowEventFilter::~WindowEventFilter() {}
+
+void WindowEventFilter::OnMouseEvent(ui::MouseEvent* event) {
+  if (event->type() != ui::ET_MOUSE_PRESSED)
+    return;
+
+  aura::Window* target = static_cast<aura::Window*>(event->target());
+  if (!target->delegate())
+    return;
+
+  int previous_click_component = HTNOWHERE;
+  int component = target->delegate()->GetNonClientComponent(event->location());
+  if (event->IsLeftMouseButton()) {
+    previous_click_component = click_component_;
+    click_component_ = component;
+  }
+
+  if (component == HTCAPTION) {
+    OnClickedCaption(event, previous_click_component);
+  } else if (component == HTMAXBUTTON) {
+    OnClickedMaximizeButton(event);
+  } else {
+    if (target->GetProperty(aura::client::kResizeBehaviorKey) &
+        ui::mojom::kResizeBehaviorCanResize) {
+      MaybeDispatchHostWindowDragMovement(component, event);
+    }
+  }
+}
+
+void WindowEventFilter::OnClickedCaption(ui::MouseEvent* event,
+                                         int previous_click_component) {
+  aura::Window* target = static_cast<aura::Window*>(event->target());
+
+  if (event->IsMiddleMouseButton()) {
+    LinuxUI::NonClientMiddleClickAction action =
+        LinuxUI::MIDDLE_CLICK_ACTION_LOWER;
+    LinuxUI* linux_ui = LinuxUI::instance();
+    if (linux_ui)
+      action = linux_ui->GetNonClientMiddleClickAction();
+
+    switch (action) {
+      case LinuxUI::MIDDLE_CLICK_ACTION_NONE:
+        break;
+      case LinuxUI::MIDDLE_CLICK_ACTION_LOWER:
+        LowerWindow();
+        break;
+      case LinuxUI::MIDDLE_CLICK_ACTION_MINIMIZE:
+        window_tree_host_->Minimize();
+        break;
+      case LinuxUI::MIDDLE_CLICK_ACTION_TOGGLE_MAXIMIZE:
+        if (target->GetProperty(aura::client::kResizeBehaviorKey) &
+            ui::mojom::kResizeBehaviorCanMaximize)
+          ToggleMaximizedState();
+        break;
+    }
+
+    event->SetHandled();
+    return;
+  }
+
+  if (event->IsLeftMouseButton() && event->flags() & ui::EF_IS_DOUBLE_CLICK) {
+    click_component_ = HTNOWHERE;
+    if ((target->GetProperty(aura::client::kResizeBehaviorKey) &
+         ui::mojom::kResizeBehaviorCanMaximize) &&
+        previous_click_component == HTCAPTION) {
+      // Our event is a double click in the caption area in a window that can be
+      // maximized. We are responsible for dispatching this as a minimize/
+      // maximize on X11 (Windows converts this to min/max events for us).
+      ToggleMaximizedState();
+      event->SetHandled();
+      return;
+    }
+  }
+
+  MaybeDispatchHostWindowDragMovement(HTCAPTION, event);
+}
+
+void WindowEventFilter::OnClickedMaximizeButton(ui::MouseEvent* event) {
+  aura::Window* target = static_cast<aura::Window*>(event->target());
+  views::Widget* widget = views::Widget::GetWidgetForNativeView(target);
+  if (!widget)
+    return;
+
+  gfx::Rect display_work_area =
+      display::Screen::GetScreen()->GetDisplayNearestWindow(target).work_area();
+  gfx::Rect bounds = widget->GetWindowBoundsInScreen();
+  if (event->IsMiddleMouseButton()) {
+    bounds.set_y(display_work_area.y());
+    bounds.set_height(display_work_area.height());
+    widget->SetBounds(bounds);
+    event->StopPropagation();
+  } else if (event->IsRightMouseButton()) {
+    bounds.set_x(display_work_area.x());
+    bounds.set_width(display_work_area.width());
+    widget->SetBounds(bounds);
+    event->StopPropagation();
+  }
+}
+
+void WindowEventFilter::ToggleMaximizedState() {
+  if (window_tree_host_->IsMaximized())
+    window_tree_host_->Restore();
+  else
+    window_tree_host_->Maximize();
+}
+
+void WindowEventFilter::MaybeDispatchHostWindowDragMovement(
+    int hittest,
+    ui::MouseEvent* event) {
+  if (event->IsLeftMouseButton())
+    window_tree_host_->PerformNativeWindowDragOrResize(hittest);
+}
+
+void WindowEventFilter::LowerWindow() {}
+
+}  // namespace views

--- a/ui/views/widget/desktop_aura/window_event_filter.h
+++ b/ui/views/widget/desktop_aura/window_event_filter.h
@@ -1,0 +1,63 @@
+// Copyright (c) 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_VIEWS_WIDGET_DESKTOP_AURA_WINDOW_EVENT_FILTER_H_
+#define UI_VIEWS_WIDGET_DESKTOP_AURA_WINDOW_EVENT_FILTER_H_
+
+#include <X11/Xlib.h>
+
+#include "base/compiler_specific.h"
+#include "base/macros.h"
+#include "base/message_loop/message_loop.h"
+#include "ui/events/event_handler.h"
+#include "ui/gfx/x/x11_types.h"
+#include "ui/views/views_export.h"
+
+namespace aura {
+class Window;
+}
+
+namespace views {
+class DesktopWindowTreeHost;
+
+// An EventFilter that sets properties on X11 windows.
+class VIEWS_EXPORT WindowEventFilter : public ui::EventHandler {
+ public:
+  explicit WindowEventFilter(DesktopWindowTreeHost* window_tree_host);
+  ~WindowEventFilter() override;
+
+  // Overridden from ui::EventHandler:
+  void OnMouseEvent(ui::MouseEvent* event) override;
+
+ private:
+  // Called when the user clicked the caption area.
+  void OnClickedCaption(ui::MouseEvent* event, int previous_click_component);
+
+  // Called when the user clicked the maximize button.
+  void OnClickedMaximizeButton(ui::MouseEvent* event);
+
+  void ToggleMaximizedState();
+
+  // Dispatches a _NET_WM_MOVERESIZE message to the window manager to tell it
+  // to act as if a border or titlebar drag occurred.
+  virtual void MaybeDispatchHostWindowDragMovement(int hittest,
+                                                   ui::MouseEvent* event);
+
+  virtual void LowerWindow();
+
+  DesktopWindowTreeHost* window_tree_host_;
+
+  // The non-client component for the target of a MouseEvent. Mouse events can
+  // be destructive to the window tree, which can cause the component of a
+  // ui::EF_IS_DOUBLE_CLICK event to no longer be the same as that of the
+  // initial click. Acting on a double click should only occur for matching
+  // components.
+  int click_component_;
+
+  DISALLOW_COPY_AND_ASSIGN(WindowEventFilter);
+};
+
+}  // namespace views
+
+#endif  // UI_VIEWS_WIDGET_DESKTOP_AURA_WINDOW_EVENT_FILTER_H_

--- a/ui/views/widget/desktop_aura/x11_window_event_filter.cc
+++ b/ui/views/widget/desktop_aura/x11_window_event_filter.cc
@@ -46,131 +46,24 @@ namespace views {
 
 X11WindowEventFilter::X11WindowEventFilter(
     DesktopWindowTreeHost* window_tree_host)
-    : xdisplay_(gfx::GetXDisplay()),
+    : WindowEventFilter(window_tree_host),
+      xdisplay_(gfx::GetXDisplay()),
       xwindow_(window_tree_host->AsWindowTreeHost()->GetAcceleratedWidget()),
-      x_root_window_(DefaultRootWindow(xdisplay_)),
-      window_tree_host_(window_tree_host),
-      click_component_(HTNOWHERE) {
-}
+      x_root_window_(DefaultRootWindow(xdisplay_)) {}
 
 X11WindowEventFilter::~X11WindowEventFilter() {
 }
 
-void X11WindowEventFilter::OnMouseEvent(ui::MouseEvent* event) {
-  if (event->type() != ui::ET_MOUSE_PRESSED)
-    return;
-
-  aura::Window* target = static_cast<aura::Window*>(event->target());
-  if (!target->delegate())
-    return;
-
-  int previous_click_component = HTNOWHERE;
-  int component =
-      target->delegate()->GetNonClientComponent(event->location());
-  if (event->IsLeftMouseButton()) {
-    previous_click_component = click_component_;
-    click_component_ = component;
-  }
-
-  if (component == HTCAPTION) {
-    OnClickedCaption(event, previous_click_component);
-  } else if (component == HTMAXBUTTON) {
-    OnClickedMaximizeButton(event);
-  } else {
-    // Get the |x_root_window_| location out of the native event.
-    if (event->IsLeftMouseButton() && event->native_event()) {
-      const gfx::Point x_root_location =
-          ui::EventSystemLocationFromNative(event->native_event());
-      if ((target->GetProperty(aura::client::kResizeBehaviorKey) &
-           ui::mojom::kResizeBehaviorCanResize) &&
-          DispatchHostWindowDragMovement(component, x_root_location)) {
-        event->StopPropagation();
-      }
-    }
-  }
-}
-
-void X11WindowEventFilter::OnClickedCaption(ui::MouseEvent* event,
-                                            int previous_click_component) {
-  aura::Window* target = static_cast<aura::Window*>(event->target());
-
-  if (event->IsMiddleMouseButton()) {
-    LinuxUI::NonClientMiddleClickAction action =
-        LinuxUI::MIDDLE_CLICK_ACTION_LOWER;
-    LinuxUI* linux_ui = LinuxUI::instance();
-    if (linux_ui)
-      action = linux_ui->GetNonClientMiddleClickAction();
-
-    switch (action) {
-      case LinuxUI::MIDDLE_CLICK_ACTION_NONE:
-        break;
-      case LinuxUI::MIDDLE_CLICK_ACTION_LOWER:
-        XLowerWindow(xdisplay_, xwindow_);
-        break;
-      case LinuxUI::MIDDLE_CLICK_ACTION_MINIMIZE:
-        window_tree_host_->Minimize();
-        break;
-      case LinuxUI::MIDDLE_CLICK_ACTION_TOGGLE_MAXIMIZE:
-        if (target->GetProperty(aura::client::kResizeBehaviorKey) &
-            ui::mojom::kResizeBehaviorCanMaximize)
-          ToggleMaximizedState();
-        break;
-    }
-
-    event->SetHandled();
-    return;
-  }
-
-  if (event->IsLeftMouseButton() && event->flags() & ui::EF_IS_DOUBLE_CLICK) {
-    click_component_ = HTNOWHERE;
-    if ((target->GetProperty(aura::client::kResizeBehaviorKey) &
-         ui::mojom::kResizeBehaviorCanMaximize) &&
-        previous_click_component == HTCAPTION) {
-      // Our event is a double click in the caption area in a window that can be
-      // maximized. We are responsible for dispatching this as a minimize/
-      // maximize on X11 (Windows converts this to min/max events for us).
-      ToggleMaximizedState();
-      event->SetHandled();
-      return;
-    }
-  }
-
-  // Get the |x_root_window_| location out of the native event.
+void X11WindowEventFilter::MaybeDispatchHostWindowDragMovement(
+    int hittest,
+    ui::MouseEvent* event) {
   if (event->IsLeftMouseButton() && event->native_event()) {
+    // Get the |x_root_window_| location out of the native event.
     const gfx::Point x_root_location =
         ui::EventSystemLocationFromNative(event->native_event());
-    if (DispatchHostWindowDragMovement(HTCAPTION, x_root_location))
+    if (DispatchHostWindowDragMovement(hittest, x_root_location))
       event->StopPropagation();
   }
-}
-
-void X11WindowEventFilter::OnClickedMaximizeButton(ui::MouseEvent* event) {
-  aura::Window* target = static_cast<aura::Window*>(event->target());
-  views::Widget* widget = views::Widget::GetWidgetForNativeView(target);
-  if (!widget)
-    return;
-
-  gfx::Rect display_work_area =
-      display::Screen::GetScreen()->GetDisplayNearestWindow(target).work_area();
-  gfx::Rect bounds = widget->GetWindowBoundsInScreen();
-  if (event->IsMiddleMouseButton()) {
-    bounds.set_y(display_work_area.y());
-    bounds.set_height(display_work_area.height());
-    widget->SetBounds(bounds);
-    event->StopPropagation();
-  } else if (event->IsRightMouseButton()) {
-    bounds.set_x(display_work_area.x());
-    bounds.set_width(display_work_area.width());
-    widget->SetBounds(bounds);
-    event->StopPropagation();
-  }
-}
-
-void X11WindowEventFilter::ToggleMaximizedState() {
-  if (window_tree_host_->IsMaximized())
-    window_tree_host_->Restore();
-  else
-    window_tree_host_->Maximize();
 }
 
 bool X11WindowEventFilter::DispatchHostWindowDragMovement(
@@ -233,6 +126,10 @@ bool X11WindowEventFilter::DispatchHostWindowDragMovement(
              &event);
 
   return true;
+}
+
+void X11WindowEventFilter::LowerWindow() {
+  XLowerWindow(xdisplay_, xwindow_);
 }
 
 }  // namespace views

--- a/ui/views/widget/desktop_aura/x11_window_event_filter.h
+++ b/ui/views/widget/desktop_aura/x11_window_event_filter.h
@@ -13,10 +13,7 @@
 #include "ui/events/event_handler.h"
 #include "ui/gfx/x/x11_types.h"
 #include "ui/views/views_export.h"
-
-namespace aura {
-class Window;
-}
+#include "ui/views/widget/desktop_aura/window_event_filter.h"
 
 namespace gfx {
 class Point;
@@ -26,26 +23,17 @@ namespace views {
 class DesktopWindowTreeHost;
 
 // An EventFilter that sets properties on X11 windows.
-class VIEWS_EXPORT X11WindowEventFilter : public ui::EventHandler {
+class VIEWS_EXPORT X11WindowEventFilter : public WindowEventFilter {
  public:
   explicit X11WindowEventFilter(DesktopWindowTreeHost* window_tree_host);
   ~X11WindowEventFilter() override;
 
-  // Overridden from ui::EventHandler:
-  void OnMouseEvent(ui::MouseEvent* event) override;
-
  private:
-  // Called when the user clicked the caption area.
-  void OnClickedCaption(ui::MouseEvent* event,
-                        int previous_click_component);
+  // WindowEventFilter override:
+  void MaybeDispatchHostWindowDragMovement(int hittest,
+                                           ui::MouseEvent* event) override;
+  void LowerWindow() override;
 
-  // Called when the user clicked the maximize button.
-  void OnClickedMaximizeButton(ui::MouseEvent* event);
-
-  void ToggleMaximizedState();
-
-  // Dispatches a _NET_WM_MOVERESIZE message to the window manager to tell it
-  // to act as if a border or titlebar drag occurred.
   bool DispatchHostWindowDragMovement(int hittest,
                                       const gfx::Point& screen_location);
 
@@ -55,15 +43,6 @@ class VIEWS_EXPORT X11WindowEventFilter : public ui::EventHandler {
 
   // The native root window.
   ::Window x_root_window_;
-
-  DesktopWindowTreeHost* window_tree_host_;
-
-  // The non-client component for the target of a MouseEvent. Mouse events can
-  // be destructive to the window tree, which can cause the component of a
-  // ui::EF_IS_DOUBLE_CLICK event to no longer be the same as that of the
-  // initial click. Acting on a double click should only occur for matching
-  // components.
-  int click_component_;
 
   DISALLOW_COPY_AND_ASSIGN(X11WindowEventFilter);
 };


### PR DESCRIPTION
This patch adds capabilities to process events, which are aimed
at starting of interactive drag and resize of native windows.
Class X11WindowEventFilter is now inherits from WindowEventFilter,
which is a main class for both Ozone X11/Wayland and non-ozone X11 builds.
That class handles the above mentioned events and can send maximize/restore/
resize/drag events down to window manager in ozone builds. In case of
non-ozone X11 builds, the move or resize events are handled by
X11WindowEventFilter and WM_MOVERESIZE atom is set (as it originally was).

At the moment, ozone X11 build doesn't have the final
PerformNativeWindowDragOrResize() method implemented as long as
the location of events is faulty there a bit