### PR TITLE
Two driven-by fixup's

### DIFF
--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -881,7 +881,7 @@ void WindowServer::OnWindowSharedPropertyChanged(
     ServerWindow* window,
     const std::string& name,
     const std::vector<uint8_t>* new_data) {
-  if (in_external_window_mode &&
+  if (in_external_window_mode_ &&
       name == mojom::WindowManager::kShowState_Property) {
     const int64_t state = mojo::ConvertTo<int64_t>(*new_data);
     SetNativeWindowState(window, static_cast<ui::mojom::ShowState>(state));

--- a/services/ui/ws/window_server.h
+++ b/services/ui/ws/window_server.h
@@ -168,8 +168,8 @@ class WindowServer : public ServerWindowDelegate,
   bool SetFocusedWindow(ServerWindow* window);
   ServerWindow* GetFocusedWindow();
 
-  void SetInExternalWindowMode() { in_external_window_mode = true; }
-  bool IsInExternalWindowMode() const { return in_external_window_mode; }
+  void SetInExternalWindowMode() { in_external_window_mode_ = true; }
+  bool IsInExternalWindowMode() const { return in_external_window_mode_; }
 
   void SetHighContrastMode(const UserId& user, bool enabled);
 
@@ -431,7 +431,7 @@ class WindowServer : public ServerWindowDelegate,
   // Provides interfaces to create and manage FrameSinks.
   std::unique_ptr<cc::mojom::FrameSinkManager> frame_sink_manager_;
 
-  bool in_external_window_mode = false;
+  bool in_external_window_mode_ = false;
 
   DisplayCreationConfig display_creation_config_;
 

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -1978,8 +1978,6 @@ void WindowTree::DeactivateWindow(Id window_id) {
 }
 
 void WindowTree::StackAbove(uint32_t change_id, Id above_id, Id below_id) {
-  client()->OnChangeCompleted(change_id, true);
-  return;
   ServerWindow* above = GetWindowByClientId(ClientWindowId(above_id));
   if (!above) {
     DVLOG(1) << "StackAbove failed (invalid above id)";
@@ -2038,8 +2036,6 @@ void WindowTree::StackAbove(uint32_t change_id, Id above_id, Id below_id) {
 }
 
 void WindowTree::StackAtTop(uint32_t change_id, Id window_id) {
-  client()->OnChangeCompleted(change_id, true);
-  return;
   ServerWindow* window = GetWindowByClientId(ClientWindowId(window_id));
   if (!window) {
     DVLOG(1) << "StackAtTop failed (invalid id)";


### PR DESCRIPTION
- Unneeded bail out this far on the road.
- wrongly named class variable (missing "_" suffix).