### PR TITLE
Fix creating mus catalog and compilation failure.

### DIFF
--- a/chrome/app/mash/BUILD.gn
+++ b/chrome/app/mash/BUILD.gn
@@ -9,6 +9,12 @@ import("//services/service_manager/public/service_manifest.gni")
 
 assert(enable_package_mash_services)
 
+# Disallow to use mash packages in Linux OS without use_ozone flag.
+# Otherwise, mus catalog is not created and compilation failes in the end.
+if (is_linux && !is_chromeos) {
+  assert(use_ozone)
+}
+
 source_set("embedded_services") {
   sources = [
     "embedded_services.cc",

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -367,7 +367,15 @@ void WaylandWindow::Configure(void* data,
 
   window->ResetWindowStates();
   uint32_t* p;
-  wl_array_for_each(p, states) {
+  // wl_array_for_each has a bug in upstream. It tries to assign void* to
+  // uint32_t *, which is not allowed in C++. Explicit cast should be performed.
+  // In other words, one just cannot assign void * to other pointer type
+  // implicitly in C++ as in C. We can't modify wayland-util.h, because it is
+  // fetched with gclient sync. Thus, use own loop.
+  // TODO(msisov, tonikitoo): use wl_array_for_each as soon as
+  // https://bugs.freedesktop.org/show_bug.cgi?id=101618 is resolved.
+  for (p = (uint32_t*)states->data;
+       (const char*)p < ((const char*)(states)->data + (states)->size); p++) {
     uint32_t state = *p;
     switch (state) {
       case (XDG_SURFACE_STATE_MAXIMIZED):


### PR DESCRIPTION
Our bot has Default target, which just has enable_package_mash_services set to true and nothing else.
This leads to catalog_mus not being created. Before that, we had the following if statement, which worked for us (if (is_chromeos || true)).

Another issue is that wl_array_for_each has a bug and one cannot just assign void* to int* without a type cast in C++ (wayland upstream bug).