### PR TITLE
fixup! c++ / mojo changes for 'external window mode'

### DIFF
--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -201,6 +201,13 @@ void WindowTree::ConfigureWindowManager(
   window_manager_state_ = base::MakeUnique<WindowManagerState>(this);
 }
 
+void WindowTree::ConfigureRootWindowTreeClient(
+    bool automatically_create_display_roots) {
+  DCHECK(window_server_->IsInExternalWindowMode());
+  automatically_create_display_roots_ = automatically_create_display_roots;
+  binding_->GetWindowManager()->OnConnect(id_);
+}
+
 const ServerWindow* WindowTree::GetWindow(const WindowId& id) const {
   if (id_ == id.client_id) {
     auto iter = created_window_map_.find(id);

--- a/services/ui/ws/window_tree.h
+++ b/services/ui/ws/window_tree.h
@@ -82,6 +82,9 @@ class WindowTree : public mojom::WindowTree,
   // on |automatically_create_display_roots|.
   void ConfigureWindowManager(bool automatically_create_display_roots);
 
+  // Called if this WindowTree is a root one, in external window mode.
+  void ConfigureRootWindowTreeClient(bool automatically_create_display_roots);
+
   bool automatically_create_display_roots() const {
     return automatically_create_display_roots_;
   }

--- a/services/ui/ws/window_tree_host_factory_registrar.cc
+++ b/services/ui/ws/window_tree_host_factory_registrar.cc
@@ -72,8 +72,10 @@ void WindowTreeHostFactoryRegistrar::Register(
   // will not get called because the WindowTree instance was created above
   // taking 'nullptr' as the ServerWindow parameter, hence the WindowTree has no
   // 'root' yet.
+  WindowTree* tree_ptr = tree.get();
   window_server_->AddTree(std::move(tree), std::move(tree_binding),
                           nullptr /*mojom::WindowTreePtr*/);
+  tree_ptr->ConfigureRootWindowTreeClient(automatically_create_display_roots);
   window_server_->set_window_tree_host_factory(std::move(host_factory));
 }
 

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -307,6 +307,11 @@ void WindowTreeClient::ConnectViaWindowTreeHostFactory() {
   SetWindowTree(std::move(window_tree));
 
   in_external_window_mode_ = true;
+
+  // Similarly in AshConfig::MUS, it is important to have
+  // the connection with the root window tree established before
+  // continuing. See chrome/browser/ui/ash/ash_init.cc @ CreateMusShell.
+  WaitForInitialDisplays();
 }
 
 void WindowTreeClient::ConnectViaWindowTreeFactory() {
@@ -1058,8 +1063,6 @@ void WindowTreeClient::OnEmbed(
     bool drawn,
     const base::Optional<cc::LocalSurfaceId>& local_surface_id) {
   if (in_external_window_mode_) {
-    client_id_ = client_id;
-
     // No need to set 'tree_ptr_' whether it was already set during
     // ConnectViaWindowManagerHostFactory.
     DCHECK(tree_ptr_);


### PR DESCRIPTION

This CL makes the WindowTreeClient awaits on the WindowTree
connection to establish before it continues.
    
Before this, there was a mismatch between the values of
WindowTreeClient::client_id_ and the WindowTree::id_. The
reason was because the former was only updated when
WindowTreeClient::OnEmbed was called.
    
With the patch, we behave similarly to (m)ash, where it awaits for
the WindowTreeClient::OnConnect call, so that WTC::client_id_ is
properly set (see chrome/browser/ui/ash/ash_init.cc @ CreateMusShell).
    
This fixes one of the blockers on using WindowManagerAccessPolicy
for both chrome/mus_demo and unittests.