### PR TITLE
fixup! Handle window minimize/maximize/restore in external window mode.

### DIFF
--- a/services/ui/ws/platform_display_default.cc
+++ b/services/ui/ws/platform_display_default.cc
@@ -290,6 +290,10 @@ void PlatformDisplayDefault::OnWindowStateChanged(
     case (ui::PlatformWindowState::PLATFORM_WINDOW_STATE_NORMAL):
       state = ui::mojom::ShowState::NORMAL;
       break;
+    // If the window is in the fullscreen mode, there is no need to notify the
+    // client about the state as long as it has been the client who has changed
+    // the state. Checked here explicitly on purpose.
+    case (ui::PlatformWindowState::PLATFORM_WINDOW_STATE_FULLSCREEN):
     default:
       // We don't support other states at the moment. Ignore them.
       return;

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -393,12 +393,9 @@ void WaylandWindow::Configure(void* data,
       ui::PlatformWindowState::PLATFORM_WINDOW_STATE_NORMAL;
   if (window->is_maximized_)
     state = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MAXIMIZED;
-
-  // If the window is in the fullscreen mode, there is no need to notify the
-  // client about the state as long as it has been the client who has changed
-  // the state.
-  if (!window->is_fullscreen_)
-    window->delegate()->OnWindowStateChanged(state);
+  if (window->is_fullscreen_)
+    state = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_FULLSCREEN;
+  window->delegate()->OnWindowStateChanged(state);
 
   // Rather than call SetBounds here for every configure event, just save the
   // most recent bounds, and have WaylandConnection call ApplyPendingBounds

--- a/ui/ozone/platform/wayland/wayland_window_unittest.cc
+++ b/ui/ozone/platform/wayland/wayland_window_unittest.cc
@@ -42,6 +42,29 @@ class WaylandWindowTest : public WaylandTest {
   }
 
  protected:
+  void SendConfigureEvent(int width,
+                          int height,
+                          uint32_t serial,
+                          struct wl_array* states) {
+    xdg_surface_send_configure(xdg_surface->resource(), width, height, states,
+                               serial);
+  }
+
+  void RestoreOnStateChanged(PlatformWindowState expected_state) {
+    ON_CALL(delegate, OnWindowStateChanged(_))
+        .WillByDefault(testing::Invoke(
+            [this, expected_state](PlatformWindowState new_state) {
+              EXPECT_EQ(new_state, expected_state);
+              window.Restore();
+            }));
+  }
+
+  void SetWlArrayWithState(uint32_t state, wl_array* states) {
+    uint32_t* s;
+    s = (uint32_t*)wl_array_add(states, sizeof *s);
+    *s = state;
+  }
+
   wl::MockXdgSurface* xdg_surface;
 
   MouseEvent test_mouse_event;
@@ -56,10 +79,16 @@ TEST_F(WaylandWindowTest, SetTitle) {
 }
 
 TEST_F(WaylandWindowTest, MaximizeAndRestore) {
+  uint32_t serial = 12;
+  wl_array states;
+  wl_array_init(&states);
+  SetWlArrayWithState(XDG_SURFACE_STATE_MAXIMIZED, &states);
+
   EXPECT_CALL(*xdg_surface, SetMaximized());
   EXPECT_CALL(*xdg_surface, UnsetMaximized());
   window.Maximize();
-  window.Restore();
+  SendConfigureEvent(0, 0, serial, &states);
+  RestoreOnStateChanged(PlatformWindowState::PLATFORM_WINDOW_STATE_MAXIMIZED);
 }
 
 TEST_F(WaylandWindowTest, Minimize) {
@@ -68,20 +97,31 @@ TEST_F(WaylandWindowTest, Minimize) {
 }
 
 TEST_F(WaylandWindowTest, SetFullScreenAndRestore) {
+  wl_array states;
+  wl_array_init(&states);
+  SetWlArrayWithState(XDG_SURFACE_STATE_FULLSCREEN, &states);
+
   EXPECT_CALL(*xdg_surface, SetFullScreen());
   EXPECT_CALL(*xdg_surface, UnsetFullScreen());
   window.ToggleFullscreen();
-  window.Restore();
+  SendConfigureEvent(0, 0, 1, &states);
+  RestoreOnStateChanged(PlatformWindowState::PLATFORM_WINDOW_STATE_FULLSCREEN);
 }
 
 TEST_F(WaylandWindowTest, SetMaximizedFullScreenAndRestore) {
+  wl_array states;
+  wl_array_init(&states);
+  SetWlArrayWithState(XDG_SURFACE_STATE_MAXIMIZED, &states);
+  SetWlArrayWithState(XDG_SURFACE_STATE_FULLSCREEN, &states);
+
   EXPECT_CALL(*xdg_surface, SetFullScreen());
   EXPECT_CALL(*xdg_surface, UnsetFullScreen());
   EXPECT_CALL(*xdg_surface, SetMaximized());
   EXPECT_CALL(*xdg_surface, UnsetMaximized());
   window.Maximize();
   window.ToggleFullscreen();
-  window.Restore();
+  SendConfigureEvent(0, 0, 2, &states);
+  RestoreOnStateChanged(PlatformWindowState::PLATFORM_WINDOW_STATE_FULLSCREEN);
 }
 
 TEST_F(WaylandWindowTest, CanDispatchMouseEventDefault) {
@@ -120,8 +160,8 @@ TEST_F(WaylandWindowTest, DispatchEvent) {
 TEST_F(WaylandWindowTest, ConfigureEvent) {
   wl_array states;
   wl_array_init(&states);
-  xdg_surface_send_configure(xdg_surface->resource(), 1000, 1000, &states, 12);
-  xdg_surface_send_configure(xdg_surface->resource(), 1500, 1000, &states, 13);
+  SendConfigureEvent(1000, 1000, 12, &states);
+  SendConfigureEvent(1500, 1000, 13, &states);
 
   // Make sure that the implementation does not call OnBoundsChanged for each
   // configure event if it receives multiple in a row.


### PR DESCRIPTION
Fix ozone_unittests and make some tweaks in WaylandWindow:

Tests are now modified in such a way that the window's state is
restored only after configure event is sent and delegate is said about
the window's state changed. This emulates real client->wayland->client
behaviour much better.

What is more, WaylandWindow now tells about FULLSCREEN state as well,
but delegate checks that and just doesn't notify mus about that, because
it was mus, who instantiated that. This is made on purpose to make
the job to write tests easier. Otherwise, MessageLoops and other tweaks
are needed.