### PR TITLE
User WindowManagerAccessPolicy both for chrome/mus and unittests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,117 @@
+# Chromium for Wayland
+
+The goal of this project is to enable
+[Chromium browser](https://www.chromium.org/) to run on
+[Wayland](https://wayland.freedesktop.org/). Note that contrary to
+[01.org/ozone-wayland](https://github.com/01org/ozone-wayland), the idea is
+to keep it very close to upstream developments as well as aligned on Google's own
+plans. In particular, this fork is rebased against
+[Chromium ToT](https://chromium.googlesource.com/chromium/src.git) each week
+and patches are upstreamed as soon as possible.
+
+The implementation also relies on actively developed Chromium technologies:
+
+* [Aura](https://www.chromium.org/developers/design-documents/aura/aura-overview) and [MUS](https://www.chromium.org/developers/mus-ash) for the user interface.
+* [Ozone](https://chromium.googlesource.com/chromium/src/+/master/docs/ozone_overview.md) as a platform abstraction layer together with the [upstream Wayland backend](https://chromium.googlesource.com/chromium/src.git/+/master/ui/ozone/platform/wayland/).
+* [Mojo](https://chromium.googlesource.com/chromium/src/+/master/mojo) to perform IPC communication.
+
+Notice that the effort done here is also useful to run Chromium via MUS on
+Linux Desktop for X11.
+
+# Building Chromium
+
+General information is provided by the upstream documentation for
+[Chromium on Linux](https://chromium.googlesource.com/chromium/src/+/master/docs/linux_build_instructions.md)
+and
+[Ozone](https://chromium.googlesource.com/chromium/src/+/master/docs/ozone_overview.md).
+Here is the summary of commands to build and run Chrome for Wayland:
+
+```
+gn args out/Ozone --args="use_ozone=true enable_package_mash_services=true"
+ninja -C out/Ozone chrome
+./out/Ozone/chrome --mus --ozone-platform=wayland
+```
+
+By default, the `headless`, `x11` and `wayland` Ozone backends are
+compiled and X11 is selected when `--ozone-platform` is not specified.
+Please refer to the
+[GN Configuration notes](https://chromium.googlesource.com/chromium/src/+/master/docs/ozone_overview.md#GN-Configuration-notes) for details on how to change
+that behavior.
+
+# Running Tests
+
+Most of the Chromium tests should pass although they are not regularly tested
+for now. One can run the MUS Demo as follows:
+
+```
+ninja -C out/Ozone mus_demo mash:all
+./out/Ozone/mash --service=mus_demo --external-window-count=2
+```
+
+One can also run automated unit tests. For example to check the MUS demo and
+window server:
+
+```
+ninja -C out/Ozone mus_ws_unittests mus_demo_unittests
+./out/Ozone/mus_demo_unittests
+./out/Ozone/mus_ws_unittests
+```
+
+Note that `--ozone-platform` can be passed to all the programs above to select
+a specific Ozone backend.
+
+# Rebase Strategy
+
+As mentioned above, the fork is rebased every week against Chromium ToT.
+The goal is to be as close as possible to the lastest Mus code, which is
+constantly receiving performance and stability fixes.
+
+Here is the current process:
+
+* Every week, a member of the Igalia Chromium team takes the rebase shift.
+
+* Commits that are complementary of each other, receive a "fixup!" prefix on
+the commit title, and keep the rest of original commit title unchanged.
+
+For example:
+
+```
+$ git log --oneline
+commit 1
+commit 2
+commit 3
+fixup! commit 1
+fixup! commit 2
+commit 4
+fixup! commit 2
+(..)
+```
+
+This allows an easy identification of "fixup" commits, which should be squashed into
+their original counterpart commit as part of the next rebase cycle. That way we keep
+our Git history clean, and commits as atomic as possible, for when upstreaming.
+
+Git has [an optimized flow for this](http://fle.github.io/git-tip-keep-your-branch-clean-with-fixup-and-autosquash.html) as well.
+
+* We always keep the 'ozone-wayland-dev' branch as our primarily development branch.
+
+This means that force pushes will happen. So every time one of the team members
+rebases our branch, the developer should first back up the existing ozone-wayland-dev
+browser, with the following naming: ozone-wayland-dev-rXXXX, where XXXX is the respective
+Chromium baseline of the branch.
+
+* Branch acceptance criteria
+
+compilation targets:
+
+```
+chrome mash:all  mus_ws_unittests  base_unittests services/ui/demo mus_*_unittests ozone_unittests mus_demo_unittests
+```
+... on LinuxOS and ChromeOS builds.
+
+Pass `mus_demo` and `mus_demo_unittests` tests.
+
+Run chrome --mash / --mus on the configurations above, and performance some sanity tests:
+basic mouse clicking / keyboard; basic navigation; multi window creation; etc.
+
+* Keep [our internal buildbot](https://build-chromium.igalia.com/) green.

--- a/ash/mus/app_launch_unittest.cc
+++ b/ash/mus/app_launch_unittest.cc
@@ -15,8 +15,10 @@
 namespace ash {
 namespace mus {
 
-void RunCallback(bool* success, const base::Closure& callback, bool result) {
-  *success = result;
+void RunCallback(uint64_t* root_window_count,
+                 const base::Closure& callback,
+                 uint64_t result) {
+  *root_window_count = result;
   callback.Run();
 }
 
@@ -44,12 +46,12 @@ TEST_F(AppLaunchTest, TestQuickLaunch) {
   connector()->BindInterface(ui::mojom::kServiceName, &test_interface);
 
   base::RunLoop run_loop;
-  bool success = false;
-  test_interface->EnsureClientHasDrawnWindow(
+  uint64_t root_window_count = 0;
+  test_interface->EnsureClientHasDrawnRootWindows(
       mash::quick_launch::mojom::kServiceName,
-      base::Bind(&RunCallback, &success, run_loop.QuitClosure()));
+      base::Bind(&RunCallback, &root_window_count, run_loop.QuitClosure()));
   run_loop.Run();
-  EXPECT_TRUE(success);
+  EXPECT_EQ(1u, root_window_count);
 }
 
 }  // namespace mus

--- a/chrome/BUILD.gn
+++ b/chrome/BUILD.gn
@@ -79,7 +79,8 @@ if (enable_package_mash_services) {
     "//services/ui/public/interfaces:constants",
   ]
 
-  if (is_chromeos) {
+  # TODO(tonikitoo,msisov): Upstream and non-chromeos bits.
+  if (is_chromeos || (use_ozone && is_linux)) {
     embedded_mash_service_deps += [ "//chrome/app/mash:chrome_mus_catalog" ]
   }
 }

--- a/chrome/app/BUILD.gn
+++ b/chrome/app/BUILD.gn
@@ -374,7 +374,8 @@ static_library("test_support") {
       "//services/ui/public/interfaces:constants",
     ]
 
-    if (is_chromeos) {
+    # TODO(tonikitoo,msisov): Upstream and non-chromeos bits.
+    if (is_chromeos || (use_ozone && is_linux)) {
       deps += [ "//chrome/app/mash:chrome_mus_catalog" ]
     }
   }

--- a/chrome/app/chrome_main.cc
+++ b/chrome/app/chrome_main.cc
@@ -101,7 +101,7 @@ int ChromeMain(int argc, const char** argv) {
   }
 #endif  // defined(OS_LINUX) || defined(OS_MACOSX) || defined(OS_WIN)
 
-#if defined(OS_CHROMEOS) && BUILDFLAG(ENABLE_PACKAGE_MASH_SERVICES)
+#if BUILDFLAG(ENABLE_PACKAGE_MASH_SERVICES)
   if (service_manager::ServiceManagerIsRemote())
     params.env_mode = aura::Env::Mode::MUS;
 #endif  // BUILDFLAG(ENABLE_PACKAGE_MASH_SERVICES)

--- a/chrome/app/chrome_main_delegate.cc
+++ b/chrome/app/chrome_main_delegate.cc
@@ -113,11 +113,7 @@
 #include "mash/common/config.h"                                   // nogncheck
 #include "mash/quick_launch/public/interfaces/constants.mojom.h"  // nogncheck
 #include "services/ui/public/interfaces/constants.mojom.h"        // nogncheck
-
-#if defined(OS_CHROMEOS)
 #include "chrome/app/mash/chrome_mus_catalog.h"
-#endif
-
 #endif  // BUILDFLAG(ENABLE_PACKAGE_MASH_SERVICES)
 
 #if defined(OS_ANDROID)
@@ -1134,7 +1130,7 @@ service_manager::ProcessType ChromeMainDelegate::OverrideProcessType() {
 std::unique_ptr<base::Value> ChromeMainDelegate::CreateServiceCatalog() {
 #if BUILDFLAG(ENABLE_PACKAGE_MASH_SERVICES)
   const auto& command_line = *base::CommandLine::ForCurrentProcess();
-#if defined(OS_CHROMEOS)
+#if defined(OS_CHROMEOS) || (defined(OS_LINUX) && defined(USE_OZONE))
   if (command_line.HasSwitch(switches::kMus))
     return CreateChromeMusCatalog();
 #endif  // defined(OS_CHROMEOS)
@@ -1171,8 +1167,11 @@ bool ChromeMainDelegate::ShouldTerminateServiceManagerOnInstanceQuit(
     const service_manager::Identity& identity,
     int* exit_code) {
 #if BUILDFLAG(ENABLE_PACKAGE_MASH_SERVICES)
-  if (identity.name() == mash::common::GetWindowManagerServiceName() ||
+  if (
+#if defined(OS_CHROMEOS)
+      identity.name() == mash::common::GetWindowManagerServiceName() ||
       identity.name() == ui::mojom::kServiceName ||
+#endif  // defined(OS_CHROMEOS)
       identity.name() == content::mojom::kPackagedServicesServiceName) {
     // Quit the main process if an important child (e.g. window manager) dies.
     // On Chrome OS the OS-level session_manager will restart the main process.

--- a/chrome/app/mash/BUILD.gn
+++ b/chrome/app/mash/BUILD.gn
@@ -63,6 +63,10 @@ source_set("embedded_services") {
   if (is_linux && !is_android) {
     deps += [ "//components/font_service:lib" ]
   }
+
+  if (is_linux && use_ozone && !is_chromeos) {
+    deps += [ ":chrome_mus_catalog" ]
+  }
 }
 
 catalog("catalog") {
@@ -100,7 +104,8 @@ catalog_cpp_source("chrome_mash_catalog") {
   generated_function_name = "CreateChromeMashCatalog"
 }
 
-if (is_chromeos) {
+# TODO(tonikitoo,msisov): Upstream and non-chromeos bits.
+if (is_chromeos || (use_ozone && is_linux)) {
   catalog("catalog_mus") {
     catalog_deps = [ "//chrome/app:catalog" ]
     embedded_services = [

--- a/chrome/browser/chrome_content_browser_manifest_overlay.json
+++ b/chrome/browser/chrome_content_browser_manifest_overlay.json
@@ -30,7 +30,7 @@
         "nacl_loader": [ "browser" ],
         "preferences_forwarder": [ "pref_client" ],
         "preferences": [ "pref_client", "pref_control" ],
-        "ui": [ "display_controller", "ime_registrar", "window_manager" ]
+        "ui": [ "display_controller", "ime_registrar", "window_manager", "window_tree_host_factory_registrar" ]
       }
     },
     "navigation:frame": {

--- a/chrome/browser/ui/views/frame/browser_frame.cc
+++ b/chrome/browser/ui/views/frame/browser_frame.cc
@@ -40,7 +40,7 @@
 #include "chrome/browser/ui/views/frame/browser_command_handler_linux.h"
 #endif
 
-#if defined(OS_LINUX) && !defined(OS_CHROMEOS)
+#if defined(USE_X11)
 #include "ui/views/widget/desktop_aura/x11_desktop_handler.h"
 #endif
 

--- a/chrome/browser/ui/views/frame/browser_non_client_frame_view_factory_views.cc
+++ b/chrome/browser/ui/views/frame/browser_non_client_frame_view_factory_views.cc
@@ -20,7 +20,7 @@ namespace chrome {
 BrowserNonClientFrameView* CreateBrowserNonClientFrameView(
     BrowserFrame* frame,
     BrowserView* browser_view) {
-#if defined(USE_AURA)
+#if defined(USE_AURA) && (!defined(USE_OZONE) || defined(OS_CHROMEOS))
   if (service_manager::ServiceManagerIsRemote()) {
     BrowserNonClientFrameViewMus* frame_view =
         new BrowserNonClientFrameViewMus(frame, browser_view);

--- a/chrome/browser/ui/views/ime_driver/ime_driver_mus.cc
+++ b/chrome/browser/ui/views/ime_driver/ime_driver_mus.cc
@@ -54,7 +54,8 @@ void IMEDriver::StartSession(int32_t session_id,
 #else
   input_method_bindings_[session_id] =
       base::MakeUnique<mojo::Binding<ui::mojom::InputMethod>>(
-          new SimpleInputMethod());
+          new SimpleInputMethod(std::move(details->client)),
+          std::move(details->input_method_request));
 #endif
 }
 

--- a/chrome/browser/ui/views/ime_driver/simple_input_method.cc
+++ b/chrome/browser/ui/views/ime_driver/simple_input_method.cc
@@ -4,7 +4,8 @@
 
 #include "chrome/browser/ui/views/ime_driver/simple_input_method.h"
 
-SimpleInputMethod::SimpleInputMethod() {}
+SimpleInputMethod::SimpleInputMethod(ui::mojom::TextInputClientPtr client)
+    : client_(std::move(client)) {}
 
 SimpleInputMethod::~SimpleInputMethod() {}
 
@@ -14,8 +15,15 @@ void SimpleInputMethod::OnTextInputTypeChanged(
 void SimpleInputMethod::OnCaretBoundsChanged(const gfx::Rect& caret_bounds) {}
 
 void SimpleInputMethod::ProcessKeyEvent(
-    std::unique_ptr<ui::Event> key_event,
+    std::unique_ptr<ui::Event> event,
     const ProcessKeyEventCallback& callback) {
+  DCHECK(event->type() == ui::ET_KEY_PRESSED || event->type() == ui::ET_KEY_RELEASED);
+  DCHECK(event->IsKeyEvent());
+
+  ui::KeyEvent* key_event = event->AsKeyEvent();
+  if (!key_event->is_char() && key_event->type() == ui::ET_KEY_PRESSED)
+    client_->InsertChar(std::move(event));
+
   callback.Run(false);
 }
 

--- a/chrome/browser/ui/views/ime_driver/simple_input_method.h
+++ b/chrome/browser/ui/views/ime_driver/simple_input_method.h
@@ -13,7 +13,7 @@
 // locally.
 class SimpleInputMethod : public ui::mojom::InputMethod {
  public:
-  SimpleInputMethod();
+  explicit SimpleInputMethod(ui::mojom::TextInputClientPtr client);
   ~SimpleInputMethod() override;
 
   // ui::mojom::InputMethod:
@@ -24,6 +24,8 @@ class SimpleInputMethod : public ui::mojom::InputMethod {
   void CancelComposition() override;
 
  private:
+  ui::mojom::TextInputClientPtr client_;
+
   DISALLOW_COPY_AND_ASSIGN(SimpleInputMethod);
 };
 

--- a/content/renderer/mus/renderer_window_tree_client.cc
+++ b/content/renderer/mus/renderer_window_tree_client.cc
@@ -148,6 +148,10 @@ void RendererWindowTreeClient::OnWindowBoundsChanged(
     const base::Optional<cc::LocalSurfaceId>& local_surface_id) {
 }
 
+void RendererWindowTreeClient::OnNewBoundsFromHostServer(
+    ui::Id window_id,
+    const gfx::Rect& new_bounds) {}
+
 void RendererWindowTreeClient::OnClientAreaChanged(
     uint32_t window_id,
     const gfx::Insets& new_client_area,

--- a/content/renderer/mus/renderer_window_tree_client.cc
+++ b/content/renderer/mus/renderer_window_tree_client.cc
@@ -260,6 +260,10 @@ void RendererWindowTreeClient::OnDragDropDone() {}
 void RendererWindowTreeClient::OnChangeCompleted(uint32_t change_id,
                                                  bool success) {}
 
+void RendererWindowTreeClient::OnWindowStateChanged(
+    uint32_t window_id,
+    ui::mojom::ShowState state) {}
+
 void RendererWindowTreeClient::RequestClose(uint32_t window_id) {}
 
 void RendererWindowTreeClient::GetWindowManager(

--- a/content/renderer/mus/renderer_window_tree_client.h
+++ b/content/renderer/mus/renderer_window_tree_client.h
@@ -153,6 +153,8 @@ class RendererWindowTreeClient : public ui::mojom::WindowTreeClient {
                                   uint32_t action_taken) override;
   void OnDragDropDone() override;
   void OnChangeCompleted(uint32_t change_id, bool success) override;
+  void OnWindowStateChanged(uint32_t window_id,
+                            ui::mojom::ShowState state) override;
   void RequestClose(uint32_t window_id) override;
   void GetWindowManager(
       mojo::AssociatedInterfaceRequest<ui::mojom::WindowManager> internal)

--- a/content/renderer/mus/renderer_window_tree_client.h
+++ b/content/renderer/mus/renderer_window_tree_client.h
@@ -89,6 +89,8 @@ class RendererWindowTreeClient : public ui::mojom::WindowTreeClient {
       const gfx::Rect& old_bounds,
       const gfx::Rect& new_bounds,
       const base::Optional<cc::LocalSurfaceId>& local_frame_id) override;
+  void OnNewBoundsFromHostServer(ui::Id window_id,
+                                 const gfx::Rect& new_bounds) override;
   void OnClientAreaChanged(
       uint32_t window_id,
       const gfx::Insets& new_client_area,

--- a/services/ui/demo/manifest.json
+++ b/services/ui/demo/manifest.json
@@ -4,7 +4,7 @@
   "interface_provider_specs": {
     "service_manager:connector": {
       "requires": {
-        "ui": [ "window_manager", "window_tree_host_factory" ]
+        "ui": [ "window_manager", "window_tree_host_factory_registrar" ]
       }
     }
   }

--- a/services/ui/demo/mus_demo.cc
+++ b/services/ui/demo/mus_demo.cc
@@ -39,32 +39,26 @@ void MusDemo::AddPrimaryDisplay(const display::Display& display) {
                                      display::DisplayList::Type::PRIMARY);
 }
 
-bool MusDemo::HasPendingWindowTreeData() const {
-  return !window_tree_data_list_.empty() &&
-         !window_tree_data_list_.back()->IsInitialized();
-}
-
 void MusDemo::AppendWindowTreeData(
     std::unique_ptr<WindowTreeData> window_tree_data) {
-  DCHECK(!HasPendingWindowTreeData());
   window_tree_data_list_.push_back(std::move(window_tree_data));
-}
-
-void MusDemo::InitWindowTreeData(
-    std::unique_ptr<aura::WindowTreeHostMus> window_tree_host) {
-  DCHECK(HasPendingWindowTreeData());
-  window_tree_data_list_.back()->Init(std::move(window_tree_host));
 }
 
 void MusDemo::RemoveWindowTreeData(aura::WindowTreeHostMus* window_tree_host) {
   DCHECK(window_tree_host);
+  auto window_tree_data = FindWindowTreeData(window_tree_host);
+  window_tree_data_list_.erase(window_tree_data);
+}
+
+std::vector<std::unique_ptr<WindowTreeData>>::iterator
+MusDemo::FindWindowTreeData(aura::WindowTreeHostMus* window_tree_host) {
   auto it =
       std::find_if(window_tree_data_list_.begin(), window_tree_data_list_.end(),
                    [window_tree_host](std::unique_ptr<WindowTreeData>& data) {
                      return data->WindowTreeHost() == window_tree_host;
                    });
   DCHECK(it != window_tree_data_list_.end());
-  window_tree_data_list_.erase(it);
+  return it;
 }
 
 void MusDemo::OnStart() {

--- a/services/ui/demo/mus_demo.h
+++ b/services/ui/demo/mus_demo.h
@@ -46,17 +46,20 @@ class MusDemo : public service_manager::Service,
   void AddPrimaryDisplay(const display::Display& display);
 
   // These functions help to manage the list of WindowTreeData structures.
-  // AppendWindowTreeData is used to add an uninitialized structure at the end
-  // of the list. When a new WindowTreeHostMus is created and is sent to
-  // MusDemo (via OnWmNewDisplay or OnEmbed), the WindowTreeData is initialized
-  // by a call to InitWindowTreeData and the demo starts. When the destruction
-  // of the WindowTreeHostMus is announced to MusDemo (via OnWmDisplayRemoved
-  // or OnEmbedRootDestroyed), the corresponding WindowTreeData is removed by
-  // a call to RemoveWindowTreeData.
+  // AppendWindowTreeData is used to add (uninitialized in case of external
+  // windows) WindowTreeData structures at the end of the list. When a new
+  // WindowTreeHostMus is created and is sent to MusDemo via OnWmNewDisplay, the
+  // WindowTreeData is initialized by a call to WindowTreeData::Init and the
+  // demo starts. In case if OnEmbedRootReady is called, corresponding
+  // WindowTreeData is found by looking associated WindowTreeHostMus with it and
+  // then WindowTreeData::Init is called. When the destruction of the
+  // WindowTreeHostMus is announced to MusDemo (via OnWmDisplayRemoved or
+  // OnEmbedRootDestroyed), the corresponding WindowTreeData is removed by a
+  // call to RemoveWindowTreeData.
   void AppendWindowTreeData(std::unique_ptr<WindowTreeData> window_tree_data);
-  void InitWindowTreeData(
-      std::unique_ptr<aura::WindowTreeHostMus> window_tree_host);
   void RemoveWindowTreeData(aura::WindowTreeHostMus* window_tree_host);
+  std::vector<std::unique_ptr<WindowTreeData>>::iterator FindWindowTreeData(
+      aura::WindowTreeHostMus* window_tree_host);
 
   aura::WindowTreeClient* window_tree_client() {
     return window_tree_client_.get();
@@ -65,7 +68,6 @@ class MusDemo : public service_manager::Service,
  private:
   virtual void OnStartImpl() = 0;
   virtual std::unique_ptr<aura::WindowTreeClient> CreateWindowTreeClient() = 0;
-  bool HasPendingWindowTreeData() const;
 
   // service_manager::Service:
   void OnStart() override;

--- a/services/ui/demo/mus_demo_external.cc
+++ b/services/ui/demo/mus_demo_external.cc
@@ -22,18 +22,12 @@ namespace {
 class WindowTreeDataExternal : public WindowTreeData {
  public:
   // Creates a new window tree host associated to the WindowTreeData.
-  WindowTreeDataExternal(mojom::WindowTreeHostFactory* factory,
-                         mojom::WindowTreeClientPtr tree_client,
+  WindowTreeDataExternal(aura::WindowTreeClient* window_tree_client,
                          int square_size)
       : WindowTreeData(square_size) {
-    // TODO(tonikitoo,fwang): Extend the API to allow creating WindowTreeHost
-    // using the WindowTreeClient.
-    factory->CreateWindowTreeHost(MakeRequest(&host_), std::move(tree_client));
+    SetWindowTreeHost(
+        base::MakeUnique<aura::WindowTreeHostMus>(window_tree_client));
   }
-
- private:
-  // Holds the Mojo pointer to the window tree host.
-  mojom::WindowTreeHostPtr host_;
 
   DISALLOW_COPY_AND_ASSIGN(WindowTreeDataExternal);
 };
@@ -50,9 +44,7 @@ MusDemoExternal::~MusDemoExternal() {}
 
 std::unique_ptr<aura::WindowTreeClient>
 MusDemoExternal::CreateWindowTreeClient() {
-  return base::MakeUnique<aura::WindowTreeClient>(
-      context()->connector(), this, nullptr,
-      MakeRequest(&window_tree_client_mojo_));
+  return base::MakeUnique<aura::WindowTreeClient>(context()->connector(), this);
 }
 
 void MusDemoExternal::OnStartImpl() {
@@ -67,38 +59,31 @@ void MusDemoExternal::OnStartImpl() {
     }
   }
 
-  // TODO(tonikitoo,fwang): Extend the WindowTreeClient API to allow connection
-  // to the window tree host factory using window_tree_client().
-  context()->connector()->BindInterface(ui::mojom::kServiceName,
-                                        &window_tree_host_factory_);
+  window_tree_client()->ConnectViaWindowTreeHostFactory();
 
   // TODO(tonikitoo,fwang): Implement management of displays in external mode.
   // For now, a fake display is created in order to work around an assertion in
   // aura::GetDeviceScaleFactorFromDisplay().
   AddPrimaryDisplay(display::Display(0));
 
-  // The number of windows to open is specified by number_of_windows_. The
-  // windows are opened sequentially (the first one here and the others after
-  // each call to OnEmbed) to ensure that the WindowTreeHostMus passed to
-  // OnEmbed corresponds to the WindowTreeDataExternal::host_ created in
-  // OpenNewWindow.
+  // TODO(tonikitoo,fwang): New windows can be launched without need to wait
+  // the respective ::OnEmbed call of the previous instance.
   OpenNewWindow();
 }
 
 void MusDemoExternal::OpenNewWindow() {
-  // TODO(tonikitoo,fwang): Extend the WindowTreeClient API to allow creation
-  // of window tree host. Then pass window_tree_client() here and remove
-  // window_tree_host_factory_ and window_tree_client_mojo_. Currently
-  // window_tree_client_mojo_ is only initialized once so this is incorrect when
-  // kNumberOfWindows > 1.
   AppendWindowTreeData(base::MakeUnique<WindowTreeDataExternal>(
-      window_tree_host_factory_.get(), std::move(window_tree_client_mojo_),
+      window_tree_client(),
       GetSquareSizeForWindow(initialized_windows_count_)));
 }
 
 void MusDemoExternal::OnEmbed(
     std::unique_ptr<aura::WindowTreeHostMus> window_tree_host) {
-  InitWindowTreeData(std::move(window_tree_host));
+  DCHECK(!window_tree_host);
+
+  // TODO: Clean up WindowTreeClientDelegate::OnEmbed API so that it passes
+  // no ownership of WindowTreeHostMus instance.
+  InitWindowTreeData(nullptr);
   initialized_windows_count_++;
 
   // Open the next window until the requested number of windows is reached.

--- a/services/ui/demo/mus_demo_external.cc
+++ b/services/ui/demo/mus_demo_external.cc
@@ -10,8 +10,10 @@
 #include "services/ui/demo/window_tree_data.h"
 #include "services/ui/public/interfaces/constants.mojom.h"
 #include "services/ui/public/interfaces/window_tree_host.mojom.h"
+#include "ui/aura/mus/window_port_mus.h"
 #include "ui/aura/mus/window_tree_client.h"
 #include "ui/aura/mus/window_tree_host_mus.h"
+#include "ui/aura/mus/window_tree_host_mus_init_params.h"
 #include "ui/display/display.h"
 
 namespace ui {
@@ -25,8 +27,15 @@ class WindowTreeDataExternal : public WindowTreeData {
   WindowTreeDataExternal(aura::WindowTreeClient* window_tree_client,
                          int square_size)
       : WindowTreeData(square_size) {
+    aura::WindowTreeHostMusInitParams init_params;
+    init_params.window_tree_client = window_tree_client;
+    init_params.frame_sink_id = cc::FrameSinkId();
+    std::unique_ptr<aura::WindowPortMus> mus =
+        static_cast<aura::WindowTreeHostMusDelegate*>(window_tree_client)
+            ->CreateWindowPortForTopLevel(nullptr);
+    init_params.window_port = std::move(mus);
     SetWindowTreeHost(
-        base::MakeUnique<aura::WindowTreeHostMus>(window_tree_client));
+        base::MakeUnique<aura::WindowTreeHostMus>(std::move(init_params)));
   }
 
   DISALLOW_COPY_AND_ASSIGN(WindowTreeDataExternal);

--- a/services/ui/demo/mus_demo_external.cc
+++ b/services/ui/demo/mus_demo_external.cc
@@ -66,29 +66,20 @@ void MusDemoExternal::OnStartImpl() {
   // aura::GetDeviceScaleFactorFromDisplay().
   AddPrimaryDisplay(display::Display(0));
 
-  // TODO(tonikitoo,fwang): New windows can be launched without need to wait
-  // the respective ::OnEmbed call of the previous instance.
-  OpenNewWindow();
+  for (size_t i = 0; i < number_of_windows_; ++i)
+    OpenNewWindow(i);
 }
 
-void MusDemoExternal::OpenNewWindow() {
+void MusDemoExternal::OpenNewWindow(size_t window_index) {
   AppendWindowTreeData(base::MakeUnique<WindowTreeDataExternal>(
-      window_tree_client(),
-      GetSquareSizeForWindow(initialized_windows_count_)));
+      window_tree_client(), GetSquareSizeForWindow(window_index)));
 }
 
-void MusDemoExternal::OnEmbed(
-    std::unique_ptr<aura::WindowTreeHostMus> window_tree_host) {
-  DCHECK(!window_tree_host);
-
-  // TODO: Clean up WindowTreeClientDelegate::OnEmbed API so that it passes
-  // no ownership of WindowTreeHostMus instance.
-  InitWindowTreeData(nullptr);
-  initialized_windows_count_++;
-
-  // Open the next window until the requested number of windows is reached.
-  if (initialized_windows_count_ < number_of_windows_)
-    OpenNewWindow();
+void MusDemoExternal::OnEmbedRootReady(
+    aura::WindowTreeHostMus* window_tree_host) {
+  DCHECK(window_tree_host);
+  auto window_tree_data = FindWindowTreeData(window_tree_host);
+  (*window_tree_data)->Init();
 }
 
 void MusDemoExternal::OnEmbedRootDestroyed(

--- a/services/ui/demo/mus_demo_external.h
+++ b/services/ui/demo/mus_demo_external.h
@@ -21,17 +21,15 @@ class MusDemoExternal : public MusDemo {
   ~MusDemoExternal() final;
 
  private:
-  void OpenNewWindow();
+  void OpenNewWindow(size_t window_index);
 
   // ui::demo::MusDemo:
   void OnStartImpl() final;
   std::unique_ptr<aura::WindowTreeClient> CreateWindowTreeClient() final;
 
   // aura::WindowTreeClientDelegate:
-  void OnEmbed(std::unique_ptr<aura::WindowTreeHostMus> window_tree_host) final;
+  void OnEmbedRootReady(aura::WindowTreeHostMus* window_tree_host) final;
   void OnEmbedRootDestroyed(aura::WindowTreeHostMus* window_tree_host) final;
-
-  size_t initialized_windows_count_ = 0;
 
   size_t number_of_windows_ = 1;
 

--- a/services/ui/demo/mus_demo_external.h
+++ b/services/ui/demo/mus_demo_external.h
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "services/ui/demo/mus_demo.h"
-#include "services/ui/public/interfaces/window_tree_host.mojom.h"
 
 namespace ui {
 namespace demo {
@@ -32,8 +31,6 @@ class MusDemoExternal : public MusDemo {
   void OnEmbed(std::unique_ptr<aura::WindowTreeHostMus> window_tree_host) final;
   void OnEmbedRootDestroyed(aura::WindowTreeHostMus* window_tree_host) final;
 
-  mojom::WindowTreeHostFactoryPtr window_tree_host_factory_;
-  mojom::WindowTreeClientPtr window_tree_client_mojo_;
   size_t initialized_windows_count_ = 0;
 
   size_t number_of_windows_ = 1;

--- a/services/ui/demo/mus_demo_internal.cc
+++ b/services/ui/demo/mus_demo_internal.cc
@@ -14,6 +14,22 @@ namespace demo {
 
 namespace {
 
+class WindowTreeDataInternal : public WindowTreeData {
+ public:
+  // Creates a new window tree host associated to the WindowTreeData.
+  WindowTreeDataInternal(
+      std::unique_ptr<aura::WindowTreeHostMus> window_tree_host,
+      int square_size)
+      : WindowTreeData(square_size) {
+    DCHECK(window_tree_host);
+    window_tree_host->InitHost();
+    window_tree_host->Show();
+    SetWindowTreeHost(std::move(window_tree_host));
+  }
+
+  DISALLOW_COPY_AND_ASSIGN(WindowTreeDataInternal);
+};
+
 // Size of square in pixels to draw.
 const int kSquareSize = 300;
 }
@@ -80,8 +96,11 @@ void MusDemoInternal::OnWmWillCreateDisplay(const display::Display& display) {
 void MusDemoInternal::OnWmNewDisplay(
     std::unique_ptr<aura::WindowTreeHostMus> window_tree_host,
     const display::Display& display) {
-  AppendWindowTreeData(base::MakeUnique<WindowTreeData>(kSquareSize));
-  InitWindowTreeData(std::move(window_tree_host));
+  std::unique_ptr<WindowTreeDataInternal> window_tree_data =
+      base::MakeUnique<WindowTreeDataInternal>(std::move(window_tree_host),
+                                               kSquareSize);
+  window_tree_data->Init();
+  AppendWindowTreeData(std::move(window_tree_data));
 }
 
 void MusDemoInternal::OnWmDisplayRemoved(

--- a/services/ui/demo/mus_demo_unittests.cc
+++ b/services/ui/demo/mus_demo_unittests.cc
@@ -18,8 +18,10 @@ namespace {
 
 const char kTestAppName[] = "mus_demo_unittests";
 
-void RunCallback(bool* success, const base::Closure& callback, bool result) {
-  *success = result;
+void RunCallback(uint64_t* root_window_count,
+                 const base::Closure& callback,
+                 uint64_t result) {
+  *root_window_count = result;
   callback.Run();
 }
 
@@ -33,6 +35,26 @@ class MusDemoTest : public service_manager::test::ServiceTest {
     ServiceTest::SetUp();
   }
 
+ protected:
+  uint64_t StartDemoAndCountDrawnWindows() {
+    connector()->StartService("mus_demo");
+
+    ::ui::mojom::WindowServerTestPtr test_interface;
+    connector()->BindInterface(ui::mojom::kServiceName, &test_interface);
+
+    base::RunLoop run_loop;
+    uint64_t root_window_count = 0;
+    // TODO(kylechar): Fix WindowServer::CreateTreeForWindowManager so that the
+    // WindowTree has the correct name instead of an empty name.
+    // TODO(tonikitoo,fwang): Also fix the WindowTree name for MusDemoExternal.
+    test_interface->EnsureClientHasDrawnRootWindows(
+        "",  // WindowTree name is empty.
+        base::Bind(&RunCallback, &root_window_count, run_loop.QuitClosure()));
+    run_loop.Run();
+
+    return root_window_count;
+  }
+
  private:
   DISALLOW_COPY_AND_ASSIGN(MusDemoTest);
 };
@@ -40,21 +62,17 @@ class MusDemoTest : public service_manager::test::ServiceTest {
 }  // namespace
 
 TEST_F(MusDemoTest, CheckMusDemoDraws) {
-  connector()->StartService("mus_demo");
-
-  ::ui::mojom::WindowServerTestPtr test_interface;
-  connector()->BindInterface(ui::mojom::kServiceName, &test_interface);
-
-  base::RunLoop run_loop;
-  bool success = false;
-  // TODO(kylechar): Fix WindowServer::CreateTreeForWindowManager so that the
-  // WindowTree has the correct name instead of an empty name.
-  test_interface->EnsureClientHasDrawnWindow(
-      "",  // WindowTree name is empty.
-      base::Bind(&RunCallback, &success, run_loop.QuitClosure()));
-  run_loop.Run();
-  EXPECT_TRUE(success);
+  EXPECT_EQ(1u, StartDemoAndCountDrawnWindows());
 }
+
+#if defined(USE_OZONE) && !defined(OS_CHROMEOS)
+TEST_F(MusDemoTest, CheckMusDemoMultipleWindows) {
+  uint64_t expected_root_window_count = 5;
+  base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
+      "external-window-count", std::to_string(expected_root_window_count));
+  EXPECT_EQ(expected_root_window_count, StartDemoAndCountDrawnWindows());
+}
+#endif  // defined(USE_OZONE) && !defined(OS_CHROMEOS)
 
 }  // namespace demo
 }  // namespace ui

--- a/services/ui/demo/window_tree_data.cc
+++ b/services/ui/demo/window_tree_data.cc
@@ -68,10 +68,11 @@ aura::Window* WindowTreeData::bitmap_window() {
 
 void WindowTreeData::Init(
     std::unique_ptr<aura::WindowTreeHostMus> window_tree_host) {
-  window_tree_host->InitHost();
-  window_tree_host->Show();
-  // Take ownership of the WTH.
-  window_tree_host_ = std::move(window_tree_host);
+  if (window_tree_host) {
+    window_tree_host->InitHost();
+    window_tree_host->Show();
+    SetWindowTreeHost(std::move(window_tree_host));
+  }
 
   // Initialize the window for the bitmap.
   window_delegate_ = new aura_extra::ImageWindowDelegate();

--- a/services/ui/demo/window_tree_data.cc
+++ b/services/ui/demo/window_tree_data.cc
@@ -66,13 +66,9 @@ aura::Window* WindowTreeData::bitmap_window() {
   return window_tree_host_->window()->children()[0];
 }
 
-void WindowTreeData::Init(
-    std::unique_ptr<aura::WindowTreeHostMus> window_tree_host) {
-  if (window_tree_host) {
-    window_tree_host->InitHost();
-    window_tree_host->Show();
-    SetWindowTreeHost(std::move(window_tree_host));
-  }
+void WindowTreeData::Init() {
+  DCHECK(window_tree_host_);
+  DCHECK(!IsInitialized());
 
   // Initialize the window for the bitmap.
   window_delegate_ = new aura_extra::ImageWindowDelegate();

--- a/services/ui/demo/window_tree_data.h
+++ b/services/ui/demo/window_tree_data.h
@@ -27,10 +27,16 @@ class WindowTreeData {
 
   // Initializes the window tree host and start drawing frames.
   void Init(std::unique_ptr<aura::WindowTreeHostMus> window_tree_host);
-  bool IsInitialized() const { return !!window_tree_host_; }
+  bool IsInitialized() const { return window_delegate_; }
 
   const aura::WindowTreeHostMus* WindowTreeHost() const {
     return window_tree_host_.get();
+  }
+
+ protected:
+  void SetWindowTreeHost(
+      std::unique_ptr<aura::WindowTreeHostMus> window_tree_host) {
+    window_tree_host_ = std::move(window_tree_host);
   }
 
  private:

--- a/services/ui/demo/window_tree_data.h
+++ b/services/ui/demo/window_tree_data.h
@@ -25,9 +25,8 @@ class WindowTreeData {
   explicit WindowTreeData(int square_size);
   ~WindowTreeData();
 
-  // Initializes the window tree host and start drawing frames.
-  void Init(std::unique_ptr<aura::WindowTreeHostMus> window_tree_host);
-  bool IsInitialized() const { return window_delegate_; }
+  // Initializes a window for bitmap and starts drawing frames.
+  void Init();
 
   const aura::WindowTreeHostMus* WindowTreeHost() const {
     return window_tree_host_.get();
@@ -40,6 +39,8 @@ class WindowTreeData {
   }
 
  private:
+  bool IsInitialized() const { return window_delegate_; }
+
   // Draws one frame, incrementing the rotation angle.
   void DrawFrame();
 

--- a/services/ui/display/BUILD.gn
+++ b/services/ui/display/BUILD.gn
@@ -17,6 +17,7 @@ source_set("display") {
   deps = [
     "//base",
     "//services/service_manager/public/cpp",
+    "//services/ui/public/interfaces",
     "//ui/display",
     "//ui/gfx",
   ]

--- a/services/ui/display/screen_manager_delegate.h
+++ b/services/ui/display/screen_manager_delegate.h
@@ -7,6 +7,8 @@
 
 #include <stdint.h>
 
+#include "services/ui/ws/user_id.h"
+
 namespace display {
 
 class Display;
@@ -29,6 +31,10 @@ class ScreenManagerDelegate {
 
   // Called when the primary display is changed.
   virtual void OnPrimaryDisplayChanged(int64_t primary_display_id) = 0;
+
+  // In external window mode, query the host system about data (resolution)
+  // of the displays available.
+  virtual void OnHostDisplaysReady(const ui::ws::UserId& user_id) = 0;
 
  protected:
   virtual ~ScreenManagerDelegate() {}

--- a/services/ui/display/screen_manager_ozone_external.cc
+++ b/services/ui/display/screen_manager_ozone_external.cc
@@ -7,8 +7,10 @@
 #include <memory>
 
 #include "services/service_manager/public/cpp/binder_registry.h"
-#include "ui/display/screen_base.h"
+#include "services/service_manager/public/interfaces/connector.mojom.h"
 #include "ui/display/types/display_constants.h"
+#include "ui/gfx/geometry/dip_util.h"
+#include "ui/ozone/public/ozone_platform.h"
 
 namespace display {
 
@@ -18,19 +20,51 @@ std::unique_ptr<ScreenManager> ScreenManager::Create() {
 }
 
 ScreenManagerOzoneExternal::ScreenManagerOzoneExternal()
-    : screen_(base::MakeUnique<display::ScreenBase>()) {}
+    : screen_owned_(base::MakeUnique<ScreenBase>()),
+      screen_(screen_owned_.get()),
+      weak_ptr_factory_(this) {
+  Screen::SetScreenInstance(screen_owned_.get());
+}
 
 ScreenManagerOzoneExternal::~ScreenManagerOzoneExternal() {}
+
+void ScreenManagerOzoneExternal::OnHostDisplaysReady(
+    const std::vector<gfx::Size>& dimensions) {
+  float device_scale_factor = 1.f;
+  if (Display::HasForceDeviceScaleFactor())
+    device_scale_factor = Display::GetForcedDeviceScaleFactor();
+
+  gfx::Size scaled_size =
+      gfx::ConvertSizeToDIP(device_scale_factor, dimensions[0]);
+
+  Display display(next_display_id_++);
+  display.set_bounds(gfx::Rect(scaled_size));
+  display.set_work_area(display.bounds());
+  display.set_device_scale_factor(device_scale_factor);
+
+  screen_->display_list().AddDisplay(display, DisplayList::Type::PRIMARY);
+
+  // TODO(tonikitoo): Before calling out to ScreenManagerDelegate check if
+  // more than one host display is available.
+  delegate_->OnHostDisplaysReady(service_manager::mojom::kRootUserID);
+}
 
 void ScreenManagerOzoneExternal::AddInterfaces(
     service_manager::BinderRegistry* registry) {}
 
-void ScreenManagerOzoneExternal::Init(ScreenManagerDelegate* delegate) {}
+void ScreenManagerOzoneExternal::Init(ScreenManagerDelegate* delegate) {
+  delegate_ = delegate;
+
+  ui::OzonePlatform::GetInstance()->QueryHostDisplaysData(
+      base::Bind(&ScreenManagerOzoneExternal::OnHostDisplaysReady,
+                 weak_ptr_factory_.GetWeakPtr()));
+}
 
 void ScreenManagerOzoneExternal::RequestCloseDisplay(int64_t display_id) {}
 
 display::ScreenBase* ScreenManagerOzoneExternal::GetScreen() {
-  return screen_.get();
+  // TODO: commit into  Allow ws to pass display::Display data to Aura/client
+  return screen_;
 }
 
 }  // namespace display

--- a/services/ui/display/screen_manager_ozone_external.h
+++ b/services/ui/display/screen_manager_ozone_external.h
@@ -7,6 +7,9 @@
 
 #include "services/ui/display/screen_manager.h"
 
+#include "base/memory/weak_ptr.h"
+#include "ui/display/screen_base.h"
+
 namespace display {
 
 // In external window mode, the purpose of having a ScreenManager
@@ -22,13 +25,28 @@ class ScreenManagerOzoneExternal : public ScreenManager {
   ~ScreenManagerOzoneExternal() override;
 
  private:
+  // Callback to be called from the Ozone platform when
+  // host displays' data are ready.
+  void OnHostDisplaysReady(const std::vector<gfx::Size>&);
+
   // ScreenManager.
   void AddInterfaces(service_manager::BinderRegistry* registry) override;
   void Init(ScreenManagerDelegate* delegate) override;
   void RequestCloseDisplay(int64_t display_id) override;
   display::ScreenBase* GetScreen() override;
 
-  std::unique_ptr<display::ScreenBase> screen_;
+  // A Screen instance is created in the constructor because it might be
+  // accessed early. The ownership of this object will be transfered to
+  // |display_manager_| when that gets initialized.
+  std::unique_ptr<ScreenBase> screen_owned_;
+
+  // Used to add/remove/modify displays.
+  ScreenBase* screen_;
+
+  ScreenManagerDelegate* delegate_ = nullptr;
+  int next_display_id_ = 0;
+
+  base::WeakPtrFactory<ScreenManagerOzoneExternal> weak_ptr_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(ScreenManagerOzoneExternal);
 };

--- a/services/ui/display/viewport_metrics.h
+++ b/services/ui/display/viewport_metrics.h
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "services/ui/public/interfaces/window_manager_constants.mojom.h"
 #include "ui/gfx/geometry/rect.h"
 
 namespace display {
@@ -17,6 +18,11 @@ struct ViewportMetrics {
   gfx::Rect bounds_in_pixels;
   float device_scale_factor = 0.0f;
   float ui_scale_factor = 0.0f;
+
+  // TODO(tonikitoo,msisov): This is an abuse of ViewportMetrics,
+  // and for upstreaming, we should likely consider renaming ViewportMetrics
+  // to DisplayProperties or so.
+  ui::mojom::WindowType window_type = ui::mojom::WindowType::WINDOW;
 };
 
 inline bool operator==(const ViewportMetrics& lhs, const ViewportMetrics& rhs) {

--- a/services/ui/manifest.json
+++ b/services/ui/manifest.json
@@ -60,6 +60,9 @@
         ],
         "window_tree_host_factory": [
           "ui::mojom::WindowTreeHostFactory"
+        ],
+        "window_tree_host_factory_registrar": [
+          "ui::mojom::WindowTreeHostFactoryRegistrar"
         ]
       },
       "requires": {

--- a/services/ui/public/cpp/BUILD.gn
+++ b/services/ui/public/cpp/BUILD.gn
@@ -51,6 +51,7 @@ source_set("internal") {
   visibility = [
     ":cpp",
     "//services/ui/demo:lib",
+    "//services/ui/ws:lib",
   ]
 
   sources = [
@@ -77,9 +78,7 @@ source_set("internal") {
     "//ui/gfx/geometry",
   ]
 
-  data_deps = [
-    "//services/ui",
-  ]
+  data_deps = []
 
   defines = [ "GL_GLEXT_PROTOTYPES" ]
 

--- a/services/ui/public/interfaces/window_server_test.mojom
+++ b/services/ui/public/interfaces/window_server_test.mojom
@@ -7,7 +7,7 @@ module ui.mojom;
 import "ui/events/mojo/event.mojom";
 
 interface WindowServerTest {
-  EnsureClientHasDrawnWindow(string client_name) => (bool success);
+  EnsureClientHasDrawnRootWindows(string client_name) => (uint64 root_window_count);
 
   // Takes an event and dispatches it as if it came from the native platform.
   // Returns false on bad |display_id| or |event|; returns true if it reaches

--- a/services/ui/public/interfaces/window_tree.mojom
+++ b/services/ui/public/interfaces/window_tree.mojom
@@ -140,6 +140,9 @@ interface WindowTree {
                     uint32 window_id,
                     string name,
                     array<uint8>? value);
+                    
+  // Sets native window to be hidden once client sends a request for it.
+  SetNativeWindowHidden(uint32 window_id);
 
   // Sets the opacity of the specified window to |opacity|.
   SetWindowOpacity(uint32 change_id, uint32 window_id, float opacity);

--- a/services/ui/public/interfaces/window_tree.mojom
+++ b/services/ui/public/interfaces/window_tree.mojom
@@ -525,6 +525,10 @@ interface WindowTreeClient {
   // A change initiated from the client has completed. See description of
   // change ids for details.
   OnChangeCompleted(uint32 change_id, bool success);
+  
+  // The WindowManager calls back after the client set proprties to minimize, maximize or restore
+  // the window or after the window is restored back from minimized state by clicking on a tray.
+  OnWindowStateChanged(uint32 window_id, ShowState state);
 
   // The WindowManager is requesting the specified window to close. If the
   // client allows the change it should delete the window.

--- a/services/ui/public/interfaces/window_tree.mojom
+++ b/services/ui/public/interfaces/window_tree.mojom
@@ -373,6 +373,10 @@ interface WindowTreeClient {
                         gfx.mojom.Rect old_bounds,
                         gfx.mojom.Rect new_bounds,
                         cc.mojom.LocalSurfaceId? local_surface_id);
+                        
+  // Invoked when a host server calls back with changed bounds of a native
+  // window.
+  OnNewBoundsFromHostServer(uint32 window, gfx.mojom.Rect new_bounds);            
 
   OnClientAreaChanged(uint32 window_id,
                       gfx.mojom.Insets new_client_area,

--- a/services/ui/public/interfaces/window_tree_host.mojom
+++ b/services/ui/public/interfaces/window_tree_host.mojom
@@ -38,5 +38,8 @@ interface WindowTreeHostFactory {
   // Creates a new WindowTreeHost in 'external window mode'.
   // One WindowTree/WindowTreeClient pair can serve one or more WindowTreeHost
   // instances.
-  CreatePlatformWindow(WindowTreeHost& window_tree_host, uint32 client_id);
+  CreatePlatformWindow(WindowTreeHost& window_tree_host,
+                       uint32 client_id,
+                       map<string, array<uint8>> properties);
+
 };

--- a/services/ui/public/interfaces/window_tree_host.mojom
+++ b/services/ui/public/interfaces/window_tree_host.mojom
@@ -17,9 +17,26 @@ interface WindowTreeHost {
   SetTitle(string title);
 };
 
+// WindowTreeHostFactoryRegistrar is the entry point to obtain a
+// WindowTreeHostFactory instance in 'external window mode'.
+// Callers also obtain a mojo handle to the unique ws::WindowTree instance,
+// on the server-side.
+//
+// NOTE: WindowTreeHostFactoryRegistrar::Register and
+// WindowTreeHostFactory::CreatePlatformWindow are put on separate interfaces,
+// so that the interface containing ::CreatePlatformWindow is obtained by
+// calling ::Register. That eliminates the possibility of ::CreatePlatformWindow
+// being called before ::Register.
+interface WindowTreeHostFactoryRegistrar {
+   Register(WindowTreeHostFactory& window_tree_host_factory,
+            WindowTree& tree_request,
+            WindowTreeClient client);
+};
+
+// WindowTreeHostFactory triggers the creation of WindowTreeHost instances.
 interface WindowTreeHostFactory {
-  // Creates a new WindowTreeHost. |tree_client| is queried for the
-  // WindowManager.
-  CreateWindowTreeHost(WindowTreeHost& window_tree_host,
-                       WindowTreeClient tree_client);
+  // Creates a new WindowTreeHost in 'external window mode'.
+  // One WindowTree/WindowTreeClient pair can serve one or more WindowTreeHost
+  // instances.
+  CreatePlatformWindow(WindowTreeHost& window_tree_host, uint32 client_id);
 };

--- a/services/ui/service.cc
+++ b/services/ui/service.cc
@@ -38,7 +38,7 @@
 #include "services/ui/ws/window_tree.h"
 #include "services/ui/ws/window_tree_binding.h"
 #include "services/ui/ws/window_tree_factory.h"
-#include "services/ui/ws/window_tree_host_factory.h"
+#include "services/ui/ws/window_tree_host_factory_registrar.h"
 #include "ui/base/platform_window_defaults.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "ui/base/ui_base_paths.h"
@@ -60,7 +60,6 @@
 
 using mojo::InterfaceRequest;
 using ui::mojom::WindowServerTest;
-using ui::mojom::WindowTreeHostFactory;
 
 namespace ui {
 
@@ -82,7 +81,6 @@ struct Service::PendingRequest {
 struct Service::UserState {
   std::unique_ptr<clipboard::ClipboardImpl> clipboard;
   std::unique_ptr<ws::AccessibilityManager> accessibility;
-  std::unique_ptr<ws::WindowTreeHostFactory> window_tree_host_factory;
 };
 
 Service::Service()
@@ -213,8 +211,8 @@ void Service::OnStart() {
       &Service::BindUserAccessManagerRequest, base::Unretained(this)));
   registry_.AddInterface<mojom::UserActivityMonitor>(base::Bind(
       &Service::BindUserActivityMonitorRequest, base::Unretained(this)));
-  registry_.AddInterface<WindowTreeHostFactory>(base::Bind(
-      &Service::BindWindowTreeHostFactoryRequest, base::Unretained(this)));
+  registry_.AddInterface<WindowTreeHostFactoryRegistrar>(base::Bind(
+      &Service::BindWindowTreeHostFactoryRegistrarRequest, base::Unretained(this)));
   registry_.AddInterface<mojom::WindowManagerWindowTreeFactory>(
       base::Bind(&Service::BindWindowManagerWindowTreeFactoryRequest,
                  base::Unretained(this)));
@@ -400,15 +398,14 @@ void Service::BindWindowTreeFactoryRequest(
       std::move(request));
 }
 
-void Service::BindWindowTreeHostFactoryRequest(
+void Service::BindWindowTreeHostFactoryRegistrarRequest(
     const service_manager::BindSourceInfo& source_info,
-    mojom::WindowTreeHostFactoryRequest request) {
-  UserState* user_state = GetUserState(source_info.identity);
-  if (!user_state->window_tree_host_factory) {
-    user_state->window_tree_host_factory.reset(new ws::WindowTreeHostFactory(
-        window_server_.get(), source_info.identity.user_id()));
-  }
-  user_state->window_tree_host_factory->AddBinding(std::move(request));
+    mojom::WindowTreeHostFactoryRegistrarRequest request) {
+  AddUserIfNecessary(source_info.identity);
+  mojo::MakeStrongBinding(base::MakeUnique<ws::WindowTreeHostFactoryRegistrar>(
+                              window_server_.get(), source_info.identity.user_id()),
+                          std::move(request));
+  window_server_->SetInExternalWindowMode();
 }
 
 void Service::BindDiscardableSharedMemoryManagerRequest(

--- a/services/ui/service.cc
+++ b/services/ui/service.cc
@@ -325,7 +325,9 @@ void Service::BindClipboardRequest(
 void Service::BindDisplayManagerRequest(
     const service_manager::BindSourceInfo& source_info,
     mojom::DisplayManagerRequest request) {
-  // DisplayManagerObservers generally expect there to be at least one display.
+// DisplayManagerObservers generally expect there to be at least one
+// ws::display, except on LinuxOS/Ozone (external window mode).
+#if !defined(USE_OZONE) || defined(OS_CHROMEOS)
   if (!window_server_->display_manager()->has_displays()) {
     std::unique_ptr<PendingRequest> pending_request(new PendingRequest);
     pending_request->source_info = source_info;
@@ -334,6 +336,7 @@ void Service::BindDisplayManagerRequest(
     pending_requests_.push_back(std::move(pending_request));
     return;
   }
+#endif
   window_server_->display_manager()
       ->GetUserDisplayManager(source_info.identity.user_id())
       ->AddDisplayManagerBinding(std::move(request));

--- a/services/ui/service.cc
+++ b/services/ui/service.cc
@@ -211,8 +211,9 @@ void Service::OnStart() {
       &Service::BindUserAccessManagerRequest, base::Unretained(this)));
   registry_.AddInterface<mojom::UserActivityMonitor>(base::Bind(
       &Service::BindUserActivityMonitorRequest, base::Unretained(this)));
-  registry_.AddInterface<WindowTreeHostFactoryRegistrar>(base::Bind(
-      &Service::BindWindowTreeHostFactoryRegistrarRequest, base::Unretained(this)));
+  registry_.AddInterface<mojom::WindowTreeHostFactoryRegistrar>(
+      base::Bind(&Service::BindWindowTreeHostFactoryRegistrarRequest,
+                 base::Unretained(this)));
   registry_.AddInterface<mojom::WindowManagerWindowTreeFactory>(
       base::Bind(&Service::BindWindowManagerWindowTreeFactoryRequest,
                  base::Unretained(this)));
@@ -402,9 +403,10 @@ void Service::BindWindowTreeHostFactoryRegistrarRequest(
     const service_manager::BindSourceInfo& source_info,
     mojom::WindowTreeHostFactoryRegistrarRequest request) {
   AddUserIfNecessary(source_info.identity);
-  mojo::MakeStrongBinding(base::MakeUnique<ws::WindowTreeHostFactoryRegistrar>(
-                              window_server_.get(), source_info.identity.user_id()),
-                          std::move(request));
+  mojo::MakeStrongBinding(
+      base::MakeUnique<ws::WindowTreeHostFactoryRegistrar>(
+          window_server_.get(), source_info.identity.user_id()),
+      std::move(request));
   window_server_->SetInExternalWindowMode();
 }
 

--- a/services/ui/service.h
+++ b/services/ui/service.h
@@ -148,9 +148,9 @@ class Service : public service_manager::Service,
       const service_manager::BindSourceInfo& source_info,
       mojom::WindowTreeFactoryRequest request);
 
-  void BindWindowTreeHostFactoryRequest(
+  void BindWindowTreeHostFactoryRegistrarRequest(
       const service_manager::BindSourceInfo& source_info,
-      mojom::WindowTreeHostFactoryRequest request);
+      mojom::WindowTreeHostFactoryRegistrarRequest request);
 
   void BindDiscardableSharedMemoryManagerRequest(
       const service_manager::BindSourceInfo& source_info,

--- a/services/ui/ws/BUILD.gn
+++ b/services/ui/ws/BUILD.gn
@@ -112,6 +112,8 @@ static_library("lib") {
     "window_tree_factory.h",
     "window_tree_host_factory.cc",
     "window_tree_host_factory.h",
+    "window_tree_host_factory_registrar.cc",
+    "window_tree_host_factory_registrar.h",
   ]
 
   deps = [

--- a/services/ui/ws/BUILD.gn
+++ b/services/ui/ws/BUILD.gn
@@ -138,6 +138,7 @@ static_library("lib") {
     "//services/ui/common:mus_common",
     "//services/ui/common:server_gpu",
     "//services/ui/display",
+    "//services/ui/public/cpp:internal",
     "//services/ui/public/interfaces",
     "//ui/base",
     "//ui/display",

--- a/services/ui/ws/default_access_policy.cc
+++ b/services/ui/ws/default_access_policy.cc
@@ -111,7 +111,8 @@ bool DefaultAccessPolicy::CanSetWindowCompositorFrameSink(
 }
 
 bool DefaultAccessPolicy::CanSetWindowBounds(const ServerWindow* window) const {
-  return WasCreatedByThisClient(window);
+  return WasCreatedByThisClient(window) ||
+         delegate_->HasRootForAccessPolicy(window);
 }
 
 bool DefaultAccessPolicy::CanSetWindowProperties(

--- a/services/ui/ws/default_access_policy.cc
+++ b/services/ui/ws/default_access_policy.cc
@@ -117,7 +117,9 @@ bool DefaultAccessPolicy::CanSetWindowBounds(const ServerWindow* window) const {
 
 bool DefaultAccessPolicy::CanSetWindowProperties(
     const ServerWindow* window) const {
-  return WasCreatedByThisClient(window);
+  // TODO(msisov, tonikitoo): resolve policies issues.
+  return WasCreatedByThisClient(window) ||
+         delegate_->HasRootForAccessPolicy(window);
 }
 
 bool DefaultAccessPolicy::CanSetWindowTextInputState(

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -342,6 +342,21 @@ void Display::OnBoundsChanged(const gfx::Rect& new_bounds) {
   OnBoundsChangedInternal(new_bounds);
 }
 
+void Display::OnCloseRequest() {
+  DCHECK(window_server_->IsInExternalWindowMode());
+  DCHECK(binding_);
+
+  WindowTree* window_tree = window_server_->GetTreeForExternalWindowMode();
+  WindowManagerDisplayRoot* display_root =
+      window_manager_display_root_map_.begin()->second;
+  ServerWindow* server_window =
+      display_root->window_manager_state()->GetWindowManagerRootForDisplayRoot(
+          root_window());
+  ClientWindowId window_id;
+  if (window_tree && window_tree->IsWindowKnown(server_window, &window_id))
+    window_tree->client()->RequestClose(window_id.id);
+}
+
 OzonePlatform* Display::GetOzonePlatform() {
 #if defined(USE_OZONE)
   return OzonePlatform::GetInstance();

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -58,9 +58,11 @@ Display::~Display() {
   } else if (!window_manager_display_root_map_.empty()) {
     // If there is a |binding_| then the tree was created specifically for this
     // display (which corresponds to a WindowTreeHost).
-    window_server_->DestroyTree(window_manager_display_root_map_.begin()
-                                    ->second->window_manager_state()
-                                    ->window_tree());
+    WindowManagerDisplayRoot* display_root =
+        window_manager_display_root_map_.begin()->second;
+    if (display_root->window_manager_state())
+      window_server_->DestroyTree(
+          display_root->window_manager_state()->window_tree());
   }
 }
 
@@ -208,7 +210,27 @@ void Display::SetTitle(const std::string& title) {
   platform_display_->SetTitle(base::UTF8ToUTF16(title));
 }
 
+void Display::InitDisplayRoot() {
+  DCHECK(window_server_->IsInExternalWindowMode());
+  DCHECK(binding_);
+
+  external_mode_root_ = base::MakeUnique<WindowManagerDisplayRoot>(this);
+  // TODO(tonikitoo): Code still has assumptions that even in external window
+  // mode make 'window_manager_display_root_map_' needed.
+  window_manager_display_root_map_[service_manager::mojom::kRootUserID] =
+      external_mode_root_.get();
+
+  ServerWindow* server_window = external_mode_root_->root();
+  WindowTree* window_tree = window_server_->GetTreeForExternalWindowMode();
+  window_tree->AddRoot(server_window);
+  window_tree->DoOnEmbed(nullptr /*mojom::WindowTreePtr*/, server_window);
+}
+
 void Display::InitWindowManagerDisplayRoots() {
+  // Tests can create ws::Display instances directly, by-passing
+  // WindowTreeHostFactory.
+  // TODO(tonikitoo): Check if with the introduction of 'external window mode'
+  // this path is still needed.
   if (binding_) {
     std::unique_ptr<WindowManagerDisplayRoot> display_root_ptr(
         new WindowManagerDisplayRoot(this));
@@ -278,7 +300,11 @@ EventSink* Display::GetEventSink() {
 
 void Display::OnAcceleratedWidgetAvailable() {
   display_manager()->OnDisplayAcceleratedWidgetAvailable(this);
-  InitWindowManagerDisplayRoots();
+
+  if (window_server_->IsInExternalWindowMode())
+    InitDisplayRoot();
+  else
+    InitWindowManagerDisplayRoots();
 }
 
 void Display::OnNativeCaptureLost() {
@@ -399,6 +425,12 @@ void Display::OnWindowManagerWindowTreeFactoryReady(
 }
 
 EventDispatchDetails Display::OnEventFromSource(Event* event) {
+  // TODO(tonikitoo): Current WindowManagerDisplayRoot class is misnamed, since
+  // in external window mode a non-WindowManager specific 'DisplayRoot' is also
+  // needed.
+  // Bits of WindowManagerState also should be factored out and made available
+  // in external window mode, so that event handling is functional.
+  // htts://crbug.com/701129
   WindowManagerDisplayRoot* display_root = GetActiveWindowManagerDisplayRoot();
   if (display_root) {
     WindowManagerState* wm_state = display_root->window_manager_state();

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -52,17 +52,27 @@ Display::~Display() {
     focus_controller_.reset();
   }
 
-  if (!binding_) {
-    for (auto& pair : window_manager_display_root_map_)
-      pair.second->window_manager_state()->OnDisplayDestroying(this);
-  } else if (!window_manager_display_root_map_.empty()) {
-    // If there is a |binding_| then the tree was created specifically for this
-    // display (which corresponds to a WindowTreeHost).
+  // Notify the window manager state that the display is being destroyed.
+  for (auto& pair : window_manager_display_root_map_)
+    pair.second->window_manager_state()->OnDisplayDestroying(this);
+
+  if (binding_ && !window_manager_display_root_map_.empty()) {
+    // If there is a |binding_| then the tree was created specifically for one
+    // or more displays, which correspond to WindowTreeHosts.
     WindowManagerDisplayRoot* display_root =
         window_manager_display_root_map_.begin()->second;
-    if (display_root->window_manager_state())
-      window_server_->DestroyTree(
-          display_root->window_manager_state()->window_tree());
+    WindowTree* tree = display_root->window_manager_state()->window_tree();
+    ServerWindow* root = display_root->root();
+    if (tree) {
+      // Delete the window root corresponding to that display.
+      ClientWindowId root_id;
+      if (tree->IsWindowKnown(root, &root_id))
+        tree->DeleteWindow(root_id);
+
+      // Destroy the tree once all the roots have been removed.
+      if (tree->roots().empty())
+        window_server_->DestroyTree(tree);
+    }
   }
 }
 
@@ -214,14 +224,26 @@ void Display::InitDisplayRoot() {
   DCHECK(window_server_->IsInExternalWindowMode());
   DCHECK(binding_);
 
-  external_mode_root_ = base::MakeUnique<WindowManagerDisplayRoot>(this);
+  std::unique_ptr<WindowManagerDisplayRoot> display_root_ptr(
+      new WindowManagerDisplayRoot(this));
   // TODO(tonikitoo): Code still has assumptions that even in external window
   // mode make 'window_manager_display_root_map_' needed.
   window_manager_display_root_map_[service_manager::mojom::kRootUserID] =
-      external_mode_root_.get();
+      display_root_ptr.get();
 
-  ServerWindow* server_window = external_mode_root_->root();
   WindowTree* window_tree = window_server_->GetTreeForExternalWindowMode();
+  ServerWindow* server_window = display_root_ptr->root();
+
+  std::unique_ptr<WindowManagerState> window_manager_state =
+      base::MakeUnique<WindowManagerState>(window_tree);
+  display_root_ptr->window_manager_state_ = window_manager_state.get();
+  window_tree->AddExternalModeWindowManagerState(
+      std::move(window_manager_state));
+
+  WindowManagerDisplayRoot* display_root = display_root_ptr.get();
+  display_root->window_manager_state_->AddWindowManagerDisplayRoot(
+      std::move(display_root_ptr));
+
   window_tree->AddRoot(server_window);
   window_tree->DoOnEmbed(nullptr /*mojom::WindowTreePtr*/, server_window);
 }

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -357,7 +357,10 @@ void Display::OnViewportMetricsChanged(
   if (root_->bounds().size() == metrics.bounds_in_pixels.size())
     return;
 
-  OnBoundsChangedInternal(gfx::Rect(metrics.bounds_in_pixels.size()));
+  gfx::Rect new_bounds(metrics.bounds_in_pixels.size());
+  root_->SetBounds(new_bounds, allocator_.GenerateId());
+  for (auto& pair : window_manager_display_root_map_)
+    pair.second->root()->SetBounds(new_bounds, allocator_.GenerateId());
 }
 
 ServerWindow* Display::GetActiveRootWindow() {
@@ -471,10 +474,9 @@ EventDispatchDetails Display::OnEventFromSource(Event* event) {
 }
 
 void Display::OnBoundsChangedInternal(const gfx::Rect& new_bounds) {
-  root_->SetBoundsFromHostWindowManager(new_bounds, allocator_.GenerateId());
+  root_->OnNewBoundsFromHostServer(new_bounds);
   for (auto& pair : window_manager_display_root_map_)
-    pair.second->root()->SetBoundsFromHostWindowManager(
-        new_bounds, allocator_.GenerateId());
+    pair.second->root()->OnNewBoundsFromHostServer(new_bounds);
 }
 
 }  // namespace ws

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -357,6 +357,24 @@ void Display::OnCloseRequest() {
     window_tree->client()->RequestClose(window_id.id);
 }
 
+void Display::OnWindowStateChanged(ui::mojom::ShowState new_state) {
+  if (!window_server_->IsInExternalWindowMode())
+    return;
+
+  WindowTree* window_tree = window_server_->GetTreeForExternalWindowMode();
+  WindowManagerDisplayRoot* display_root =
+      window_manager_display_root_map_.begin()->second;
+  ServerWindow* server_window =
+      display_root->window_manager_state()->GetWindowManagerRootForDisplayRoot(
+          root_window());
+  ClientWindowId window_id;
+  // We are calling WindowTreeClient directly from here for the sake not
+  // changing WindowTree for such a simple call, adding less code as possible
+  // downstream.
+  if (window_tree && window_tree->IsWindowKnown(server_window, &window_id))
+    window_tree->client()->OnWindowStateChanged(window_id.id, new_state);
+}
+
 OzonePlatform* Display::GetOzonePlatform() {
 #if defined(USE_OZONE)
   return OzonePlatform::GetInstance();

--- a/services/ui/ws/display.h
+++ b/services/ui/ws/display.h
@@ -195,6 +195,7 @@ class Display : public PlatformDisplayDelegate,
   void OnAcceleratedWidgetAvailable() override;
   void OnNativeCaptureLost() override;
   void OnBoundsChanged(const gfx::Rect& new_bounds) override;
+  void OnCloseRequest() override;
 
   OzonePlatform* GetOzonePlatform() override;
 

--- a/services/ui/ws/display.h
+++ b/services/ui/ws/display.h
@@ -196,6 +196,7 @@ class Display : public PlatformDisplayDelegate,
   void OnNativeCaptureLost() override;
   void OnBoundsChanged(const gfx::Rect& new_bounds) override;
   void OnCloseRequest() override;
+  void OnWindowStateChanged(ui::mojom::ShowState new_state) override;
 
   OzonePlatform* GetOzonePlatform() override;
 

--- a/services/ui/ws/display.h
+++ b/services/ui/ws/display.h
@@ -173,6 +173,10 @@ class Display : public PlatformDisplayDelegate,
   // Inits the necessary state once the display is ready.
   void InitWindowManagerDisplayRoots();
 
+  // Inits the display root once the display is ready in
+  // 'external window mode'.
+  void InitDisplayRoot();
+
   // Creates the set of WindowManagerDisplayRoots from the
   // WindowManagerWindowTreeFactorySet.
   void CreateWindowManagerDisplayRootsFromFactories();
@@ -226,6 +230,8 @@ class Display : public PlatformDisplayDelegate,
   cc::LocalSurfaceIdAllocator allocator_;
 
   WindowManagerDisplayRootMap window_manager_display_root_map_;
+
+  std::unique_ptr<WindowManagerDisplayRoot> external_mode_root_;
 
   DISALLOW_COPY_AND_ASSIGN(Display);
 };

--- a/services/ui/ws/display.h
+++ b/services/ui/ws/display.h
@@ -41,6 +41,7 @@ class DisplayBinding;
 class DisplayManager;
 class FocusController;
 class WindowManagerDisplayRoot;
+class WindowManagerState;
 class WindowServer;
 class WindowTree;
 
@@ -230,8 +231,6 @@ class Display : public PlatformDisplayDelegate,
   cc::LocalSurfaceIdAllocator allocator_;
 
   WindowManagerDisplayRootMap window_manager_display_root_map_;
-
-  std::unique_ptr<WindowManagerDisplayRoot> external_mode_root_;
 
   DISALLOW_COPY_AND_ASSIGN(Display);
 };

--- a/services/ui/ws/display.h
+++ b/services/ui/ws/display.h
@@ -194,6 +194,8 @@ class Display : public PlatformDisplayDelegate,
   EventSink* GetEventSink() override;
   void OnAcceleratedWidgetAvailable() override;
   void OnNativeCaptureLost() override;
+  void OnBoundsChanged(const gfx::Rect& new_bounds) override;
+
   OzonePlatform* GetOzonePlatform() override;
 
   // FocusControllerDelegate:
@@ -215,6 +217,8 @@ class Display : public PlatformDisplayDelegate,
 
   // EventSink:
   EventDispatchDetails OnEventFromSource(Event* event) override;
+
+  void OnBoundsChangedInternal(const gfx::Rect& new_bounds);
 
   std::unique_ptr<DisplayBinding> binding_;
   WindowServer* const window_server_;

--- a/services/ui/ws/display_manager.cc
+++ b/services/ui/ws/display_manager.cc
@@ -260,5 +260,12 @@ void DisplayManager::OnPrimaryDisplayChanged(int64_t primary_display_id) {
     pair.second->OnPrimaryDisplayChanged(primary_display_id);
 }
 
+void DisplayManager::OnHostDisplaysReady(const UserId& user_id) {
+  // Valid only for when in external window mode.
+  // For now, mimic the behavior of whether we had received the
+  // frame decoration data from the Window Manager.
+  GetUserDisplayManager(user_id)->OnFrameDecorationValuesChanged();
+}
+
 }  // namespace ws
 }  // namespace ui

--- a/services/ui/ws/display_manager.h
+++ b/services/ui/ws/display_manager.h
@@ -100,6 +100,7 @@ class DisplayManager : public UserIdTrackerObserver,
   void OnDisplayModified(const display::Display& display,
                          const display::ViewportMetrics& metrics) override;
   void OnPrimaryDisplayChanged(int64_t primary_display_id) override;
+  void OnHostDisplaysReady(const UserId& user_id) override;
 
   WindowServer* window_server_;
   UserIdTracker* user_id_tracker_;

--- a/services/ui/ws/mus_ws_unittests_app_manifest.json
+++ b/services/ui/ws/mus_ws_unittests_app_manifest.json
@@ -13,7 +13,8 @@
         "mus_ws_unittests_app": [ "ui:window_tree_client" ],
         "ui": [
           "window_manager",
-          "window_tree_host_factory"
+          "window_tree_host_factory",
+          "window_tree_host_factory_registrar"
         ]
       }
     }

--- a/services/ui/ws/platform_display.h
+++ b/services/ui/ws/platform_display.h
@@ -15,6 +15,7 @@
 #include "services/ui/public/interfaces/cursor/cursor.mojom.h"
 #include "ui/events/event_source.h"
 #include "ui/gfx/native_widget_types.h"
+#include "ui/platform_window/platform_window_delegate.h"
 
 namespace ui {
 
@@ -63,6 +64,9 @@ class PlatformDisplay : public ui::EventSource {
 
   // Shows or hides native window.
   virtual void SetWindowVisibility(bool visible) {}
+
+  // Changes state of a native window to minimized, maximized or normal.
+  virtual void SetNativeWindowState(ui::mojom::ShowState state) {}
 
   // Overrides factory for testing. Default (NULL) value indicates regular
   // (non-test) environment.

--- a/services/ui/ws/platform_display.h
+++ b/services/ui/ws/platform_display.h
@@ -61,6 +61,9 @@ class PlatformDisplay : public ui::EventSource {
 
   virtual FrameGenerator* GetFrameGenerator() = 0;
 
+  // Shows or hides native window.
+  virtual void SetWindowVisibility(bool visible) {}
+
   // Overrides factory for testing. Default (NULL) value indicates regular
   // (non-test) environment.
   static void set_factory_for_testing(PlatformDisplayFactory* factory) {

--- a/services/ui/ws/platform_display_default.cc
+++ b/services/ui/ws/platform_display_default.cc
@@ -232,10 +232,12 @@ void PlatformDisplayDefault::DispatchEvent(ui::Event* event) {
 }
 
 void PlatformDisplayDefault::OnCloseRequest() {
-  // TODO(tonikitoo): Handle a close request in external window mode. The window
-  // should be closed by the WS and it shouldn't involve ScreenManager.
+#if !defined(USE_OZONE) || defined(CHROMEOS)
   const int64_t display_id = delegate_->GetDisplay().id();
   display::ScreenManager::GetInstance()->RequestCloseDisplay(display_id);
+#else
+  delegate_->OnCloseRequest();
+#endif
 }
 
 void PlatformDisplayDefault::OnClosed() {}

--- a/services/ui/ws/platform_display_default.cc
+++ b/services/ui/ws/platform_display_default.cc
@@ -121,6 +121,9 @@ void PlatformDisplayDefault::SetNativeWindowState(ui::mojom::ShowState state) {
     case (ui::mojom::ShowState::MAXIMIZED):
       platform_window_->Maximize();
       break;
+    case (ui::mojom::ShowState::FULLSCREEN):
+      platform_window_->ToggleFullscreen();
+      break;
     case (ui::mojom::ShowState::NORMAL):
       platform_window_->Restore();
       break;

--- a/services/ui/ws/platform_display_default.cc
+++ b/services/ui/ws/platform_display_default.cc
@@ -105,6 +105,13 @@ void PlatformDisplayDefault::ReleaseCapture() {
   platform_window_->ReleaseCapture();
 }
 
+void PlatformDisplayDefault::SetWindowVisibility(bool visible) {
+  if (visible)
+    platform_window_->Show();
+  else
+    platform_window_->Hide();
+}
+
 void PlatformDisplayDefault::SetCursor(const ui::CursorData& cursor_data) {
   if (!image_cursors_)
     return;

--- a/services/ui/ws/platform_display_default.cc
+++ b/services/ui/ws/platform_display_default.cc
@@ -112,6 +112,12 @@ void PlatformDisplayDefault::SetWindowVisibility(bool visible) {
     platform_window_->Hide();
 }
 
+void PlatformDisplayDefault::GetWindowType(
+    ui::mojom::WindowType* result) {
+  DCHECK(result);
+  *result = metrics_.window_type;
+}
+
 void PlatformDisplayDefault::SetCursor(const ui::CursorData& cursor_data) {
   if (!image_cursors_)
     return;

--- a/services/ui/ws/platform_display_default.cc
+++ b/services/ui/ws/platform_display_default.cc
@@ -112,8 +112,24 @@ void PlatformDisplayDefault::SetWindowVisibility(bool visible) {
     platform_window_->Hide();
 }
 
-void PlatformDisplayDefault::GetWindowType(
-    ui::mojom::WindowType* result) {
+void PlatformDisplayDefault::SetNativeWindowState(ui::mojom::ShowState state) {
+  switch (state) {
+    case (ui::mojom::ShowState::MINIMIZED):
+      platform_window_->ReleaseCapture();
+      platform_window_->Minimize();
+      break;
+    case (ui::mojom::ShowState::MAXIMIZED):
+      platform_window_->Maximize();
+      break;
+    case (ui::mojom::ShowState::NORMAL):
+      platform_window_->Restore();
+      break;
+    default:
+      break;
+  }
+}
+
+void PlatformDisplayDefault::GetWindowType(ui::mojom::WindowType* result) {
   DCHECK(result);
   *result = metrics_.window_type;
 }
@@ -256,7 +272,24 @@ void PlatformDisplayDefault::OnCloseRequest() {
 void PlatformDisplayDefault::OnClosed() {}
 
 void PlatformDisplayDefault::OnWindowStateChanged(
-    ui::PlatformWindowState new_state) {}
+    ui::PlatformWindowState new_state) {
+  ui::mojom::ShowState state;
+  switch (new_state) {
+    case (ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MINIMIZED):
+      state = ui::mojom::ShowState::MINIMIZED;
+      break;
+    case (ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MAXIMIZED):
+      state = ui::mojom::ShowState::MAXIMIZED;
+      break;
+    case (ui::PlatformWindowState::PLATFORM_WINDOW_STATE_NORMAL):
+      state = ui::mojom::ShowState::NORMAL;
+      break;
+    default:
+      // We don't support other states at the moment. Ignore them.
+      return;
+  }
+  delegate_->OnWindowStateChanged(state);
+}
 
 void PlatformDisplayDefault::OnLostCapture() {
   delegate_->OnNativeCaptureLost();

--- a/services/ui/ws/platform_display_default.cc
+++ b/services/ui/ws/platform_display_default.cc
@@ -78,11 +78,15 @@ void PlatformDisplayDefault::Init(PlatformDisplayDelegate* delegate) {
   NOTREACHED() << "Unsupported platform";
 #endif
 
-  platform_window_->Show();
   if (image_cursors_) {
     image_cursors_->SetDisplay(delegate_->GetDisplay(),
                                metrics_.device_scale_factor);
   }
+  // Show() must be called only after |image_cursors_| has created a
+  // a cursor loader after display is sent to it. Otherwise, Show()
+  // triggers a delegate call to OnBoundsChanged(), which end up to
+  // changing cursor location for not existing cursor loader.
+  platform_window_->Show();
 }
 
 void PlatformDisplayDefault::SetViewportSize(const gfx::Size& size) {
@@ -190,11 +194,14 @@ void PlatformDisplayDefault::UpdateEventRootLocation(ui::LocatedEvent* event) {
 
 void PlatformDisplayDefault::OnBoundsChanged(const gfx::Rect& new_bounds) {
   // We only care if the window size has changed.
-  if (new_bounds.size() == metrics_.bounds_in_pixels.size())
+  if (new_bounds == metrics_.bounds_in_pixels)
     return;
 
-  // TODO(tonikitoo): Handle the bounds changing in external window mode. The
-  // window should be resized by the WS and it shouldn't involve ScreenManager.
+  metrics_.bounds_in_pixels = new_bounds;
+  if (frame_generator_)
+    frame_generator_->OnWindowSizeChanged(new_bounds.size());
+
+  delegate_->OnBoundsChanged(new_bounds);
 }
 
 void PlatformDisplayDefault::OnDamageRect(const gfx::Rect& damaged_region) {

--- a/services/ui/ws/platform_display_default.h
+++ b/services/ui/ws/platform_display_default.h
@@ -51,6 +51,7 @@ class PlatformDisplayDefault : public PlatformDisplay,
   gfx::AcceleratedWidget GetAcceleratedWidget() const override;
   FrameGenerator* GetFrameGenerator() override;
   void SetWindowVisibility(bool visible) override;
+  void SetNativeWindowState(ui::mojom::ShowState state) override;
   void GetWindowType(ui::mojom::WindowType* result) override;
 
  private:

--- a/services/ui/ws/platform_display_default.h
+++ b/services/ui/ws/platform_display_default.h
@@ -51,6 +51,7 @@ class PlatformDisplayDefault : public PlatformDisplay,
   gfx::AcceleratedWidget GetAcceleratedWidget() const override;
   FrameGenerator* GetFrameGenerator() override;
   void SetWindowVisibility(bool visible) override;
+  void GetWindowType(ui::mojom::WindowType* result) override;
 
  private:
   // Update the root_location of located events to be relative to the origin

--- a/services/ui/ws/platform_display_default.h
+++ b/services/ui/ws/platform_display_default.h
@@ -50,6 +50,7 @@ class PlatformDisplayDefault : public PlatformDisplay,
   void UpdateViewportMetrics(const display::ViewportMetrics& metrics) override;
   gfx::AcceleratedWidget GetAcceleratedWidget() const override;
   FrameGenerator* GetFrameGenerator() override;
+  void SetWindowVisibility(bool visible) override;
 
  private:
   // Update the root_location of located events to be relative to the origin

--- a/services/ui/ws/platform_display_default_unittest.cc
+++ b/services/ui/ws/platform_display_default_unittest.cc
@@ -57,6 +57,7 @@ class TestPlatformDisplayDelegate : public PlatformDisplayDelegate {
   void OnBoundsChanged(const gfx::Rect& new_bounds) override {}
   void OnCloseRequest() override {}
   void OnNativeCaptureLost() override {}
+  void OnWindowStateChanged(ui::mojom::ShowState new_state) override {}
   OzonePlatform* GetOzonePlatform() override { return ozone_platform_; }
 
  private:

--- a/services/ui/ws/platform_display_default_unittest.cc
+++ b/services/ui/ws/platform_display_default_unittest.cc
@@ -55,6 +55,7 @@ class TestPlatformDisplayDelegate : public PlatformDisplayDelegate {
   EventSink* GetEventSink() override { return event_sink_; }
   void OnAcceleratedWidgetAvailable() override {}
   void OnBoundsChanged(const gfx::Rect& new_bounds) override {}
+  void OnCloseRequest() override {}
   void OnNativeCaptureLost() override {}
   OzonePlatform* GetOzonePlatform() override { return ozone_platform_; }
 

--- a/services/ui/ws/platform_display_default_unittest.cc
+++ b/services/ui/ws/platform_display_default_unittest.cc
@@ -54,6 +54,7 @@ class TestPlatformDisplayDelegate : public PlatformDisplayDelegate {
   ServerWindow* GetRootWindow() override { return nullptr; }
   EventSink* GetEventSink() override { return event_sink_; }
   void OnAcceleratedWidgetAvailable() override {}
+  void OnBoundsChanged(const gfx::Rect& new_bounds) override {}
   void OnNativeCaptureLost() override {}
   OzonePlatform* GetOzonePlatform() override { return ozone_platform_; }
 

--- a/services/ui/ws/platform_display_delegate.h
+++ b/services/ui/ws/platform_display_delegate.h
@@ -38,6 +38,9 @@ class PlatformDisplayDelegate {
   // Called when the Display loses capture.
   virtual void OnNativeCaptureLost() = 0;
 
+  // Called when the Display is resized.
+  virtual void OnBoundsChanged(const gfx::Rect& new_bounds) = 0;
+
   // Allows the OzonePlatform to be overridden, e.g. for tests. Returns null
   // for non-Ozone platforms.
   virtual OzonePlatform* GetOzonePlatform() = 0;

--- a/services/ui/ws/platform_display_delegate.h
+++ b/services/ui/ws/platform_display_delegate.h
@@ -44,6 +44,10 @@ class PlatformDisplayDelegate {
   // Called when the Display is closed (external mode).
   virtual void OnCloseRequest() = 0;
 
+  // Called when the Display is minimized, maximized or restored (external
+  // mode).
+  virtual void OnWindowStateChanged(ui::mojom::ShowState new_state) = 0;
+
   // Allows the OzonePlatform to be overridden, e.g. for tests. Returns null
   // for non-Ozone platforms.
   virtual OzonePlatform* GetOzonePlatform() = 0;

--- a/services/ui/ws/platform_display_delegate.h
+++ b/services/ui/ws/platform_display_delegate.h
@@ -41,6 +41,9 @@ class PlatformDisplayDelegate {
   // Called when the Display is resized.
   virtual void OnBoundsChanged(const gfx::Rect& new_bounds) = 0;
 
+  // Called when the Display is closed (external mode).
+  virtual void OnCloseRequest() = 0;
+
   // Allows the OzonePlatform to be overridden, e.g. for tests. Returns null
   // for non-Ozone platforms.
   virtual OzonePlatform* GetOzonePlatform() = 0;

--- a/services/ui/ws/server_window.cc
+++ b/services/ui/ws/server_window.cc
@@ -178,7 +178,29 @@ void ServerWindow::SetBounds(
     const base::Optional<cc::LocalSurfaceId>& local_surface_id) {
   if (bounds_ == bounds && current_local_surface_id_ == local_surface_id)
     return;
+  SetBoundsInternal(bounds, local_surface_id);
+}
 
+void ServerWindow::SetBoundsFromHostWindowManager(
+    const gfx::Rect& bounds,
+    const base::Optional<cc::LocalSurfaceId>& local_surface_id) {
+  if (bounds_ == bounds && current_local_surface_id_ == local_surface_id)
+    return;
+
+  gfx::Rect old_bounds = bounds_;
+  SetBoundsInternal(bounds, local_surface_id);
+  if (bounds.origin() != old_bounds.origin()) {
+	// The root_'s origin mustn't be changed here, so that events are correctly
+	// translated after bounds change.
+	// TODO(msisov): Maybe there is a better way than actually restore the
+	// original origin?
+    bounds_.set_origin(old_bounds.origin());
+  }
+}
+
+void ServerWindow::SetBoundsInternal(
+    const gfx::Rect& bounds,
+    const base::Optional<cc::LocalSurfaceId>& local_surface_id) {
   const gfx::Rect old_bounds = bounds_;
 
   current_local_surface_id_ = local_surface_id;

--- a/services/ui/ws/server_window.cc
+++ b/services/ui/ws/server_window.cc
@@ -298,6 +298,13 @@ void ServerWindow::SetVisible(bool value) {
     observer.OnWindowVisibilityChanged(this);
 }
 
+void ServerWindow::SetNativeWindowHidden() {
+  if (visible_)
+    return;
+  for (auto& observer : observers_)
+    observer.OnSetNativeWindowHidden(this);
+}
+
 void ServerWindow::SetOpacity(float value) {
   if (value == opacity_)
     return;

--- a/services/ui/ws/server_window.cc
+++ b/services/ui/ws/server_window.cc
@@ -178,36 +178,21 @@ void ServerWindow::SetBounds(
     const base::Optional<cc::LocalSurfaceId>& local_surface_id) {
   if (bounds_ == bounds && current_local_surface_id_ == local_surface_id)
     return;
-  SetBoundsInternal(bounds, local_surface_id);
-}
-
-void ServerWindow::SetBoundsFromHostWindowManager(
-    const gfx::Rect& bounds,
-    const base::Optional<cc::LocalSurfaceId>& local_surface_id) {
-  if (bounds_ == bounds && current_local_surface_id_ == local_surface_id)
-    return;
-
-  gfx::Rect old_bounds = bounds_;
-  SetBoundsInternal(bounds, local_surface_id);
-  if (bounds.origin() != old_bounds.origin()) {
-	// The root_'s origin mustn't be changed here, so that events are correctly
-	// translated after bounds change.
-	// TODO(msisov): Maybe there is a better way than actually restore the
-	// original origin?
-    bounds_.set_origin(old_bounds.origin());
-  }
-}
-
-void ServerWindow::SetBoundsInternal(
-    const gfx::Rect& bounds,
-    const base::Optional<cc::LocalSurfaceId>& local_surface_id) {
-  const gfx::Rect old_bounds = bounds_;
 
   current_local_surface_id_ = local_surface_id;
 
+  gfx::Rect old_bounds = bounds_;
   bounds_ = bounds;
   for (auto& observer : observers_)
     observer.OnWindowBoundsChanged(this, old_bounds, bounds);
+}
+
+void ServerWindow::OnNewBoundsFromHostServer(const gfx::Rect& bounds) {
+  if (bounds_ == bounds)
+    return;
+
+  for (auto& observer : observers_)
+    observer.OnNewBoundsFromHostServer(this, bounds);
 }
 
 void ServerWindow::SetClientArea(

--- a/services/ui/ws/server_window.h
+++ b/services/ui/ws/server_window.h
@@ -91,6 +91,12 @@ class ServerWindow {
                  const base::Optional<cc::LocalSurfaceId>& local_surface_id =
                      base::nullopt);
 
+  // Sets the bounds from a host window manager, which is a system wm.
+  // This is a reaction to resizes/moves done in the host window manager window.
+  void SetBoundsFromHostWindowManager(const gfx::Rect& bounds,
+                                      const base::Optional<cc::LocalSurfaceId>&
+                                          local_surface_id = base::nullopt);
+
   const std::vector<gfx::Rect>& additional_client_areas() const {
     return additional_client_areas_;
   }
@@ -223,6 +229,10 @@ class ServerWindow {
   static void ReorderImpl(ServerWindow* window,
                           ServerWindow* relative,
                           mojom::OrderDirection diretion);
+
+  void SetBoundsInternal(
+      const gfx::Rect& bounds,
+      const base::Optional<cc::LocalSurfaceId>& local_surface_id);
 
   // Returns a pointer to the stacking target that can be used by
   // RestackTransientDescendants.

--- a/services/ui/ws/server_window.h
+++ b/services/ui/ws/server_window.h
@@ -151,6 +151,9 @@ class ServerWindow {
   bool visible() const { return visible_; }
   void SetVisible(bool value);
 
+  // Tells WindowServer to hide native window.
+  void SetNativeWindowHidden();
+
   float opacity() const { return opacity_; }
   void SetOpacity(float value);
 

--- a/services/ui/ws/server_window.h
+++ b/services/ui/ws/server_window.h
@@ -91,11 +91,10 @@ class ServerWindow {
                  const base::Optional<cc::LocalSurfaceId>& local_surface_id =
                      base::nullopt);
 
-  // Sets the bounds from a host window manager, which is a system wm.
-  // This is a reaction to resizes/moves done in the host window manager window.
-  void SetBoundsFromHostWindowManager(const gfx::Rect& bounds,
-                                      const base::Optional<cc::LocalSurfaceId>&
-                                          local_surface_id = base::nullopt);
+  // Tells the client to set the bounds from a host window manager, which is a
+  // system wm. This is a reaction to resizes/moves done in the host window
+  // manager window.
+  void OnNewBoundsFromHostServer(const gfx::Rect& bounds);
 
   const std::vector<gfx::Rect>& additional_client_areas() const {
     return additional_client_areas_;
@@ -229,10 +228,6 @@ class ServerWindow {
   static void ReorderImpl(ServerWindow* window,
                           ServerWindow* relative,
                           mojom::OrderDirection diretion);
-
-  void SetBoundsInternal(
-      const gfx::Rect& bounds,
-      const base::Optional<cc::LocalSurfaceId>& local_surface_id);
 
   // Returns a pointer to the stacking target that can be used by
   // RestackTransientDescendants.

--- a/services/ui/ws/server_window_observer.h
+++ b/services/ui/ws/server_window_observer.h
@@ -66,6 +66,7 @@ class ServerWindowObserver {
 
   virtual void OnWillChangeWindowVisibility(ServerWindow* window) {}
   virtual void OnWindowVisibilityChanged(ServerWindow* window) {}
+  virtual void OnSetNativeWindowHidden(ServerWindow* window) {}
   virtual void OnWindowOpacityChanged(ServerWindow* window,
                                       float old_opacity,
                                       float new_opacity) {}

--- a/services/ui/ws/server_window_observer.h
+++ b/services/ui/ws/server_window_observer.h
@@ -51,6 +51,10 @@ class ServerWindowObserver {
                                      const gfx::Rect& old_bounds,
                                      const gfx::Rect& new_bounds) {}
 
+  // Called when a host server wants client to change bounds.
+  virtual void OnNewBoundsFromHostServer(ServerWindow* window,
+                                         const gfx::Rect& new_bounds) {}
+
   virtual void OnWindowClientAreaChanged(
       ServerWindow* window,
       const gfx::Insets& new_client_area,

--- a/services/ui/ws/test_utils.cc
+++ b/services/ui/ws/test_utils.cc
@@ -347,6 +347,10 @@ void TestWindowTreeClient::OnWindowBoundsChanged(
                                  std::move(new_bounds), local_surface_id);
 }
 
+void TestWindowTreeClient::OnNewBoundsFromHostServer(
+    Id window_id,
+    const gfx::Rect& new_bounds) {}
+
 void TestWindowTreeClient::OnClientAreaChanged(
     uint32_t window_id,
     const gfx::Insets& new_client_area,

--- a/services/ui/ws/test_utils.cc
+++ b/services/ui/ws/test_utils.cc
@@ -469,6 +469,9 @@ void TestWindowTreeClient::OnChangeCompleted(uint32_t change_id, bool success) {
     tracker_.OnChangeCompleted(change_id, success);
 }
 
+void TestWindowTreeClient::OnWindowStateChanged(uint32_t window_id,
+                                                ::ui::mojom::ShowState state) {}
+
 void TestWindowTreeClient::RequestClose(uint32_t window_id) {}
 
 void TestWindowTreeClient::GetWindowManager(

--- a/services/ui/ws/test_utils.h
+++ b/services/ui/ws/test_utils.h
@@ -516,6 +516,8 @@ class TestWindowTreeClient : public ui::mojom::WindowTreeClient {
                                   uint32_t action_taken) override;
   void OnDragDropDone() override;
   void OnChangeCompleted(uint32_t change_id, bool success) override;
+  void OnWindowStateChanged(uint32_t window_id,
+                            ::ui::mojom::ShowState state) override;
   void RequestClose(uint32_t window_id) override;
   void GetWindowManager(
       mojo::AssociatedInterfaceRequest<mojom::WindowManager> internal) override;

--- a/services/ui/ws/test_utils.h
+++ b/services/ui/ws/test_utils.h
@@ -451,6 +451,8 @@ class TestWindowTreeClient : public ui::mojom::WindowTreeClient {
       const gfx::Rect& old_bounds,
       const gfx::Rect& new_bounds,
       const base::Optional<cc::LocalSurfaceId>& local_surface_id) override;
+  void OnNewBoundsFromHostServer(Id window_id,
+                                 const gfx::Rect& new_bounds) override;
   void OnClientAreaChanged(
       uint32_t window_id,
       const gfx::Insets& new_client_area,

--- a/services/ui/ws/window_manager_state.cc
+++ b/services/ui/ws/window_manager_state.cc
@@ -365,7 +365,8 @@ void WindowManagerState::OnDisplayDestroying(Display* display) {
         (*iter)->root()->AddObserver(this);
       orphaned_window_manager_display_roots_.push_back(std::move(*iter));
       window_manager_display_roots_.erase(iter);
-      window_tree_->OnDisplayDestroying(display->GetId());
+      if (!window_server()->IsInExternalWindowMode())
+        window_tree_->OnDisplayDestroying(display->GetId());
       orphaned_window_manager_display_roots_.back()->display_ = nullptr;
       return;
     }

--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -207,6 +207,12 @@ WindowTree* WindowServer::GetTreeWithClientName(
   return nullptr;
 }
 
+WindowTree* WindowServer::GetTreeForExternalWindowMode() {
+  DCHECK_LE(1u, tree_map_.size());
+  DCHECK(IsInExternalWindowMode());
+  return tree_map_.begin()->second.get();
+}
+
 ServerWindow* WindowServer::GetWindow(const WindowId& id) {
   // kInvalidClientId is used for Display and WindowManager nodes.
   if (id.client_id == kInvalidClientId) {

--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -368,6 +368,15 @@ void WindowServer::WindowManagerCreatedTopLevelWindow(
                                              change.client_change_id, window);
 }
 
+void WindowServer::OnNewBoundsFromHostServer(ServerWindow* window,
+                                             const gfx::Rect& new_bounds) {
+  if (in_destructor_)
+    return;
+
+  for (auto& pair : tree_map_)
+    pair.second->OnNewBoundsFromHostServer(window, new_bounds);
+}
+
 void WindowServer::ProcessWindowBoundsChanged(
     const ServerWindow* window,
     const gfx::Rect& old_bounds,

--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -570,6 +570,17 @@ cc::mojom::FrameSinkManager* WindowServer::GetFrameSinkManager() {
 bool WindowServer::GetFrameDecorationsForUser(
     const UserId& user_id,
     mojom::FrameDecorationValuesPtr* values) {
+  if (IsInExternalWindowMode() && values) {
+    *values = mojom::FrameDecorationValues::New();
+    // '33' was picked up by trial/error and because this is the value
+    // used in ChromeOS/mash builds. The value is used to calculate chrome's
+    // tabstrip height in BrowserNonClientFrameViewMus::GetHeaderHeigh().
+    // TODO(tonikitoo,msisov): Maybe there is some refinement to be done here?
+    // What about maximized_client_area_insets and max_title_bar_button_width?
+    (*values)->normal_client_area_insets = gfx::Insets(33, 0, 0, 0);
+    return true;
+  }
+
   WindowManagerState* window_manager_state =
       window_manager_window_tree_factory_set_.GetWindowManagerStateForUser(
           user_id);

--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -10,6 +10,7 @@
 #include "base/logging.h"
 #include "base/memory/ptr_util.h"
 #include "base/stl_util.h"
+#include "services/ui/public/cpp/property_type_converters.h"
 #include "services/ui/ws/display.h"
 #include "services/ui/ws/display_manager.h"
 #include "services/ui/ws/frame_generator.h"
@@ -691,6 +692,17 @@ void WindowServer::SetNativeWindowVisibility(
   display->SetWindowVisibility(visible);
 }
 
+void WindowServer::SetNativeWindowState(ServerWindow* window,
+                                        ui::mojom::ShowState state) {
+  WindowManagerDisplayRoot* display_root =
+      display_manager_->GetWindowManagerDisplayRoot(window);
+  if (!display_root)
+    return;
+  PlatformDisplay* display = display_root->display()->platform_display();
+  DCHECK(display);
+  display->SetNativeWindowState(state);
+}
+
 ServerWindow* WindowServer::GetRootWindow(const ServerWindow* window) {
   Display* display = display_manager_->GetDisplayContaining(window);
   return display ? display->root_window() : nullptr;
@@ -842,6 +854,12 @@ void WindowServer::OnWindowSharedPropertyChanged(
     ServerWindow* window,
     const std::string& name,
     const std::vector<uint8_t>* new_data) {
+  if (in_external_window_mode &&
+      name == mojom::WindowManager::kShowState_Property) {
+    const int64_t state = mojo::ConvertTo<int64_t>(*new_data);
+    SetNativeWindowState(window, static_cast<ui::mojom::ShowState>(state));
+  }
+
   for (auto& pair : tree_map_) {
     pair.second->ProcessWindowPropertyChanged(window, name, new_data,
                                               IsOperationSource(pair.first));

--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -670,6 +670,16 @@ void WindowServer::HandleTemporaryReferenceForNewSurface(
   }
 }
 
+void WindowServer::SetNativeWindowVisibility(
+    WindowManagerDisplayRoot* display_root,
+    bool visible) {
+  if (!IsInExternalWindowMode())
+    return;
+  PlatformDisplay* display = display_root->display()->platform_display();
+  DCHECK(display);
+  display->SetWindowVisibility(visible);
+}
+
 ServerWindow* WindowServer::GetRootWindow(const ServerWindow* window) {
   Display* display = display_manager_->GetDisplayContaining(window);
   return display ? display->root_window() : nullptr;
@@ -775,9 +785,27 @@ void WindowServer::OnWindowVisibilityChanged(ServerWindow* window) {
 
   WindowManagerDisplayRoot* display_root =
       display_manager_->GetWindowManagerDisplayRoot(window);
-  if (display_root)
+  if (display_root) {
     display_root->window_manager_state()->ReleaseCaptureBlockedByModalWindow(
         window);
+    bool visible = window->visible();
+    if (visible)
+      SetNativeWindowVisibility(display_root, visible);
+  }
+}
+
+void WindowServer::OnSetNativeWindowHidden(ServerWindow* window) {
+  if (in_destructor_)
+    return;
+
+  WindowManagerDisplayRoot* display_root =
+      display_manager_->GetWindowManagerDisplayRoot(window);
+  if (!display_root)
+    return;
+
+  bool visible = window->visible();
+  DCHECK(!visible);
+  SetNativeWindowVisibility(display_root, visible);
 }
 
 void WindowServer::OnWindowCursorChanged(ServerWindow* window,

--- a/services/ui/ws/window_server.h
+++ b/services/ui/ws/window_server.h
@@ -309,6 +309,10 @@ class WindowServer : public ServerWindowDelegate,
   void SetNativeWindowVisibility(WindowManagerDisplayRoot* display_root,
                                  bool visible);
 
+  // Sets a state (minimize/maximize/restore) of a native window (only in
+  // external mode).
+  void SetNativeWindowState(ServerWindow* window, ui::mojom::ShowState state);
+
   // Overridden from ServerWindowDelegate:
   ServerWindow* GetRootWindow(const ServerWindow* window) override;
 

--- a/services/ui/ws/window_server.h
+++ b/services/ui/ws/window_server.h
@@ -318,6 +318,8 @@ class WindowServer : public ServerWindowDelegate,
   void OnWindowBoundsChanged(ServerWindow* window,
                              const gfx::Rect& old_bounds,
                              const gfx::Rect& new_bounds) override;
+  void OnNewBoundsFromHostServer(ServerWindow* window,
+                                 const gfx::Rect& new_bounds) override;
   void OnWindowClientAreaChanged(
       ServerWindow* window,
       const gfx::Insets& new_client_area,

--- a/services/ui/ws/window_server.h
+++ b/services/ui/ws/window_server.h
@@ -27,6 +27,7 @@
 #include "services/ui/ws/user_id_tracker.h"
 #include "services/ui/ws/user_id_tracker_observer.h"
 #include "services/ui/ws/window_manager_window_tree_factory_set.h"
+#include "services/ui/ws/window_tree_host_factory.h"
 
 namespace ui {
 namespace ws {
@@ -101,6 +102,8 @@ class WindowServer : public ServerWindowDelegate,
 
   WindowTree* GetTreeWithClientName(const std::string& client_name);
 
+  WindowTree* GetTreeForExternalWindowMode();
+
   size_t num_trees() const { return tree_map_.size(); }
 
   // Returns the Window identified by |id|.
@@ -137,11 +140,20 @@ class WindowServer : public ServerWindowDelegate,
     return &window_manager_window_tree_factory_set_;
   }
 
+  void set_window_tree_host_factory(
+      std::unique_ptr<WindowTreeHostFactory> factory) {
+    DCHECK(factory);
+    window_tree_host_factory_ = std::move(factory);
+  }
+
   // Sets focus to |window|. Returns true if |window| already has focus, or
   // focus was successfully changed. Returns |false| if |window| is not a valid
   // window to receive focus.
   bool SetFocusedWindow(ServerWindow* window);
   ServerWindow* GetFocusedWindow();
+
+  void SetInExternalWindowMode() { in_external_window_mode = true; }
+  bool IsInExternalWindowMode() const { return in_external_window_mode; }
 
   void SetHighContrastMode(const UserId& user, bool enabled);
 
@@ -381,12 +393,16 @@ class WindowServer : public ServerWindowDelegate,
 
   WindowManagerWindowTreeFactorySet window_manager_window_tree_factory_set_;
 
+  std::unique_ptr<WindowTreeHostFactory> window_tree_host_factory_;
+
   cc::SurfaceId root_surface_id_;
 
   // Provides interfaces to create and manage FrameSinks.
   mojo::Binding<cc::mojom::FrameSinkManagerClient>
       frame_sink_manager_client_binding_;
   cc::mojom::FrameSinkManagerPtr frame_sink_manager_;
+
+  bool in_external_window_mode = false;
 
   DISALLOW_COPY_AND_ASSIGN(WindowServer);
 };

--- a/services/ui/ws/window_server.h
+++ b/services/ui/ws/window_server.h
@@ -38,6 +38,7 @@ class DisplayManager;
 class GpuHost;
 class ServerWindow;
 class UserActivityMonitor;
+class WindowManagerDisplayRoot;
 class WindowManagerState;
 class WindowServerDelegate;
 class WindowTree;
@@ -304,6 +305,10 @@ class WindowServer : public ServerWindowDelegate,
   void HandleTemporaryReferenceForNewSurface(const cc::SurfaceId& surface_id,
                                              ServerWindow* window);
 
+  // Hides or shows native window.
+  void SetNativeWindowVisibility(WindowManagerDisplayRoot* display_root,
+                                 bool visible);
+
   // Overridden from ServerWindowDelegate:
   ServerWindow* GetRootWindow(const ServerWindow* window) override;
 
@@ -329,6 +334,7 @@ class WindowServer : public ServerWindowDelegate,
                          mojom::OrderDirection direction) override;
   void OnWillChangeWindowVisibility(ServerWindow* window) override;
   void OnWindowVisibilityChanged(ServerWindow* window) override;
+  void OnSetNativeWindowHidden(ServerWindow* window) override;
   void OnWindowOpacityChanged(ServerWindow* window,
                               float old_opacity,
                               float new_opacity) override;

--- a/services/ui/ws/window_server_test_impl.h
+++ b/services/ui/ws/window_server_test_impl.h
@@ -5,6 +5,8 @@
 #ifndef SERVICES_UI_WS_WINDOW_SERVER_TEST_IMPL_H_
 #define SERVICES_UI_WS_WINDOW_SERVER_TEST_IMPL_H_
 
+#include <map>
+
 #include "services/ui/public/interfaces/window_server_test.mojom.h"
 
 namespace ui {
@@ -20,18 +22,19 @@ class WindowServerTestImpl : public mojom::WindowServerTest {
 
  private:
   void OnWindowPaint(const std::string& name,
-                     const EnsureClientHasDrawnWindowCallback& cb,
+                     const EnsureClientHasDrawnRootWindowsCallback& cb,
                      ServerWindow* window);
 
   // mojom::WindowServerTest:
-  void EnsureClientHasDrawnWindow(
+  void EnsureClientHasDrawnRootWindows(
       const std::string& client_name,
-      const EnsureClientHasDrawnWindowCallback& callback) override;
+      const EnsureClientHasDrawnRootWindowsCallback& callback) override;
   void DispatchEvent(int64_t display_id,
                      std::unique_ptr<ui::Event> event,
                      const DispatchEventCallback& cb) override;
 
   WindowServer* window_server_;
+  std::map<std::string, unsigned> painted_window_roots_;
 
   DISALLOW_COPY_AND_ASSIGN(WindowServerTestImpl);
 };

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -148,6 +148,12 @@ void WindowTree::DoOnEmbed(mojom::WindowTreePtr tree,
     // In external window mode, every platform window is an activation parent.
     AddActivationParent(window_id);
 
+    // In case of external window mode, when aura/mus sets the initial focus
+    // to the Chrome's server window (WindowManagerDisplayRoot::root_), the
+    // call chain checks either WindowManagerDisplayRoot::root_'s parent window
+    // (Display::root_) is part of the Displayu::activation_parents_ set.
+    display->AddActivationParent(display->root_window());
+
     const bool drawn =
         root_window->parent() && root_window->parent()->IsDrawn();
     client()->OnEmbed(id_, WindowToWindowData(root_window),

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -145,6 +145,9 @@ void WindowTree::DoOnEmbed(mojom::WindowTreePtr tree,
     ClientWindowId window_id;
     IsWindowKnown(root_window, &window_id);
 
+    // In external window mode, every platform window is an activation parent.
+    AddActivationParent(window_id);
+
     const bool drawn =
         root_window->parent() && root_window->parent()->IsDrawn();
     client()->OnEmbed(id_, WindowToWindowData(root_window),

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -389,8 +389,6 @@ ServerWindow* WindowTree::ProcessSetDisplayRoot(
 bool WindowTree::SetCapture(const ClientWindowId& client_window_id) {
   ServerWindow* window = GetWindowByClientId(client_window_id);
   WindowManagerDisplayRoot* display_root = GetWindowManagerDisplayRoot(window);
-  if (display_root && !display_root->window_manager_state())
-    return false;
   ServerWindow* current_capture_window =
       display_root ? display_root->window_manager_state()->capture_window()
                    : nullptr;
@@ -408,8 +406,6 @@ bool WindowTree::SetCapture(const ClientWindowId& client_window_id) {
 bool WindowTree::ReleaseCapture(const ClientWindowId& client_window_id) {
   ServerWindow* window = GetWindowByClientId(client_window_id);
   WindowManagerDisplayRoot* display_root = GetWindowManagerDisplayRoot(window);
-  if (display_root && !display_root->window_manager_state())
-    return false;
   ServerWindow* current_capture_window =
       display_root ? display_root->window_manager_state()->capture_window()
                    : nullptr;
@@ -1032,6 +1028,11 @@ void WindowTree::SendToPointerWatcher(const ui::Event& event,
   IsWindowKnown(target_window, &client_window_id);
   client()->OnPointerEventObserved(ui::Event::Clone(event), client_window_id.id,
                                    display_id);
+}
+
+void WindowTree::AddExternalModeWindowManagerState(
+    std::unique_ptr<WindowManagerState> window_manager_state) {
+  external_mode_wm_states_.insert(std::move(window_manager_state));
 }
 
 bool WindowTree::ShouldRouteToWindowManager(const ServerWindow* window) const {
@@ -1912,6 +1913,8 @@ void WindowTree::DeactivateWindow(Id window_id) {
 }
 
 void WindowTree::StackAbove(uint32_t change_id, Id above_id, Id below_id) {
+  client()->OnChangeCompleted(change_id, true);
+  return;
   ServerWindow* above = GetWindowByClientId(ClientWindowId(above_id));
   if (!above) {
     DVLOG(1) << "StackAbove failed (invalid above id)";
@@ -1970,6 +1973,8 @@ void WindowTree::StackAbove(uint32_t change_id, Id above_id, Id below_id) {
 }
 
 void WindowTree::StackAtTop(uint32_t change_id, Id window_id) {
+  client()->OnChangeCompleted(change_id, true);
+  return;
   ServerWindow* window = GetWindowByClientId(ClientWindowId(window_id));
   if (!window) {
     DVLOG(1) << "StackAtTop failed (invalid id)";

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -1670,6 +1670,11 @@ void WindowTree::SetWindowProperty(
   client()->OnChangeCompleted(change_id, success);
 }
 
+void WindowTree::SetNativeWindowHidden(Id window_id) {
+  ServerWindow* window = GetWindowByClientId(ClientWindowId(window_id));
+  window->SetNativeWindowHidden();
+}
+
 void WindowTree::SetWindowOpacity(uint32_t change_id,
                                   Id window_id,
                                   float opacity) {

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -2440,6 +2440,9 @@ bool WindowTree::IsWindowRootOfAnotherTreeForAccessPolicy(
 
 bool WindowTree::IsWindowCreatedByWindowManager(
     const ServerWindow* window) const {
+  if (window_server_->IsInExternalWindowMode())
+    return false;  // No window manager is available in external mode.
+
   // The WindowManager is attached to the root of the Display, if there isn't a
   // WindowManager attached, the window manager didn't create this window.
   const WindowManagerDisplayRoot* display_root =

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -766,6 +766,15 @@ void WindowTree::ClientJankinessChanged(WindowTree* tree) {
   }
 }
 
+void WindowTree::OnNewBoundsFromHostServer(const ServerWindow* window,
+                                           const gfx::Rect& new_bounds) {
+  ClientWindowId client_window_id;
+  if (!IsWindowKnown(window, &client_window_id))
+    return;
+
+  client()->OnNewBoundsFromHostServer(client_window_id.id, new_bounds);
+}
+
 void WindowTree::ProcessWindowBoundsChanged(
     const ServerWindow* window,
     const gfx::Rect& old_bounds,

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -128,7 +128,35 @@ void WindowTree::Init(std::unique_ptr<WindowTreeBinding> binding,
   if (roots_.empty())
     return;
 
+  DoOnEmbed(std::move(tree), nullptr /*ServerWindow*/);
+}
+
+void WindowTree::DoOnEmbed(mojom::WindowTreePtr tree,
+                           ServerWindow* root_window) {
+  bool in_external_window_mode = !!root_window;
+  if (in_external_window_mode) {
+    DCHECK(!tree);
+    CHECK_LE(1u, roots_.size());
+
+    Display* display = GetDisplay(root_window);
+    int64_t display_id =
+        display ? display->GetId() : display::kInvalidDisplayId;
+
+    ClientWindowId window_id;
+    IsWindowKnown(root_window, &window_id);
+
+    const bool drawn =
+        root_window->parent() && root_window->parent()->IsDrawn();
+    client()->OnEmbed(id_, WindowToWindowData(root_window),
+                      nullptr /*mojom::WindowTreePtr*/, display_id,
+                      window_id.id, drawn,
+                      root_window->current_local_surface_id());
+    return;
+  }
+
   std::vector<const ServerWindow*> to_send;
+
+  DCHECK(!root_window);
   CHECK_EQ(1u, roots_.size());
   const ServerWindow* root = *roots_.begin();
   GetUnknownWindowsFrom(root, &to_send);
@@ -218,6 +246,22 @@ void WindowTree::PrepareForWindowServerShutdown() {
   binding_->ResetClientForShutdown();
   if (window_manager_internal_)
     window_manager_internal_ = binding_->GetWindowManager();
+}
+
+void WindowTree::AddRoot(const ServerWindow* root) {
+  DCHECK(pending_client_window_id_ != kInvalidClientId);
+
+  const ClientWindowId client_window_id(pending_client_window_id_);
+  DCHECK_EQ(0u, client_id_to_window_id_map_.count(client_window_id));
+
+  client_id_to_window_id_map_[client_window_id] = root->id();
+  window_id_to_client_id_map_[root->id()] = client_window_id;
+  pending_client_window_id_ = kInvalidClientId;
+
+  roots_.insert(root);
+
+  Display* display = GetDisplay(root);
+  DCHECK(display);
 }
 
 void WindowTree::AddRootForWindowManager(const ServerWindow* root) {
@@ -345,6 +389,8 @@ ServerWindow* WindowTree::ProcessSetDisplayRoot(
 bool WindowTree::SetCapture(const ClientWindowId& client_window_id) {
   ServerWindow* window = GetWindowByClientId(client_window_id);
   WindowManagerDisplayRoot* display_root = GetWindowManagerDisplayRoot(window);
+  if (display_root && !display_root->window_manager_state())
+    return false;
   ServerWindow* current_capture_window =
       display_root ? display_root->window_manager_state()->capture_window()
                    : nullptr;
@@ -362,6 +408,8 @@ bool WindowTree::SetCapture(const ClientWindowId& client_window_id) {
 bool WindowTree::ReleaseCapture(const ClientWindowId& client_window_id) {
   ServerWindow* window = GetWindowByClientId(client_window_id);
   WindowManagerDisplayRoot* display_root = GetWindowManagerDisplayRoot(window);
+  if (display_root && !display_root->window_manager_state())
+    return false;
   ServerWindow* current_capture_window =
       display_root ? display_root->window_manager_state()->capture_window()
                    : nullptr;

--- a/services/ui/ws/window_tree.h
+++ b/services/ui/ws/window_tree.h
@@ -294,6 +294,10 @@ class WindowTree : public mojom::WindowTree,
                             ServerWindow* target_window,
                             int64_t display_id);
 
+  // TODO(tonikitoo,msisov,fwang): Add a comment.
+  void AddExternalModeWindowManagerState(
+      std::unique_ptr<WindowManagerState> window_manager_state);
+
  private:
   friend class test::WindowTreeTestApi;
 
@@ -644,8 +648,11 @@ class WindowTree : public mojom::WindowTree,
       window_manager_internal_client_binding_;
   mojom::WindowManager* window_manager_internal_;
   std::unique_ptr<WindowManagerState> window_manager_state_;
+
   // See mojom for details.
   bool automatically_create_display_roots_ = true;
+
+  std::set<std::unique_ptr<WindowManagerState>> external_mode_wm_states_;
 
   std::unique_ptr<WaitingForTopLevelWindowInfo>
       waiting_for_top_level_window_info_;

--- a/services/ui/ws/window_tree.h
+++ b/services/ui/ws/window_tree.h
@@ -465,6 +465,7 @@ class WindowTree : public mojom::WindowTree,
       Id transport_window_id,
       const std::string& name,
       const base::Optional<std::vector<uint8_t>>& value) override;
+  void SetNativeWindowHidden(Id window_id) override;
   void SetWindowOpacity(uint32_t change_id,
                         Id window_id,
                         float opacity) override;

--- a/services/ui/ws/window_tree.h
+++ b/services/ui/ws/window_tree.h
@@ -155,9 +155,19 @@ class WindowTree : public mojom::WindowTree,
   WindowServer* window_server() { return window_server_; }
   const WindowServer* window_server() const { return window_server_; }
 
+  void WillCreateRootDisplay(Id transport_window_id) {
+    pending_client_window_id_ = transport_window_id;
+  }
+
+  // Calls WindowTreeClient::OnEmbed.
+  void DoOnEmbed(mojom::WindowTreePtr tree, ServerWindow* root);
+
   // Called from ~WindowServer. Reset WindowTreeClient so that it no longer gets
   // any messages.
   void PrepareForWindowServerShutdown();
+
+  // Adds a new root to this tree.
+  void AddRoot(const ServerWindow* root);
 
   // Adds a new root to this tree. This is only valid for window managers.
   void AddRootForWindowManager(const ServerWindow* root);
@@ -645,6 +655,8 @@ class WindowTree : public mojom::WindowTree,
   // WmMoveDragImage. Non-null while we're waiting for a response.
   struct DragMoveState;
   std::unique_ptr<DragMoveState> drag_move_state_;
+
+  Id pending_client_window_id_ = kInvalidClientId;
 
   // A weak ptr factory for callbacks from the window manager for when we send
   // a image move. All weak ptrs are invalidated when a drag is completed.

--- a/services/ui/ws/window_tree.h
+++ b/services/ui/ws/window_tree.h
@@ -233,6 +233,10 @@ class WindowTree : public mojom::WindowTree,
   // window(s).
   void ClientJankinessChanged(WindowTree* tree);
 
+  // Called when a host server triggers to change bounds of the client.
+  void OnNewBoundsFromHostServer(const ServerWindow* window,
+                                 const gfx::Rect& new_bounds);
+
   // The following methods are invoked after the corresponding change has been
   // processed. They do the appropriate bookkeeping and update the client as
   // necessary.

--- a/services/ui/ws/window_tree_client_unittest.cc
+++ b/services/ui/ws/window_tree_client_unittest.cc
@@ -273,6 +273,9 @@ class TestWindowTreeClient : public mojom::WindowTreeClient,
     }
   }
 
+  void OnWindowStateChanged(uint32_t window_id,
+                            ::ui::mojom::ShowState state) override {}
+
   // WindowTreeClient:
   void OnEmbed(
       ClientSpecificId client_id,

--- a/services/ui/ws/window_tree_client_unittest.cc
+++ b/services/ui/ws/window_tree_client_unittest.cc
@@ -137,6 +137,7 @@ class TestWindowTreeClient : public mojom::WindowTreeClient,
   }
 
   mojom::WindowTree* tree() { return tree_.get(); }
+  void set_tree(mojom::WindowTreePtr tree) { tree_ = std::move(tree); }
   TestChangeTracker* tracker() { return &tracker_; }
   Id root_window_id() const { return root_window_id_; }
 
@@ -164,7 +165,7 @@ class TestWindowTreeClient : public mojom::WindowTreeClient,
 
   // Runs a nested MessageLoop until OnEmbed() has been encountered.
   void WaitForOnEmbed() {
-    if (tree_)
+    if (tree_ready_)
       return;
     embed_run_loop_ = base::MakeUnique<base::RunLoop>();
     embed_run_loop_->Run();
@@ -284,7 +285,9 @@ class TestWindowTreeClient : public mojom::WindowTreeClient,
     // TODO(sky): add coverage of |focused_window_id|.
     ASSERT_TRUE(root);
     root_window_id_ = root->window_id;
-    tree_ = std::move(tree);
+    if (!tree_)
+      set_tree(std::move(tree));
+    tree_ready_ = true;
     client_id_ = client_id;
     tracker()->OnEmbed(client_id, std::move(root), drawn);
     if (embed_run_loop_)
@@ -515,6 +518,7 @@ class TestWindowTreeClient : public mojom::WindowTreeClient,
   TestChangeTracker tracker_;
 
   mojom::WindowTreePtr tree_;
+  bool tree_ready_ = false;
 
   // If non-null we're waiting for OnEmbed() using this RunLoop.
   std::unique_ptr<base::RunLoop> embed_run_loop_;
@@ -687,15 +691,19 @@ class WindowTreeClientTest : public WindowServerServiceTestBase {
 
     WindowServerServiceTestBase::SetUp();
 
-    mojom::WindowTreeHostFactoryPtr factory;
-    connector()->BindInterface(ui::mojom::kServiceName, &factory);
+    ui::mojom::WindowTreeHostFactoryRegistrarPtr factory_registrar;
+    connector()->BindInterface(ui::mojom::kServiceName, &factory_registrar);
 
+    mojom::WindowTreeHostFactoryPtr factory;
+    ui::mojom::WindowTreePtr window_tree;
     mojom::WindowTreeClientPtr tree_client_ptr;
     wt_client1_ = base::MakeUnique<TestWindowTreeClient>();
     wt_client1_->Bind(MakeRequest(&tree_client_ptr));
-
-    factory->CreateWindowTreeHost(MakeRequest(&host_),
-                                  std::move(tree_client_ptr));
+    factory_registrar->Register(MakeRequest(&factory),
+                                MakeRequest(&window_tree),
+                                std::move(tree_client_ptr));
+    wt_client1_->set_tree(std::move(window_tree));
+    factory->CreatePlatformWindow(MakeRequest(&host_), BuildWindowId(1, 0));
 
     // Next we should get an embed call on the "window manager" client.
     wt_client1_->WaitForOnEmbed();

--- a/services/ui/ws/window_tree_client_unittest.cc
+++ b/services/ui/ws/window_tree_client_unittest.cc
@@ -703,7 +703,9 @@ class WindowTreeClientTest : public WindowServerServiceTestBase {
                                 MakeRequest(&window_tree),
                                 std::move(tree_client_ptr));
     wt_client1_->set_tree(std::move(window_tree));
-    factory->CreatePlatformWindow(MakeRequest(&host_), BuildWindowId(1, 0));
+    std::unordered_map<std::string, std::vector<uint8_t>> transport_properties;
+    factory->CreatePlatformWindow(MakeRequest(&host_), BuildWindowId(1, 0),
+                                  transport_properties);
 
     // Next we should get an embed call on the "window manager" client.
     wt_client1_->WaitForOnEmbed();

--- a/services/ui/ws/window_tree_client_unittest.cc
+++ b/services/ui/ws/window_tree_client_unittest.cc
@@ -276,6 +276,9 @@ class TestWindowTreeClient : public mojom::WindowTreeClient,
   void OnWindowStateChanged(uint32_t window_id,
                             ::ui::mojom::ShowState state) override {}
 
+  void OnNewBoundsFromHostServer(uint32_t window,
+                                 const gfx::Rect& new_bounds) override {}
+
   // WindowTreeClient:
   void OnEmbed(
       ClientSpecificId client_id,

--- a/services/ui/ws/window_tree_host_factory.cc
+++ b/services/ui/ws/window_tree_host_factory.cc
@@ -54,6 +54,12 @@ void WindowTreeHostFactory::CreatePlatformWindow(
   } else
     metrics.bounds_in_pixels = gfx::Rect(1024, 768);
 
+  iter = properties.find(ui::mojom::WindowManager::kWindowType_InitProperty);
+  if (iter != properties.end()) {
+    metrics.window_type = static_cast<ui::mojom::WindowType>(
+        mojo::ConvertTo<int32_t>(iter->second));
+  }
+
   ws_display->Init(metrics, std::move(display_binding));
 }
 

--- a/services/ui/ws/window_tree_host_factory.cc
+++ b/services/ui/ws/window_tree_host_factory.cc
@@ -4,7 +4,9 @@
 
 #include "services/ui/ws/window_tree_host_factory.h"
 
+#include "mojo/public/cpp/bindings/map.h"
 #include "services/ui/display/viewport_metrics.h"
+#include "services/ui/public/cpp/property_type_converters.h"
 #include "services/ui/ws/display.h"
 #include "services/ui/ws/display_binding.h"
 #include "services/ui/ws/window_server.h"
@@ -26,7 +28,8 @@ void WindowTreeHostFactory::AddBinding(
 
 void WindowTreeHostFactory::CreatePlatformWindow(
     mojom::WindowTreeHostRequest tree_host_request,
-    Id transport_window_id) {
+    Id transport_window_id,
+    const TransportProperties& transport_properties) {
   WindowTree* tree = window_server_->GetTreeForExternalWindowMode();
   tree->WillCreateRootDisplay(transport_window_id);
 
@@ -36,11 +39,20 @@ void WindowTreeHostFactory::CreatePlatformWindow(
       new DisplayBindingImpl(std::move(tree_host_request), ws_display, user_id_,
                              nullptr, window_server_));
 
-  // Provide an initial size for the WindowTreeHost.
+  // Provide an initial size for the Display.
+  std::map<std::string, std::vector<uint8_t>> properties =
+      mojo::UnorderedMapToMap(transport_properties);
+
   display::ViewportMetrics metrics;
   metrics.bounds_in_pixels = gfx::Rect(1024, 768);
   metrics.device_scale_factor = 1.0f;
   metrics.ui_scale_factor = 1.0f;
+
+  auto iter = properties.find(ui::mojom::WindowManager::kBounds_InitProperty);
+  if (iter != properties.end()) {
+    metrics.bounds_in_pixels = mojo::ConvertTo<gfx::Rect>(iter->second);
+  } else
+    metrics.bounds_in_pixels = gfx::Rect(1024, 768);
 
   ws_display->Init(metrics, std::move(display_binding));
 }

--- a/services/ui/ws/window_tree_host_factory.h
+++ b/services/ui/ws/window_tree_host_factory.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 #include "mojo/public/cpp/bindings/binding_set.h"
+#include "services/ui/common/types.h"
 #include "services/ui/public/interfaces/window_tree_host.mojom.h"
 #include "services/ui/ws/user_id.h"
 
@@ -25,8 +26,8 @@ class WindowTreeHostFactory : public mojom::WindowTreeHostFactory {
 
  private:
   // mojom::WindowTreeHostFactory implementation.
-  void CreateWindowTreeHost(mojom::WindowTreeHostRequest host,
-                            mojom::WindowTreeClientPtr tree_client) override;
+  void CreatePlatformWindow(mojom::WindowTreeHostRequest tree_host_request,
+                            Id client_id) override;
 
   WindowServer* window_server_;
   const UserId user_id_;

--- a/services/ui/ws/window_tree_host_factory.h
+++ b/services/ui/ws/window_tree_host_factory.h
@@ -25,9 +25,13 @@ class WindowTreeHostFactory : public mojom::WindowTreeHostFactory {
   void AddBinding(mojom::WindowTreeHostFactoryRequest request);
 
  private:
-  // mojom::WindowTreeHostFactory implementation.
-  void CreatePlatformWindow(mojom::WindowTreeHostRequest tree_host_request,
-                            Id client_id) override;
+  using TransportProperties =
+      std::unordered_map<std::string, std::vector<uint8_t>>;
+
+  void CreatePlatformWindow(
+      mojom::WindowTreeHostRequest tree_host_request,
+      Id transport_window_id,
+      const TransportProperties& transport_properties) override;
 
   WindowServer* window_server_;
   const UserId user_id_;

--- a/services/ui/ws/window_tree_host_factory_registrar.cc
+++ b/services/ui/ws/window_tree_host_factory_registrar.cc
@@ -6,6 +6,7 @@
 
 #include "services/ui/ws/default_access_policy.h"
 #include "services/ui/ws/window_server.h"
+#include "services/ui/ws/window_server_delegate.h"
 #include "services/ui/ws/window_tree.h"
 #include "services/ui/ws/window_tree_host_factory.h"
 
@@ -50,6 +51,11 @@ void WindowTreeHostFactoryRegistrar::Register(
   window_server_->AddTree(std::move(tree), std::move(tree_binding),
                           nullptr /*mojom::WindowTreePtr*/);
   window_server_->set_window_tree_host_factory(std::move(host_factory));
+
+  // TODO(tonikitoo,msisov): Maybe remove the "window manager" suffix
+  // if the method name?
+  window_server_->delegate()->OnWillCreateTreeForWindowManager(
+      true /*automatically_create_display_roots*/);
 }
 
 }  // namespace ws

--- a/services/ui/ws/window_tree_host_factory_registrar.cc
+++ b/services/ui/ws/window_tree_host_factory_registrar.cc
@@ -4,7 +4,7 @@
 
 #include "services/ui/ws/window_tree_host_factory_registrar.h"
 
-#include "services/ui/ws/window_manager_access_policy.h"
+#include "services/ui/ws/default_access_policy.h"
 #include "services/ui/ws/window_server.h"
 #include "services/ui/ws/window_tree.h"
 #include "services/ui/ws/window_tree_host_factory.h"
@@ -31,7 +31,7 @@ void WindowTreeHostFactoryRegistrar::Register(
   // FIXME(tonikitoo,msisov,fwang): Do we need our own AccessPolicy?
   std::unique_ptr<ws::WindowTree> tree(
       new ws::WindowTree(window_server_, user_id_, nullptr /*ServerWindow*/,
-                         base::WrapUnique(new WindowManagerAccessPolicy)));
+                         base::WrapUnique(new DefaultAccessPolicy())));
 
   std::unique_ptr<ws::DefaultWindowTreeBinding> tree_binding(
       new ws::DefaultWindowTreeBinding(tree.get(), window_server_,

--- a/services/ui/ws/window_tree_host_factory_registrar.cc
+++ b/services/ui/ws/window_tree_host_factory_registrar.cc
@@ -42,12 +42,13 @@ void WindowTreeHostFactoryRegistrar::Register(
   // window mode, the WindowTreePtr is created on the aura/WindowTreeClient
   // side.
   //
-  // NOTE: This call to ::AddTree calls ::Init. However, it will not trigger a
-  // ::OnEmbed call because the WindowTree instance was created above passing
-  // 'nullptr' as the ServerWindow, hence there is no 'root' yet.
+  // NOTE: WindowServer::AddTree calls WindowTree::Init, which can trigger a
+  // WindowTreeClient::OnEmbed call. In the particular flow though, WTC::OnEmbed
+  // will not get called because the WindowTree instance was created above
+  // taking 'nullptr' as the ServerWindow parameter, hence the WindowTree has no
+  // 'root' yet.
   window_server_->AddTree(std::move(tree), std::move(tree_binding),
                           nullptr /*mojom::WindowTreePtr*/);
-
   window_server_->set_window_tree_host_factory(std::move(host_factory));
 }
 

--- a/services/ui/ws/window_tree_host_factory_registrar.cc
+++ b/services/ui/ws/window_tree_host_factory_registrar.cc
@@ -1,0 +1,55 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "services/ui/ws/window_tree_host_factory_registrar.h"
+
+#include "services/ui/ws/window_manager_access_policy.h"
+#include "services/ui/ws/window_server.h"
+#include "services/ui/ws/window_tree.h"
+#include "services/ui/ws/window_tree_host_factory.h"
+
+namespace ui {
+namespace ws {
+
+WindowTreeHostFactoryRegistrar::WindowTreeHostFactoryRegistrar(
+    WindowServer* window_server,
+    const UserId& user_id)
+    : window_server_(window_server), user_id_(user_id) {}
+
+WindowTreeHostFactoryRegistrar::~WindowTreeHostFactoryRegistrar() {}
+
+void WindowTreeHostFactoryRegistrar::Register(
+    mojom::WindowTreeHostFactoryRequest host_factory_request,
+    mojom::WindowTreeRequest tree_request,
+    mojom::WindowTreeClientPtr tree_client) {
+  std::unique_ptr<WindowTreeHostFactory> host_factory(
+      new WindowTreeHostFactory(window_server_, user_id_));
+
+  host_factory->AddBinding(std::move(host_factory_request));
+
+  // FIXME(tonikitoo,msisov,fwang): Do we need our own AccessPolicy?
+  std::unique_ptr<ws::WindowTree> tree(
+      new ws::WindowTree(window_server_, user_id_, nullptr /*ServerWindow*/,
+                         base::WrapUnique(new WindowManagerAccessPolicy)));
+
+  std::unique_ptr<ws::DefaultWindowTreeBinding> tree_binding(
+      new ws::DefaultWindowTreeBinding(tree.get(), window_server_,
+                                       std::move(tree_request),
+                                       std::move(tree_client)));
+
+  // Pass nullptr as mojom::WindowTreePtr (3rd parameter), because in external
+  // window mode, the WindowTreePtr is created on the aura/WindowTreeClient
+  // side.
+  //
+  // NOTE: This call to ::AddTree calls ::Init. However, it will not trigger a
+  // ::OnEmbed call because the WindowTree instance was created above passing
+  // 'nullptr' as the ServerWindow, hence there is no 'root' yet.
+  window_server_->AddTree(std::move(tree), std::move(tree_binding),
+                          nullptr /*mojom::WindowTreePtr*/);
+
+  window_server_->set_window_tree_host_factory(std::move(host_factory));
+}
+
+}  // namespace ws
+}  // namespace ui

--- a/services/ui/ws/window_tree_host_factory_registrar.h
+++ b/services/ui/ws/window_tree_host_factory_registrar.h
@@ -1,0 +1,39 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SERVICES_UI_WS_WINDOW_TREE_HOST_FACTORY_REGISTRAR_H_
+#define SERVICES_UI_WS_WINDOW_TREE_HOST_FACTORY_REGISTRAR_H_
+
+#include "services/ui/public/interfaces/window_tree_host.mojom.h"
+#include "services/ui/ws/user_id.h"
+
+namespace ui {
+namespace ws {
+
+class WindowServer;
+
+class WindowTreeHostFactoryRegistrar
+    : public mojom::WindowTreeHostFactoryRegistrar {
+ public:
+  WindowTreeHostFactoryRegistrar(WindowServer* window_server,
+                                 const UserId& user_id);
+  ~WindowTreeHostFactoryRegistrar() override;
+
+  const UserId& user_id() const { return user_id_; }
+
+ private:
+  void Register(mojom::WindowTreeHostFactoryRequest,
+                mojom::WindowTreeRequest tree_request,
+                mojom::WindowTreeClientPtr tree_client) override;
+
+  WindowServer* window_server_;
+  const UserId user_id_;
+
+  DISALLOW_COPY_AND_ASSIGN(WindowTreeHostFactoryRegistrar);
+};
+
+}  // namespace ws
+}  // namespace ui
+
+#endif  // SERVICES_UI_WS_WINDOW_TREE_HOST_FACTORY_REGISTRAR_H_

--- a/ui/aura/local/window_port_local.cc
+++ b/ui/aura/local/window_port_local.cc
@@ -138,4 +138,6 @@ void WindowPortLocal::OnSurfaceChanged(const cc::SurfaceId& surface_id,
           ->reference_factory());
 }
 
+void WindowPortLocal::OnWillHideNativeWindow() {}
+
 }  // namespace aura

--- a/ui/aura/local/window_port_local.h
+++ b/ui/aura/local/window_port_local.h
@@ -44,6 +44,8 @@ class AURA_EXPORT WindowPortLocal : public WindowPort {
   void OnWindowAddedToRootWindow() override;
   void OnWillRemoveWindowFromRootWindow() override;
 
+  void OnWillHideNativeWindow() override;
+
  private:
   void OnSurfaceChanged(const cc::SurfaceId& surface_id,
                         const gfx::Size& surface_size);

--- a/ui/aura/mus/window_port_mus.cc
+++ b/ui/aura/mus/window_port_mus.cc
@@ -505,6 +505,10 @@ cc::SurfaceId WindowPortMus::GetSurfaceId() const {
   return cc::SurfaceId();
 }
 
+void WindowPortMus::OnWillHideNativeWindow() {
+  window_tree_client_->OnWindowMusHideNativeWindow(this);
+}
+
 void WindowPortMus::UpdatePrimarySurfaceInfo() {
   bool embeds_surface = window_mus_type() == WindowMusType::TOP_LEVEL_IN_WM ||
                         window_mus_type() == WindowMusType::EMBED_IN_OWNER;

--- a/ui/aura/mus/window_port_mus.h
+++ b/ui/aura/mus/window_port_mus.h
@@ -258,6 +258,7 @@ class AURA_EXPORT WindowPortMus : public WindowPort, public WindowMus {
   cc::SurfaceId GetSurfaceId() const override;
   void OnWindowAddedToRootWindow() override {}
   void OnWillRemoveWindowFromRootWindow() override {}
+  void OnWillHideNativeWindow() override;
 
   void UpdatePrimarySurfaceInfo();
   void UpdateClientSurfaceEmbedder();

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -2013,7 +2013,7 @@ std::unique_ptr<WindowPortMus> WindowTreeClient::CreateWindowPortForTopLevel(
     // Ends up calling back to client side, aura::WindowTreeClient::OnEmbed.
     ui::mojom::WindowTreeHostPtr host;
     window_tree_host_factory_ptr_->CreatePlatformWindow(
-        MakeRequest(&host), window_port->server_id());
+        MakeRequest(&host), window_port->server_id(), transport_properties);
   } else {
     const uint32_t change_id =
         ScheduleInFlightChange(base::MakeUnique<CrashInFlightChange>(

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -1172,6 +1172,17 @@ void WindowTreeClient::OnWindowBoundsChanged(
   SetWindowBoundsFromServer(window, new_bounds, local_surface_id);
 }
 
+void WindowTreeClient::OnNewBoundsFromHostServer(Id window_id,
+                                                 const gfx::Rect& new_bounds) {
+  WindowMus* window = GetWindowByServerId(window_id);
+  if (!window || !IsRoot(window))
+    return;
+
+  // WindowTreeHost expects bounds to be in pixels.
+  WindowTreeHostMus* host = GetWindowTreeHostMus(window);
+  host->SetBoundsInPixels(new_bounds);
+}
+
 void WindowTreeClient::OnClientAreaChanged(
     uint32_t window_id,
     const gfx::Insets& new_client_area,

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -513,9 +513,17 @@ void WindowTreeClient::ConfigureWindowDataFromServer(
     SetWindowVisibleFromServer(WindowMus::Get(window_tree_host->window()),
                                true);
   }
+  gfx::Rect new_bounds = window_data.bounds;
+  // Disallow changing StubWindow's bounds in external window mode as long
+  // as the StubWindow's bounds are used as a origin reference of a real
+  // native window.
+  if (in_external_window_mode_ && new_bounds.origin() == gfx::Point()) {
+    gfx::Point old_origin = window_tree_host->GetBoundsInPixels().origin();
+    new_bounds.set_origin(old_origin);
+  }
   WindowMus* window = WindowMus::Get(window_tree_host->window());
 
-  SetWindowBoundsFromServer(window, window_data.bounds, local_surface_id);
+  SetWindowBoundsFromServer(window, new_bounds, local_surface_id);
   ui::Compositor* compositor =
       window_tree_host->window()->GetHost()->compositor();
   compositor->AddObserver(this);

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -210,6 +210,7 @@ WindowTreeClient::WindowTreeClient(
       binding_(this),
       tree_(nullptr),
       in_destructor_(false),
+      in_external_window_mode_(false),
       weak_factory_(this) {
   DCHECK(delegate_);
   // Allow for a null request in tests.
@@ -273,6 +274,22 @@ WindowTreeClient::~WindowTreeClient() {
       env->context_factory() == compositor_context_factory_.get()) {
     env->set_context_factory(initial_context_factory_);
   }
+}
+
+void WindowTreeClient::ConnectViaWindowTreeHostFactory() {
+  // The client id doesn't really matter, we use 101 purely for debugging.
+  client_id_ = 101;
+
+  ui::mojom::WindowTreeHostFactoryRegistrarPtr host_factory_registrar;
+  connector_->BindInterface(ui::mojom::kServiceName, &host_factory_registrar);
+
+  ui::mojom::WindowTreePtr window_tree;
+  host_factory_registrar->Register(MakeRequest(&window_tree_host_factory_ptr_),
+                                   MakeRequest(&window_tree),
+                                   binding_.CreateInterfacePtrAndBind());
+  SetWindowTree(std::move(window_tree));
+
+  in_external_window_mode_ = true;
 }
 
 void WindowTreeClient::ConnectViaWindowTreeFactory() {
@@ -480,6 +497,16 @@ std::unique_ptr<WindowTreeHostMus> WindowTreeClient::CreateWindowTreeHost(
   std::unique_ptr<WindowTreeHostMus> window_tree_host =
       base::MakeUnique<WindowTreeHostMus>(std::move(init_params));
   window_tree_host->InitHost();
+
+  ConfigureWindowDataFromServer(window_tree_host.get(), window_data,
+                                local_surface_id);
+  return window_tree_host;
+}
+
+void WindowTreeClient::ConfigureWindowDataFromServer(
+    WindowTreeHostMus* window_tree_host,
+    const ui::mojom::WindowData& window_data,
+    const base::Optional<cc::LocalSurfaceId>& local_surface_id) {
   SetLocalPropertiesFromServerProperties(
       WindowMus::Get(window_tree_host->window()), window_data);
   if (window_data.visible) {
@@ -492,7 +519,6 @@ std::unique_ptr<WindowTreeHostMus> WindowTreeClient::CreateWindowTreeHost(
   ui::Compositor* compositor =
       window_tree_host->window()->GetHost()->compositor();
   compositor->AddObserver(this);
-  return window_tree_host;
 }
 
 WindowMus* WindowTreeClient::NewWindowFromWindowData(
@@ -972,7 +998,32 @@ void WindowTreeClient::OnEmbed(
     Id focused_window_id,
     bool drawn,
     const base::Optional<cc::LocalSurfaceId>& local_surface_id) {
+  if (in_external_window_mode_) {
+    client_id_ = client_id;
+
+    // No need to set 'tree_ptr_' whether it was already set during
+    // ConnectViaWindowManagerHostFactory.
+    DCHECK(tree_ptr_);
+    DCHECK(!tree);
+
+    auto it = windows_.find(focused_window_id);
+    DCHECK(it != windows_.end());
+
+    WindowTreeHostMus* window_tree_host = GetWindowTreeHostMus(it->second);
+    window_tree_host->InitHost();
+    ConfigureWindowDataFromServer(window_tree_host, *root_data,
+                                  local_surface_id);
+
+    // TODO(tonikitoo): Fix the WindowTreeClientDelegate::OnEmbed API.
+    // In external window mode, this needs not to pass the ownership of the
+    // WindowTreeHostMus instance to the delegate_. A raw pointer should
+    // surface.
+    delegate_->OnEmbed(nullptr);
+    return;
+  }
+
   DCHECK(!tree_ptr_);
+  DCHECK(tree);
   tree_ptr_ = std::move(tree);
 
   is_from_embed_ = true;
@@ -1941,8 +1992,12 @@ void WindowTreeClient::OnWindowTreeHostCancelWindowMove(
 
 std::unique_ptr<WindowPortMus> WindowTreeClient::CreateWindowPortForTopLevel(
     const std::map<std::string, std::vector<uint8_t>>* properties) {
+  WindowMusType window_type = in_external_window_mode_
+                                  ? WindowMusType::EMBED
+                                  : WindowMusType::TOP_LEVEL;
+
   std::unique_ptr<WindowPortMus> window_port =
-      base::MakeUnique<WindowPortMus>(this, WindowMusType::TOP_LEVEL);
+      base::MakeUnique<WindowPortMus>(this, window_type);
   roots_.insert(window_port.get());
 
   window_port->set_server_id(MakeTransportId(client_id_, next_window_id_++));
@@ -1954,11 +2009,21 @@ std::unique_ptr<WindowPortMus> WindowTreeClient::CreateWindowPortForTopLevel(
       transport_properties[property_pair.first] = property_pair.second;
   }
 
-  const uint32_t change_id =
-      ScheduleInFlightChange(base::MakeUnique<CrashInFlightChange>(
-          window_port.get(), ChangeType::NEW_TOP_LEVEL_WINDOW));
-  tree_->NewTopLevelWindow(change_id, window_port->server_id(),
-                           transport_properties);
+  if (in_external_window_mode_) {
+    // Triggers the creation of a mojom::WindowTreeHost (aka ws::Display)
+    // instance on the server side.
+    // Ends up calling back to client side, aura::WindowTreeClient::OnEmbed.
+    ui::mojom::WindowTreeHostPtr host;
+    window_tree_host_factory_ptr_->CreatePlatformWindow(
+        MakeRequest(&host), window_port->server_id());
+  } else {
+    const uint32_t change_id =
+        ScheduleInFlightChange(base::MakeUnique<CrashInFlightChange>(
+            window_port.get(), ChangeType::NEW_TOP_LEVEL_WINDOW));
+    tree_->NewTopLevelWindow(change_id, window_port->server_id(),
+                             transport_properties);
+  }
+
   return window_port;
 }
 

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -1528,6 +1528,36 @@ void WindowTreeClient::OnChangeCompleted(uint32_t change_id, bool success) {
   }
 }
 
+void WindowTreeClient::OnWindowStateChanged(uint32_t window_id,
+                                            ui::mojom::ShowState state) {
+  DCHECK(in_external_window_mode_);
+  WindowMus* window = GetWindowByServerId(window_id);
+  if (!window || !IsRoot(window))
+    return;
+
+  aura::Window* aura_window = window->GetWindow();
+  WindowTreeHostMus* host = GetWindowTreeHostMus(aura_window);
+  ui::WindowShowState show_state;
+  switch (state) {
+    case (ui::mojom::ShowState::MINIMIZED):
+      show_state = ui::SHOW_STATE_MINIMIZED;
+      host->Hide();
+      break;
+    case (ui::mojom::ShowState::MAXIMIZED):
+      show_state = ui::SHOW_STATE_MAXIMIZED;
+      host->Show();
+      break;
+    case (ui::mojom::ShowState::NORMAL):
+      show_state = ui::SHOW_STATE_NORMAL;
+      host->Show();
+      break;
+    default:
+      return;
+  }
+
+  aura_window->SetProperty(aura::client::kShowStateKey, show_state);
+}
+
 void WindowTreeClient::GetWindowManager(
     mojo::AssociatedInterfaceRequest<WindowManager> internal) {
   window_manager_internal_.reset(

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -708,7 +708,15 @@ void WindowTreeClient::ScheduleInFlightBoundsChange(
     local_surface_id = window->GetOrAllocateLocalSurfaceId(new_bounds.size());
     synchronizing_with_child_on_next_frame_ = true;
   }
-  tree_->SetWindowBounds(change_id, window->server_id(), new_bounds,
+
+  gfx::Rect newest_bounds = new_bounds;
+  // TODO(msisov): figure out why this stops settings bounds of
+  // ServerWindow for additional windows like menus, but still
+  // doesn't break clicking functionality and still let's
+  // main chrome window to set bounds to 10:10, for example.
+  if (window->window_mus_type() == WindowMusType::EMBED)
+    newest_bounds.set_origin(gfx::Point());
+  tree_->SetWindowBounds(change_id, window->server_id(), newest_bounds,
                          local_surface_id);
 }
 

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -1014,11 +1014,9 @@ void WindowTreeClient::OnEmbed(
     ConfigureWindowDataFromServer(window_tree_host, *root_data,
                                   local_surface_id);
 
-    // TODO(tonikitoo): Fix the WindowTreeClientDelegate::OnEmbed API.
-    // In external window mode, this needs not to pass the ownership of the
-    // WindowTreeHostMus instance to the delegate_. A raw pointer should
-    // surface.
-    delegate_->OnEmbed(nullptr);
+    // Pass a raw pointer to WindowTreeHostMus, which helps delegate to identify
+    // which WindowTreeHostMus to use in case if there are many of them.
+    delegate_->OnEmbedRootReady(window_tree_host);
     return;
   }
 

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -927,6 +927,11 @@ void WindowTreeClient::OnWindowMusPropertyChanged(
                            transport_value_mojo);
 }
 
+void WindowTreeClient::OnWindowMusHideNativeWindow(WindowMus* window) {
+  DCHECK(tree_);
+  tree_->SetNativeWindowHidden(window->server_id());
+}
+
 void WindowTreeClient::OnWmMoveLoopCompleted(uint32_t change_id,
                                              bool completed) {
   if (window_manager_client_)

--- a/ui/aura/mus/window_tree_client.h
+++ b/ui/aura/mus/window_tree_client.h
@@ -324,6 +324,7 @@ class AURA_EXPORT WindowTreeClient
                                   const void* key,
                                   int64_t old_value,
                                   std::unique_ptr<ui::PropertyData> data);
+  void OnWindowMusHideNativeWindow(WindowMus* window);
 
   // Callback passed from WmPerformMoveLoop().
   void OnWmMoveLoopCompleted(uint32_t change_id, bool completed);

--- a/ui/aura/mus/window_tree_client.h
+++ b/ui/aura/mus/window_tree_client.h
@@ -419,6 +419,8 @@ class AURA_EXPORT WindowTreeClient
                                   uint32_t action_taken) override;
   void OnDragDropDone() override;
   void OnChangeCompleted(uint32_t change_id, bool success) override;
+  void OnWindowStateChanged(uint32_t window_id,
+                            ui::mojom::ShowState state) override;
   void RequestClose(uint32_t window_id) override;
   void GetWindowManager(
       mojo::AssociatedInterfaceRequest<WindowManager> internal) override;

--- a/ui/aura/mus/window_tree_client.h
+++ b/ui/aura/mus/window_tree_client.h
@@ -23,6 +23,7 @@
 #include "mojo/public/cpp/bindings/associated_binding.h"
 #include "mojo/public/cpp/bindings/strong_binding.h"
 #include "services/ui/public/interfaces/window_tree.mojom.h"
+#include "services/ui/public/interfaces/window_tree_host.mojom.h"
 #include "ui/aura/aura_export.h"
 #include "ui/aura/client/transient_window_client_observer.h"
 #include "ui/aura/mus/capture_synchronizer_delegate.h"
@@ -114,6 +115,9 @@ class AURA_EXPORT WindowTreeClient
 
   // Establishes the connection by way of the WindowTreeFactory.
   void ConnectViaWindowTreeFactory();
+
+  // Establishes the connection by way of the WindowTreeFactoryHost.
+  void ConnectViaWindowTreeHostFactory();
 
   // Establishes the connection by way of WindowManagerWindowTreeFactory.
   // See mojom for details on |automatically_create_display_roots|.
@@ -240,6 +244,11 @@ class AURA_EXPORT WindowTreeClient
       int64_t display_id,
       const base::Optional<cc::LocalSurfaceId>& local_surface_id =
           base::nullopt);
+
+  void ConfigureWindowDataFromServer(
+      WindowTreeHostMus* window_tree_host,
+      const ui::mojom::WindowData& window_data,
+      const base::Optional<cc::LocalSurfaceId>& local_surface_id);
 
   WindowMus* NewWindowFromWindowData(WindowMus* parent,
                                      const ui::mojom::WindowData& window_data);
@@ -595,6 +604,8 @@ class AURA_EXPORT WindowTreeClient
 
   bool has_pointer_watcher_ = false;
 
+  bool in_external_window_mode_ = false;
+
   // The current change id for the client.
   uint32_t current_move_loop_change_ = 0u;
 
@@ -633,6 +644,8 @@ class AURA_EXPORT WindowTreeClient
   bool holding_pointer_moves_ = false;
 
   gfx::Insets normal_client_area_insets_;
+
+  ui::mojom::WindowTreeHostFactoryPtr window_tree_host_factory_ptr_;
 
   base::WeakPtrFactory<WindowTreeClient> weak_factory_;
 

--- a/ui/aura/mus/window_tree_client.h
+++ b/ui/aura/mus/window_tree_client.h
@@ -354,6 +354,8 @@ class AURA_EXPORT WindowTreeClient
       const gfx::Rect& old_bounds,
       const gfx::Rect& new_bounds,
       const base::Optional<cc::LocalSurfaceId>& local_surface_id) override;
+  void OnNewBoundsFromHostServer(Id window_id,
+                                 const gfx::Rect& new_bounds) override;
   void OnClientAreaChanged(
       uint32_t window_id,
       const gfx::Insets& new_client_area,

--- a/ui/aura/mus/window_tree_client_delegate.cc
+++ b/ui/aura/mus/window_tree_client_delegate.cc
@@ -8,4 +8,7 @@ namespace aura {
 
 void WindowTreeClientDelegate::OnUnembed(Window* root) {}
 
+void WindowTreeClientDelegate::OnEmbedRootReady(
+    WindowTreeHostMus* window_tree_host) {}
+
 }  // namespace aura

--- a/ui/aura/mus/window_tree_client_delegate.h
+++ b/ui/aura/mus/window_tree_client_delegate.h
@@ -27,6 +27,10 @@ class AURA_EXPORT WindowTreeClientDelegate {
   // InterfaceRequest.
   virtual void OnEmbed(std::unique_ptr<WindowTreeHostMus> window_tree_host) = 0;
 
+  // Called when the application implementing this interface is embedded and
+  // uses external window mode.
+  virtual void OnEmbedRootReady(WindowTreeHostMus* window_tree_host);
+
   // Sent when another app is embedded in |root| (one of the roots of the
   // connection). Afer this call |root| is deleted. If the associated
   // WindowTreeClient was created from a WindowTreeClientRequest then

--- a/ui/aura/mus/window_tree_host_mus.cc
+++ b/ui/aura/mus/window_tree_host_mus.cc
@@ -165,6 +165,10 @@ WindowTreeHostMus::ReleaseDisplayInitParams() {
 void WindowTreeHostMus::HideImpl() {
   WindowTreeHostPlatform::HideImpl();
   window()->Hide();
+
+  WindowPortMus* window_port = WindowPortMus::Get(window());
+  if (window_port)
+    window_port->OnWillHideNativeWindow();
 }
 
 void WindowTreeHostMus::SetBoundsInPixels(const gfx::Rect& bounds) {

--- a/ui/aura/test/mus/test_window_tree.cc
+++ b/ui/aura/test/mus/test_window_tree.cc
@@ -173,6 +173,8 @@ void TestWindowTree::SetWindowProperty(
   OnChangeReceived(change_id, WindowTreeChangeType::PROPERTY);
 }
 
+void TestWindowTree::SetNativeWindowHidden(Id window_id) {}
+
 void TestWindowTree::SetWindowOpacity(uint32_t change_id,
                                       uint32_t window_id,
                                       float opacity) {

--- a/ui/aura/test/mus/test_window_tree.h
+++ b/ui/aura/test/mus/test_window_tree.h
@@ -140,6 +140,7 @@ class TestWindowTree : public ui::mojom::WindowTree {
       uint32_t window_id,
       const std::string& name,
       const base::Optional<std::vector<uint8_t>>& value) override;
+  void SetNativeWindowHidden(Id window_id) override;
   void SetWindowOpacity(uint32_t change_id,
                         uint32_t window_id,
                         float opacity) override;

--- a/ui/aura/window_port.h
+++ b/ui/aura/window_port.h
@@ -86,6 +86,8 @@ class AURA_EXPORT WindowPort {
   virtual void OnWindowAddedToRootWindow() = 0;
   virtual void OnWillRemoveWindowFromRootWindow() = 0;
 
+  virtual void OnWillHideNativeWindow() = 0;
+
  protected:
   // Returns the WindowPort associated with a Window.
   static WindowPort* Get(Window* window);

--- a/ui/events/platform/x11/x11_event_source_libevent.cc
+++ b/ui/events/platform/x11/x11_event_source_libevent.cc
@@ -158,7 +158,8 @@ void X11EventSourceLibevent::RemoveXEventDispatcher(
 void X11EventSourceLibevent::ProcessXEvent(XEvent* xevent) {
   std::unique_ptr<ui::Event> translated_event = TranslateXEventToEvent(*xevent);
   if (translated_event) {
-    DispatchEvent(translated_event.get());
+    EventWithPlatformEvent ewxe = {translated_event.get(), xevent};
+    DispatchEvent(&ewxe);
   } else {
     // Only if we can't translate XEvent into ui::Event, try to dispatch XEvent
     // directly to XEventDispatchers.

--- a/ui/events/platform/x11/x11_event_source_libevent.h
+++ b/ui/events/platform/x11/x11_event_source_libevent.h
@@ -13,6 +13,13 @@
 
 namespace ui {
 
+class Event;
+
+struct EVENTS_EXPORT EventWithPlatformEvent {
+  Event* event;
+  PlatformEvent platform_event;
+};
+
 // Interface for classes that want to receive XEvent directly. Only used with
 // Ozone X11 currently and only events that can't be translated into ui::Events
 // are sent via this path.

--- a/ui/ozone/platform/headless/ozone_platform_headless.cc
+++ b/ui/ozone/platform/headless/ozone_platform_headless.cc
@@ -98,6 +98,12 @@ class OzonePlatformHeadless : public OzonePlatform {
       surface_factory_.reset(new HeadlessSurfaceFactory());
   }
 
+  void QueryHostDisplaysData(QueryHostDisplaysDataCallback callback) override {
+    DCHECK(!callback.is_null());
+
+    // For now just use a random resolution so that unit tests pass.
+    callback.Run(std::vector<gfx::Size>(1, gfx::Size(1024, 768)));
+  }
  private:
   std::unique_ptr<HeadlessWindowManager> window_manager_;
   std::unique_ptr<HeadlessSurfaceFactory> surface_factory_;

--- a/ui/ozone/platform/wayland/BUILD.gn
+++ b/ui/ozone/platform/wayland/BUILD.gn
@@ -5,9 +5,16 @@
 visibility = [ "//ui/ozone/*" ]
 
 import("//build/config/linux/pkg_config.gni")
+import("//ui/base/ui_features.gni")
 
 pkg_config("wayland-egl") {
   packages = [ "wayland-egl" ]
+}
+
+if (use_xkbcommon) {
+  pkg_config("xkbcommon") {
+    packages = [ "xkbcommon" ]
+  }
 }
 
 source_set("wayland") {
@@ -34,12 +41,12 @@ source_set("wayland") {
     "wayland_window.h",
   ]
 
-  import("//ui/base/ui_features.gni")
   if (use_xkbcommon) {
     sources += [
       "wayland_xkb_keyboard_layout_engine.cc",
       "wayland_xkb_keyboard_layout_engine.h",
     ]
+    configs += [ ":xkbcommon" ]
   }
 
   deps = [

--- a/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+++ b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
@@ -74,6 +74,19 @@ class OzonePlatformWayland : public OzonePlatform {
     return base::MakeUnique<display::FakeDisplayDelegate>();
   }
 
+  void QueryHostDisplaysData(QueryHostDisplaysDataCallback callback) override {
+    // On Wayland, the screen dimensions come from WaylandOutput.
+    DCHECK(connection_->PrimaryOutput());
+    if (connection_->PrimaryOutput()) {
+      DCHECK(!callback.is_null());
+      gfx::Rect geometry = connection_->PrimaryOutput()->Geometry();
+      callback.Run(std::vector<gfx::Size>(1, geometry.size()));
+      return;
+    }
+
+    CHECK(false) << "Add support for asynchronous resolution fetch.";
+  }
+
   void InitializeUI(const InitParams& args) override {
     connection_.reset(new WaylandConnection);
     if (!connection_->Initialize())

--- a/ui/ozone/platform/wayland/wayland_connection.cc
+++ b/ui/ozone/platform/wayland/wayland_connection.cc
@@ -196,6 +196,10 @@ void WaylandConnection::Global(void* data,
 
     connection->output_list_.push_back(
         base::WrapUnique(new WaylandOutput(output.release())));
+
+    // By the time the Wayland output is instantiated, it must be able
+    // to receive and process events from the Wayland server.
+    connection->StartProcessingEvents();
   }
 
   connection->ScheduleFlush();

--- a/ui/ozone/platform/wayland/wayland_connection.cc
+++ b/ui/ozone/platform/wayland/wayland_connection.cc
@@ -103,7 +103,7 @@ WaylandWindow* WaylandConnection::GetWindow(gfx::AcceleratedWidget widget) {
 WaylandWindow* WaylandConnection::GetCurrentFocusedWindow() {
   for (auto entry : window_map_) {
     WaylandWindow* window = entry.second;
-    if (window->has_pointer_or_keyboard_focus())
+    if (window->has_pointer_focus())
       return window;
   }
   return nullptr;

--- a/ui/ozone/platform/wayland/wayland_connection.cc
+++ b/ui/ozone/platform/wayland/wayland_connection.cc
@@ -100,6 +100,15 @@ WaylandWindow* WaylandConnection::GetWindow(gfx::AcceleratedWidget widget) {
   return it == window_map_.end() ? nullptr : it->second;
 }
 
+WaylandWindow* WaylandConnection::GetCurrentFocusedWindow() {
+  for (auto entry : window_map_) {
+    WaylandWindow* window = entry.second;
+    if (window->has_pointer_or_keyboard_focus())
+      return window;
+  }
+  return nullptr;
+}
+
 void WaylandConnection::AddWindow(gfx::AcceleratedWidget widget,
                                   WaylandWindow* window) {
   window_map_[widget] = window;
@@ -227,6 +236,7 @@ void WaylandConnection::Capabilities(void* data,
       connection->pointer_ = base::MakeUnique<WaylandPointer>(
           pointer, base::Bind(&WaylandConnection::DispatchUiEvent,
                               base::Unretained(connection)));
+      connection->pointer_->set_connection(connection);
     }
   } else if (connection->pointer_) {
     connection->pointer_.reset();
@@ -241,6 +251,7 @@ void WaylandConnection::Capabilities(void* data,
       connection->keyboard_ = base::MakeUnique<WaylandKeyboard>(
           keyboard, base::Bind(&WaylandConnection::DispatchUiEvent,
                                base::Unretained(connection)));
+      connection->keyboard_->set_connection(connection);
     }
   } else if (connection->keyboard_) {
     connection->keyboard_.reset();

--- a/ui/ozone/platform/wayland/wayland_connection.h
+++ b/ui/ozone/platform/wayland/wayland_connection.h
@@ -35,13 +35,18 @@ class WaylandConnection : public PlatformEventSource,
   wl_compositor* compositor() { return compositor_.get(); }
   wl_shm* shm() { return shm_.get(); }
   xdg_shell* shell() { return shell_.get(); }
+  wl_seat* seat() { return seat_.get(); }
 
   WaylandWindow* GetWindow(gfx::AcceleratedWidget widget);
+  WaylandWindow* GetCurrentFocusedWindow();
   void AddWindow(gfx::AcceleratedWidget widget, WaylandWindow* window);
   void RemoveWindow(gfx::AcceleratedWidget widget);
 
   const std::vector<std::unique_ptr<WaylandOutput>>& GetOutputList() const;
   WaylandOutput* PrimaryOutput() const;
+
+  void set_serial(uint32_t serial) { serial_ = serial; }
+  uint32_t serial() { return serial_; }
 
  private:
   void Flush();
@@ -86,6 +91,8 @@ class WaylandConnection : public PlatformEventSource,
   base::MessagePumpLibevent::FileDescriptorWatcher controller_;
 
   std::vector<std::unique_ptr<WaylandOutput>> output_list_;
+
+  uint32_t serial_ = 0;
 
   DISALLOW_COPY_AND_ASSIGN(WaylandConnection);
 };

--- a/ui/ozone/platform/wayland/wayland_keyboard.h
+++ b/ui/ozone/platform/wayland/wayland_keyboard.h
@@ -10,10 +10,16 @@
 
 namespace ui {
 
+class WaylandConnection;
+
 class WaylandKeyboard {
  public:
   WaylandKeyboard(wl_keyboard* keyboard, const EventDispatchCallback& callback);
   virtual ~WaylandKeyboard();
+
+  void set_connection(WaylandConnection* connection) {
+    connection_ = connection;
+  }
 
  private:
   // wl_keyboard_listener
@@ -49,6 +55,9 @@ class WaylandKeyboard {
                          int32_t rate,
                          int32_t delay);
 
+  void SetSerial(uint32_t serial);
+
+  WaylandConnection* connection_ = nullptr;
   wl::Object<wl_keyboard> obj_;
   EventDispatchCallback callback_;
   uint8_t modifiers_ = 0;

--- a/ui/ozone/platform/wayland/wayland_object.cc
+++ b/ui/ozone/platform/wayland/wayland_object.cc
@@ -78,4 +78,7 @@ const wl_interface* ObjectTraits<xdg_surface>::interface =
     &xdg_surface_interface;
 void (*ObjectTraits<xdg_surface>::deleter)(xdg_surface*) = &xdg_surface_destroy;
 
+const wl_interface* ObjectTraits<xdg_popup>::interface = &xdg_popup_interface;
+void (*ObjectTraits<xdg_popup>::deleter)(xdg_popup*) = &xdg_popup_destroy;
+
 }  // namespace wl

--- a/ui/ozone/platform/wayland/wayland_object.h
+++ b/ui/ozone/platform/wayland/wayland_object.h
@@ -21,6 +21,7 @@ struct wl_shm_pool;
 struct wl_surface;
 struct xdg_shell;
 struct xdg_surface;
+struct xdg_popup;
 
 namespace wl {
 
@@ -103,6 +104,12 @@ template <>
 struct ObjectTraits<xdg_surface> {
   static const wl_interface* interface;
   static void (*deleter)(xdg_surface*);
+};
+
+template <>
+struct ObjectTraits<xdg_popup> {
+  static const wl_interface* interface;
+  static void (*deleter)(xdg_popup*);
 };
 
 struct Deleter {

--- a/ui/ozone/platform/wayland/wayland_pointer.cc
+++ b/ui/ozone/platform/wayland/wayland_pointer.cc
@@ -8,6 +8,7 @@
 #include <wayland-client.h>
 
 #include "ui/events/event.h"
+#include "ui/ozone/platform/wayland/wayland_connection.h"
 #include "ui/ozone/platform/wayland/wayland_window.h"
 
 // TODO(forney): Handle version 5 of wl_pointer.
@@ -35,6 +36,7 @@ void WaylandPointer::Enter(void* data,
                            wl_fixed_t surface_x,
                            wl_fixed_t surface_y) {
   WaylandPointer* pointer = static_cast<WaylandPointer*>(data);
+  pointer->SetSerial(serial);
   pointer->location_.SetPoint(wl_fixed_to_double(surface_x),
                               wl_fixed_to_double(surface_y));
   if (surface)
@@ -46,6 +48,8 @@ void WaylandPointer::Leave(void* data,
                            wl_pointer* obj,
                            uint32_t serial,
                            wl_surface* surface) {
+  WaylandPointer* pointer = static_cast<WaylandPointer*>(data);
+  pointer->SetSerial(serial);
   if (surface)
     WaylandWindow::FromSurface(surface)->set_pointer_focus(false);
 }
@@ -75,6 +79,7 @@ void WaylandPointer::Button(void* data,
                             uint32_t button,
                             uint32_t state) {
   WaylandPointer* pointer = static_cast<WaylandPointer*>(data);
+  pointer->SetSerial(serial);
   int flag;
   switch (button) {
     case BTN_LEFT:
@@ -141,6 +146,11 @@ void WaylandPointer::Axis(void* data,
   event.set_location_f(pointer->location_);
   event.set_root_location_f(pointer->location_);
   pointer->callback_.Run(&event);
+}
+
+void WaylandPointer::SetSerial(uint32_t serial) {
+  DCHECK(connection_);
+  connection_->set_serial(serial);
 }
 
 }  // namespace ui

--- a/ui/ozone/platform/wayland/wayland_pointer.h
+++ b/ui/ozone/platform/wayland/wayland_pointer.h
@@ -11,10 +11,16 @@
 
 namespace ui {
 
+class WaylandConnection;
+
 class WaylandPointer {
  public:
   WaylandPointer(wl_pointer* pointer, const EventDispatchCallback& callback);
   virtual ~WaylandPointer();
+
+  void set_connection(WaylandConnection* connection) {
+    connection_ = connection;
+  }
 
  private:
   // wl_pointer_listener
@@ -45,6 +51,9 @@ class WaylandPointer {
                    uint32_t axis,
                    wl_fixed_t value);
 
+  void SetSerial(uint32_t serial);
+
+  WaylandConnection* connection_ = nullptr;
   wl::Object<wl_pointer> obj_;
   EventDispatchCallback callback_;
   gfx::PointF location_;

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -45,7 +45,10 @@ bool WaylandWindow::Initialize() {
   }
   wl_surface_set_user_data(surface_.get(), this);
 
-  ui::mojom::WindowType window_type;
+  // There is now default initialization for this type. Initialize it
+  // to ::WINDOW here. It will be changed by delelgate if it know the
+  // type of the window.
+  ui::mojom::WindowType window_type = ui::mojom::WindowType::WINDOW;
   delegate_->GetWindowType(&window_type);
   if (window_type == ui::mojom::WindowType::WINDOW) {
     xdg_surface_.reset(

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -249,7 +249,7 @@ void WaylandWindow::ConvertEventLocationToCurrentWindowLocation(
     ui::Event* event) {
   WaylandWindow* wayland_window = connection_->GetCurrentFocusedWindow();
   DCHECK_NE(wayland_window, this);
-  if (event->IsLocatedEvent()) {
+  if (wayland_window && event->IsLocatedEvent()) {
     gfx::Vector2d offset =
         wayland_window->GetBounds().origin() - GetBounds().origin();
     ui::LocatedEvent* located_event = event->AsLocatedEvent();

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -44,13 +44,20 @@ bool WaylandWindow::Initialize() {
     return false;
   }
   wl_surface_set_user_data(surface_.get(), this);
-  xdg_surface_.reset(
-      xdg_shell_get_xdg_surface(connection_->shell(), surface_.get()));
-  if (!xdg_surface_) {
-    LOG(ERROR) << "Failed to create xdg_surface";
+
+  ui::mojom::WindowType window_type;
+  delegate_->GetWindowType(&window_type);
+  if (window_type == ui::mojom::WindowType::WINDOW) {
+    xdg_surface_.reset(
+        xdg_shell_get_xdg_surface(connection_->shell(), surface_.get()));
+    if (!xdg_surface_) {
+      LOG(ERROR) << "Failed to create xdg_surface";
+      return false;
+    }
+    xdg_surface_add_listener(xdg_surface_.get(), &xdg_surface_listener, this);
+  } else {
     return false;
   }
-  xdg_surface_add_listener(xdg_surface_.get(), &xdg_surface_listener, this);
   connection_->ScheduleFlush();
 
   connection_->AddWindow(surface_.id(), this);

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -15,6 +15,24 @@
 
 namespace ui {
 
+namespace {
+
+static WaylandWindow* g_current_capture_ = nullptr;
+
+static const xdg_popup_listener xdg_popup_listener = {
+    &WaylandWindow::PopupDone,
+};
+
+// TODO(msisov, tonikitoo): fix customization according to screen resolution
+// once we are able to get global coordinates of wayland windows.
+gfx::Rect TranslateBoundsToScreenCoordinates(const gfx::Rect& child_bounds,
+                                            const gfx::Rect& parent_bounds) {
+  int x = child_bounds.x() - parent_bounds.x();
+  int y = child_bounds.y() - parent_bounds.y();
+  return gfx::Rect(gfx::Point(x, y), child_bounds.size());
+}
+}
+
 WaylandWindow::WaylandWindow(PlatformWindowDelegate* delegate,
                              WaylandConnection* connection,
                              const gfx::Rect& bounds)
@@ -34,10 +52,6 @@ WaylandWindow* WaylandWindow::FromSurface(wl_surface* surface) {
 }
 
 bool WaylandWindow::Initialize() {
-  static const xdg_surface_listener xdg_surface_listener = {
-      &WaylandWindow::Configure, &WaylandWindow::Close,
-  };
-
   surface_.reset(wl_compositor_create_surface(connection_->compositor()));
   if (!surface_) {
     LOG(ERROR) << "Failed to create wl_surface";
@@ -51,6 +65,9 @@ bool WaylandWindow::Initialize() {
   ui::mojom::WindowType window_type = ui::mojom::WindowType::WINDOW;
   delegate_->GetWindowType(&window_type);
   if (window_type == ui::mojom::WindowType::WINDOW) {
+    static const xdg_surface_listener xdg_surface_listener = {
+        &WaylandWindow::Configure, &WaylandWindow::Close,
+    };
     xdg_surface_.reset(
         xdg_shell_get_xdg_surface(connection_->shell(), surface_.get()));
     if (!xdg_surface_) {
@@ -59,7 +76,18 @@ bool WaylandWindow::Initialize() {
     }
     xdg_surface_add_listener(xdg_surface_.get(), &xdg_surface_listener, this);
   } else {
-    return false;
+    parent_window_ = connection_->GetCurrentFocusedWindow();
+    if (!parent_window_) {
+      LOG(ERROR) << "Failed to get parent window";
+      return false;
+    }
+
+    CreatePopupWindow();
+    if (!xdg_popup_) {
+      LOG(ERROR) << "Failed to create xdg_popup";
+      return false;
+    }
+    parent_window_->set_child_window(this);
   }
   connection_->ScheduleFlush();
 
@@ -81,10 +109,34 @@ void WaylandWindow::ApplyPendingBounds() {
   connection_->ScheduleFlush();
 }
 
-void WaylandWindow::Show() {}
+void WaylandWindow::CreatePopupWindow() {
+  DCHECK(parent_window_);
+  gfx::Rect bounds =
+      TranslateBoundsToScreenCoordinates(bounds_, parent_window_->GetBounds());
+  xdg_popup_.reset(xdg_shell_get_xdg_popup(
+      connection_->shell(), surface_.get(), parent_window_->surface(),
+      connection_->seat(), connection_->serial(), bounds.x(), bounds.y()));
+  xdg_popup_add_listener(xdg_popup_.get(), &xdg_popup_listener, this);
+}
 
+// TODO(msisov, tonikitoo): we will want to trigger show and hide of all
+// windows once we pass minimize events from chrome.
+void WaylandWindow::Show() {
+  if (xdg_surface_)
+    return;
+  if (!xdg_popup_) {
+    CreatePopupWindow();
+    connection_->ScheduleFlush();
+  }
+}
+
+// TODO(msisov, tonikitoo): we will want to trigger show and hide of all
+// windows once we pass minimize events from chrome.
 void WaylandWindow::Hide() {
-  NOTIMPLEMENTED();
+  if (child_window_)
+    child_window_->Hide();
+  if (xdg_popup_)
+    xdg_popup_.reset();
 }
 
 void WaylandWindow::Close() {
@@ -111,11 +163,19 @@ void WaylandWindow::SetTitle(const base::string16& title) {
 }
 
 void WaylandWindow::SetCapture() {
-  NOTIMPLEMENTED();
+  if (g_current_capture_ == this)
+    return;
+
+  WaylandWindow* old_capture = g_current_capture_;
+  if (old_capture)
+    old_capture->delegate()->OnLostCapture();
+
+  g_current_capture_ = this;
 }
 
 void WaylandWindow::ReleaseCapture() {
-  NOTIMPLEMENTED();
+  if (g_current_capture_ == this)
+    g_current_capture_ = nullptr;
 }
 
 void WaylandWindow::ToggleFullscreen() {
@@ -159,18 +219,45 @@ PlatformImeController* WaylandWindow::GetPlatformImeController() {
 
 bool WaylandWindow::CanDispatchEvent(const PlatformEvent& native_event) {
   Event* event = static_cast<Event*>(native_event);
-  if (event->IsMouseEvent())
-    return has_pointer_focus_;
+  if (event->IsMouseEvent()) {
+    if (g_current_capture_ == this) {
+      if (has_pointer_focus_ || child_window_->is_focused_popup())
+        return true;
+      else
+        return false;
+    } else {
+      return has_pointer_focus_;
+    }
+  }
   if (event->IsKeyEvent())
     return has_keyboard_focus_;
   return false;
 }
 
 uint32_t WaylandWindow::DispatchEvent(const PlatformEvent& native_event) {
+  Event* event = static_cast<Event*>(native_event);
+  if (event->IsLocatedEvent() && !has_pointer_focus_)
+    ConvertEventLocationToCurrentWindowLocation(event);
+
   DispatchEventFromNativeUiEvent(
       native_event, base::Bind(&PlatformWindowDelegate::DispatchEvent,
                                base::Unretained(delegate_)));
   return POST_DISPATCH_STOP_PROPAGATION;
+}
+
+void WaylandWindow::ConvertEventLocationToCurrentWindowLocation(
+    ui::Event* event) {
+  WaylandWindow* wayland_window = connection_->GetCurrentFocusedWindow();
+  DCHECK_NE(wayland_window, this);
+  if (event->IsLocatedEvent()) {
+    gfx::Vector2d offset =
+        wayland_window->GetBounds().origin() - GetBounds().origin();
+    ui::LocatedEvent* located_event = event->AsLocatedEvent();
+    gfx::PointF location_in_pixel_in_host =
+        located_event->location_f() + gfx::Vector2dF(offset);
+    located_event->set_location_f(location_in_pixel_in_host);
+    located_event->set_root_location_f(location_in_pixel_in_host);
+  }
 }
 
 // static
@@ -181,6 +268,13 @@ void WaylandWindow::Configure(void* data,
                               wl_array* states,
                               uint32_t serial) {
   WaylandWindow* window = static_cast<WaylandWindow*>(data);
+
+  // Width or height set 0 means that we should decide on width and height by
+  // ourselves, but we don't want to set to anything else. Use previous size.
+  if (width == 0 || height == 0) {
+    width = window->GetBounds().width();
+    height = window->GetBounds().height();
+  }
 
   // Rather than call SetBounds here for every configure event, just save the
   // most recent bounds, and have WaylandConnection call ApplyPendingBounds
@@ -193,6 +287,13 @@ void WaylandWindow::Configure(void* data,
 // static
 void WaylandWindow::Close(void* data, xdg_surface* obj) {
   NOTIMPLEMENTED();
+}
+
+// static
+void WaylandWindow::PopupDone(void* data, xdg_popup* obj) {
+  WaylandWindow* window = static_cast<WaylandWindow*>(data);
+  window->Hide();
+  window->delegate_->OnCloseRequest();
 }
 
 }  // namespace ui

--- a/ui/ozone/platform/wayland/wayland_window.h
+++ b/ui/ozone/platform/wayland/wayland_window.h
@@ -39,9 +39,7 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
   // Set whether this window has keyboard focus and should dispatch key events.
   void set_keyboard_focus(bool focus) { has_keyboard_focus_ = focus; }
 
-  bool has_pointer_or_keyboard_focus() {
-    return has_pointer_focus_ || has_keyboard_focus_;
-  }
+  bool has_pointer_focus() { return has_pointer_focus_; }
 
   // Tells if it is a focused popup.
   bool is_focused_popup() {

--- a/ui/ozone/platform/wayland/wayland_window.h
+++ b/ui/ozone/platform/wayland/wayland_window.h
@@ -43,7 +43,7 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
 
   // Tells if it is a focused popup.
   bool is_focused_popup() {
-    return !!xdg_popup_.get() && has_pointer_or_keyboard_focus();
+    return !!xdg_popup_.get() && has_pointer_focus();
   }
 
   // Set a child of this window. It is very important in case of nested

--- a/ui/ozone/platform/wayland/wayland_window.h
+++ b/ui/ozone/platform/wayland/wayland_window.h
@@ -39,6 +39,20 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
   // Set whether this window has keyboard focus and should dispatch key events.
   void set_keyboard_focus(bool focus) { has_keyboard_focus_ = focus; }
 
+  bool has_pointer_or_keyboard_focus() {
+    return has_pointer_focus_ || has_keyboard_focus_;
+  }
+
+  // Tells if it is a focused popup.
+  bool is_focused_popup() {
+    return !!xdg_popup_.get() && has_pointer_or_keyboard_focus();
+  }
+
+  // Set a child of this window. It is very important in case of nested
+  // xdg_popups as long as we must destroy the very last first and only then
+  // its parent.
+  void set_child_window(WaylandWindow* window) { child_window_ = window; }
+
   // PlatformWindow
   void Show() override;
   void Hide() override;
@@ -71,12 +85,28 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
                         uint32_t serial);
   static void Close(void* data, xdg_surface* obj);
 
+  // xdg_popup_listener
+  static void PopupDone(void* data, xdg_popup* obj);
+
+ protected:
+  PlatformWindowDelegate* delegate() { return delegate_; }
+
  private:
+  // TODO(msisov, tonikitoo): share this with X11WindowOzone and
+  // DesktopWindowTreeHostX11.
+  void ConvertEventLocationToCurrentWindowLocation(ui::Event* located_event);
+
+  // Creates a popup window, which is visible as a menu window.
+  void CreatePopupWindow();
+
   PlatformWindowDelegate* delegate_;
   WaylandConnection* connection_;
+  WaylandWindow* parent_window_ = nullptr;
+  WaylandWindow* child_window_ = nullptr;
 
   wl::Object<wl_surface> surface_;
   wl::Object<xdg_surface> xdg_surface_;
+  wl::Object<xdg_popup> xdg_popup_;
 
   gfx::Rect bounds_;
   gfx::Rect pending_bounds_;

--- a/ui/ozone/platform/x11/ozone_platform_x11.cc
+++ b/ui/ozone/platform/x11/ozone_platform_x11.cc
@@ -106,6 +106,16 @@ class OzonePlatformX11 : public OzonePlatform {
     surface_factory_ozone_ = base::MakeUnique<X11SurfaceFactory>();
   }
 
+  void QueryHostDisplaysData(QueryHostDisplaysDataCallback callback) override {
+    DCHECK(!callback.is_null());
+
+    // TODO(tonikitoo): Add support to multiple displays.
+    XDisplay* display = gfx::GetXDisplay();
+    Screen* screen = DefaultScreenOfDisplay(display);
+    callback.Run(std::vector<gfx::Size>(
+        1, gfx::Size(screen->width, screen->height)));
+  }
+
   base::MessageLoop::Type GetMessageLoopTypeForGpu() override {
     // When Ozone X11 backend is running use an UI loop to grab Expose events.
     // See GLSurfaceGLX and https://crbug.com/326995.

--- a/ui/ozone/public/ozone_platform.cc
+++ b/ui/ozone/public/ozone_platform.cc
@@ -98,6 +98,10 @@ base::MessageLoop::Type OzonePlatform::GetMessageLoopTypeForGpu() {
   return base::MessageLoop::TYPE_DEFAULT;
 }
 
+void OzonePlatform::QueryHostDisplaysData(QueryHostDisplaysDataCallback callback) {
+  NOTREACHED();
+}
+
 void OzonePlatform::AddInterfaces(service_manager::BinderRegistry* registry) {}
 
 }  // namespace ui

--- a/ui/ozone/public/ozone_platform.h
+++ b/ui/ozone/public/ozone_platform.h
@@ -7,8 +7,10 @@
 
 #include <memory>
 
+#include "base/callback_forward.h"
 #include "base/macros.h"
 #include "base/message_loop/message_loop.h"
+#include "ui/gfx/geometry/size.h"
 #include "ui/ozone/ozone_export.h"
 
 namespace display {
@@ -114,6 +116,9 @@ class OZONE_EXPORT OzonePlatform {
       const gfx::Rect& bounds) = 0;
   virtual std::unique_ptr<display::NativeDisplayDelegate>
   CreateNativeDisplayDelegate() = 0;
+
+  using QueryHostDisplaysDataCallback = base::Callback<void(const std::vector<gfx::Size>&)>;
+  virtual void QueryHostDisplaysData(QueryHostDisplaysDataCallback callback);
 
   // Returns the message loop type required for OzonePlatform instance that
   // will be initialized for the GPU process.

--- a/ui/platform_window/platform_window_delegate.h
+++ b/ui/platform_window/platform_window_delegate.h
@@ -5,6 +5,7 @@
 #ifndef UI_PLATFORM_WINDOW_PLATFORM_WINDOW_DELEGATE_H_
 #define UI_PLATFORM_WINDOW_PLATFORM_WINDOW_DELEGATE_H_
 
+#include "services/ui/public/interfaces/window_manager_constants.mojom.h"
 #include "ui/gfx/native_widget_types.h"
 
 namespace gfx {
@@ -51,6 +52,11 @@ class PlatformWindowDelegate {
   virtual void OnAcceleratedWidgetDestroyed() = 0;
 
   virtual void OnActivationChanged(bool active) = 0;
+
+  // TODO(tonikitoo,msisov): Adding this method with an out parameter so that
+  // we can have a default implementation here and not need to add stubs to
+  // all subclasses. To be discussed when upstraming.
+  virtual void GetWindowType(ui::mojom::WindowType* result) { }
 };
 
 }  // namespace ui

--- a/ui/platform_window/x11/x11_window_base.cc
+++ b/ui/platform_window/x11/x11_window_base.cc
@@ -13,6 +13,7 @@
 
 #include "base/strings/utf_string_conversions.h"
 #include "ui/base/platform_window_defaults.h"
+#include "ui/base/x/x11_util.h"
 #include "ui/base/x/x11_window_event_manager.h"
 #include "ui/events/devices/x11/touch_factory_x11.h"
 #include "ui/events/event.h"
@@ -27,11 +28,19 @@ namespace ui {
 
 namespace {
 
+// Constants that are part of EWMH.
+const int k_NET_WM_STATE_ADD = 1;
+const int k_NET_WM_STATE_REMOVE = 0;
+
 const char* kAtomsToCache[] = {"UTF8_STRING",
                                "WM_DELETE_WINDOW",
                                "_NET_WM_NAME",
                                "_NET_WM_PID",
                                "_NET_WM_PING",
+                               "_NET_WM_STATE",
+                               "_NET_WM_STATE_HIDDEN",
+                               "_NET_WM_STATE_MAXIMIZED_HORZ",
+                               "_NET_WM_STATE_MAXIMIZED_VERT",
                                "_NET_WM_WINDOW_TYPE_MENU",
                                "_NET_WM_WINDOW_TYPE_NORMAL",
                                "_NET_WM_WINDOW_TYPE",
@@ -194,7 +203,7 @@ void X11WindowBase::Show() {
 }
 
 void X11WindowBase::Hide() {
-  if (!window_mapped_)
+  if (!window_mapped_ || IsMinimized())
     return;
   XWithdrawWindow(xdisplay_, xwindow_, 0);
   window_mapped_ = false;
@@ -266,11 +275,28 @@ void X11WindowBase::ReleaseCapture() {}
 
 void X11WindowBase::ToggleFullscreen() {}
 
-void X11WindowBase::Maximize() {}
+void X11WindowBase::Maximize() {
+  if (IsMaximized())
+    return;
+  // When we are in the process of requesting to maximize a window, we can
+  // accurately keep track of our restored bounds instead of relying on the
+  // heuristics that are in the PropertyNotify and ConfigureNotify handlers.
+  restored_bounds_in_pixels_ = bounds_;
 
-void X11WindowBase::Minimize() {}
+  SetWMSpecState(true, atom_cache_.GetAtom("_NET_WM_STATE_MAXIMIZED_VERT"),
+                 atom_cache_.GetAtom("_NET_WM_STATE_MAXIMIZED_HORZ"));
+}
 
-void X11WindowBase::Restore() {}
+void X11WindowBase::Minimize() {
+  if (IsMinimized())
+    return;
+  XIconifyWindow(xdisplay_, xwindow_, 0);
+}
+
+void X11WindowBase::Restore() {
+  SetWMSpecState(false, atom_cache_.GetAtom("_NET_WM_STATE_MAXIMIZED_VERT"),
+                 atom_cache_.GetAtom("_NET_WM_STATE_MAXIMIZED_HORZ"));
+}
 
 void X11WindowBase::MoveCursorTo(const gfx::Point& location) {
   XWarpPointer(xdisplay_, None, xroot_window_, 0, 0, 0, 0,
@@ -339,7 +365,84 @@ void X11WindowBase::ProcessXWindowEvent(XEvent* xev) {
       }
       break;
     }
+
+    case PropertyNotify: {
+      ::Atom changed_atom = xev->xproperty.atom;
+      if (changed_atom == atom_cache_.GetAtom("_NET_WM_STATE"))
+        OnWMStateUpdated();
+      break;
+    }
   }
+}
+
+void X11WindowBase::SetWMSpecState(bool enabled, ::Atom state1, ::Atom state2) {
+  XEvent xclient;
+  memset(&xclient, 0, sizeof(xclient));
+  xclient.type = ClientMessage;
+  xclient.xclient.window = xwindow_;
+  xclient.xclient.message_type = atom_cache_.GetAtom("_NET_WM_STATE");
+  xclient.xclient.format = 32;
+  xclient.xclient.data.l[0] =
+      enabled ? k_NET_WM_STATE_ADD : k_NET_WM_STATE_REMOVE;
+  xclient.xclient.data.l[1] = state1;
+  xclient.xclient.data.l[2] = state2;
+  xclient.xclient.data.l[3] = 1;
+  xclient.xclient.data.l[4] = 0;
+
+  XSendEvent(xdisplay_, xroot_window_, False,
+             SubstructureRedirectMask | SubstructureNotifyMask, &xclient);
+}
+
+void X11WindowBase::OnWMStateUpdated() {
+  std::vector<::Atom> atom_list;
+  // Ignore the return value of ui::GetAtomArrayProperty(). Fluxbox removes the
+  // _NET_WM_STATE property when no _NET_WM_STATE atoms are set.
+  ui::GetAtomArrayProperty(xwindow_, "_NET_WM_STATE", &atom_list);
+
+  bool was_minimized = IsMinimized();
+
+  window_properties_.clear();
+  std::copy(atom_list.begin(), atom_list.end(),
+            inserter(window_properties_, window_properties_.begin()));
+
+  // Propagate the window minimization information to the client.
+  bool is_minimized = IsMinimized();
+  ui::PlatformWindowState state;
+  // Check state after minimization/restore.
+  if (is_minimized != was_minimized) {
+    if (is_minimized) {
+      state = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MINIMIZED;
+    } else {
+      // When the window is recovered from minimized state, set state to the
+      // previous state.
+      state = IsMaximized()
+                  ? ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MAXIMIZED
+                  : ui::PlatformWindowState::PLATFORM_WINDOW_STATE_NORMAL;
+    }
+    delegate_->OnWindowStateChanged(state);
+    return;
+  }
+
+  // If it hasn't been a restore or minimize state, then check if the window
+  // has been maximized or restored.
+  state = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_NORMAL;
+  if (IsMaximized())
+    state = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MAXIMIZED;
+  delegate_->OnWindowStateChanged(state);
+}
+
+bool X11WindowBase::HasWMSpecProperty(const char* property) const {
+  return window_properties_.find(atom_cache_.GetAtom(property)) !=
+         window_properties_.end();
+}
+
+bool X11WindowBase::IsMinimized() const {
+  return HasWMSpecProperty("_NET_WM_STATE_HIDDEN");
+}
+
+bool X11WindowBase::IsMaximized() const {
+  return (HasWMSpecProperty("_NET_WM_STATE_MAXIMIZED_VERT") &&
+          HasWMSpecProperty("_NET_WM_STATE_MAXIMIZED_HORZ"));
 }
 
 }  // namespace ui

--- a/ui/platform_window/x11/x11_window_base.cc
+++ b/ui/platform_window/x11/x11_window_base.cc
@@ -86,7 +86,10 @@ void X11WindowBase::Create() {
   swa.override_redirect = UseTestConfigForPlatformWindows();
 
   ::Atom window_type;
-  ui::mojom::WindowType ui_window_type;
+  // There is now default initialization for this type. Initialize it
+  // to ::WINDOW here. It will be changed by delelgate if it know the
+  // type of the window.
+  ui::mojom::WindowType ui_window_type = ui::mojom::WindowType::WINDOW;
   delegate_->GetWindowType(&ui_window_type);
   if (ui_window_type != ui::mojom::WindowType::WINDOW) {
     // Setting this to True, doesn't allow X server to set different

--- a/ui/platform_window/x11/x11_window_base.h
+++ b/ui/platform_window/x11/x11_window_base.h
@@ -78,6 +78,7 @@ class X11_WINDOW_EXPORT X11WindowBase : public PlatformWindow {
   // TODO(msisov, tonikitoo): share this with DesktopWindowTreeHostX11.
   bool IsMinimized() const;
   bool IsMaximized() const;
+  bool IsFullScreen() const;
 
   PlatformWindowDelegate* delegate_;
 
@@ -99,6 +100,7 @@ class X11_WINDOW_EXPORT X11WindowBase : public PlatformWindow {
   std::set<::Atom> window_properties_;
 
   bool window_mapped_ = false;
+  bool is_fullscreen_ = false;
 
   DISALLOW_COPY_AND_ASSIGN(X11WindowBase);
 };

--- a/ui/platform_window/x11/x11_window_base.h
+++ b/ui/platform_window/x11/x11_window_base.h
@@ -7,6 +7,8 @@
 
 #include <stdint.h>
 
+#include <X11/Xutil.h>
+
 #include "base/callback.h"
 #include "base/macros.h"
 #include "ui/gfx/geometry/rect.h"
@@ -61,6 +63,22 @@ class X11_WINDOW_EXPORT X11WindowBase : public PlatformWindow {
   void ProcessXWindowEvent(XEvent* xev);
 
  private:
+  // Sends a message to the x11 window manager, enabling or disabling the
+  // states |state1| and |state2|.
+  // TODO(msisov, tonikitoo): share this with DesktopWindowTreeHostX11.
+  void SetWMSpecState(bool enabled, ::Atom state1, ::Atom state2);
+
+  // Called when WM_STATE property is changed.
+  void OnWMStateUpdated();
+
+  // Checks if the window manager has set a specific state.
+  // TODO(msisov, tonikitoo): share this with DesktopWindowTreeHostX11.
+  bool HasWMSpecProperty(const char* property) const;
+
+  // TODO(msisov, tonikitoo): share this with DesktopWindowTreeHostX11.
+  bool IsMinimized() const;
+  bool IsMaximized() const;
+
   PlatformWindowDelegate* delegate_;
 
   XDisplay* xdisplay_;
@@ -73,6 +91,12 @@ class X11_WINDOW_EXPORT X11WindowBase : public PlatformWindow {
 
   // The bounds of |xwindow_|.
   gfx::Rect bounds_;
+
+  // The bounds of our window before we were maximized.
+  gfx::Rect restored_bounds_in_pixels_;
+
+  // The window manager state bits.
+  std::set<::Atom> window_properties_;
 
   bool window_mapped_ = false;
 

--- a/ui/platform_window/x11/x11_window_manager_ozone.cc
+++ b/ui/platform_window/x11/x11_window_manager_ozone.cc
@@ -8,20 +8,49 @@
 
 namespace ui {
 
-X11WindowManagerOzone::X11WindowManagerOzone() : event_grabber_(None) {}
+X11WindowManagerOzone::X11WindowManagerOzone() : event_grabber_(nullptr) {}
 
-X11WindowManagerOzone::~X11WindowManagerOzone() {}
-
-void X11WindowManagerOzone::GrabEvents(XID xwindow) {
-  if (event_grabber_ != None)
-    return;
-  event_grabber_ = xwindow;
+X11WindowManagerOzone::~X11WindowManagerOzone() {
+  DCHECK(x11_windows_.empty());
 }
 
-void X11WindowManagerOzone::UngrabEvents(XID xwindow) {
-  if (event_grabber_ != xwindow)
+void X11WindowManagerOzone::GrabEvents(X11WindowOzone* window) {
+  if (event_grabber_ == window)
     return;
-  event_grabber_ = None;
+
+  X11WindowOzone* old_grabber = event_grabber_;
+  if (old_grabber)
+    old_grabber->OnLostCapture();
+
+  event_grabber_ = window;
+}
+
+void X11WindowManagerOzone::UngrabEvents(X11WindowOzone* window) {
+  if (event_grabber_ != window)
+    return;
+  event_grabber_->OnLostCapture();
+  event_grabber_ = nullptr;
+}
+
+void X11WindowManagerOzone::AddX11Window(X11WindowOzone* window) {
+  auto it = std::find(x11_windows_.begin(), x11_windows_.end(), window);
+  DCHECK(it == x11_windows_.end());
+  x11_windows_.push_back(window);
+}
+
+void X11WindowManagerOzone::DeleteX11Window(X11WindowOzone* window) {
+  auto it = std::find(x11_windows_.begin(), x11_windows_.end(), window);
+  if (it != x11_windows_.end())
+    x11_windows_.erase(it);
+}
+
+X11WindowOzone* X11WindowManagerOzone::GetX11WindowByTarget(
+    const XID& xwindow) {
+  for (auto* x11_window : x11_windows_) {
+    if (x11_window->xwindow() == xwindow)
+      return x11_window;
+  }
+  return nullptr;
 }
 
 }  // namespace ui

--- a/ui/platform_window/x11/x11_window_manager_ozone.h
+++ b/ui/platform_window/x11/x11_window_manager_ozone.h
@@ -16,18 +16,29 @@ class X11_WINDOW_EXPORT X11WindowManagerOzone {
   X11WindowManagerOzone();
   ~X11WindowManagerOzone();
 
-  // Tries to set a given XWindow as the recipient for events. It will fail if
-  // there is already another XWindow as recipient.
-  void GrabEvents(XID xwindow);
+  // Tries to set a given X11WindowOzone as the recipient for events. It will
+  // fail if there is already another X11WindowOzone as recipient.
+  void GrabEvents(X11WindowOzone* window);
 
-  // Unsets a given XWindow as the recipient for events.
-  void UngrabEvents(XID xwindow);
+  // Unsets a given X11WindowOzone as the recipient for events.
+  void UngrabEvents(X11WindowOzone* window);
 
-  // Gets the current XWindow recipient of mouse events.
-  XID event_grabber() const { return event_grabber_; }
+  // Gets the current X11WindowOzone recipient of mouse events.
+  X11WindowOzone* event_grabber() const { return event_grabber_; }
+
+  // Stores raw pointers to X11WindowOzone.
+  void AddX11Window(X11WindowOzone* window);
+
+  // Removes raw pointers to X11WindowOzone.
+  void DeleteX11Window(X11WindowOzone* window);
+
+  // Returns pointer to X11WindowOzone found by XID.
+  X11WindowOzone* GetX11WindowByTarget(const XID& xwindow);
 
  private:
-  XID event_grabber_;
+  X11WindowOzone* event_grabber_;
+
+  std::vector<X11WindowOzone*> x11_windows_;
 
   DISALLOW_COPY_AND_ASSIGN(X11WindowManagerOzone);
 };

--- a/ui/platform_window/x11/x11_window_ozone.cc
+++ b/ui/platform_window/x11/x11_window_ozone.cc
@@ -5,6 +5,7 @@
 #include "ui/platform_window/x11/x11_window_ozone.h"
 
 #include <X11/Xlib.h>
+#include <X11/extensions/XInput2.h>
 
 #include "base/bind.h"
 #include "ui/events/event.h"
@@ -16,11 +17,25 @@
 
 namespace ui {
 
+namespace {
+
+XID GetEventXWindow(EventWithPlatformEvent* ewpe) {
+  auto* xev = static_cast<XEvent*>(ewpe->platform_event);
+  XID target = xev->xany.window;
+  if (xev->type == GenericEvent)
+    target = static_cast<XIDeviceEvent*>(xev->xcookie.data)->event;
+  return target;
+}
+
+}  // namespace
+
 X11WindowOzone::X11WindowOzone(X11WindowManagerOzone* window_manager,
                                PlatformWindowDelegate* delegate,
                                const gfx::Rect& bounds)
     : X11WindowBase(delegate, bounds), window_manager_(window_manager) {
   DCHECK(window_manager);
+  window_manager_->AddX11Window(this);
+
   auto* event_source = X11EventSourceLibevent::GetInstance();
   if (event_source) {
     event_source->AddPlatformEventDispatcher(this);
@@ -33,6 +48,9 @@ X11WindowOzone::~X11WindowOzone() {
 }
 
 void X11WindowOzone::PrepareForShutdown() {
+  DCHECK(window_manager_);
+  window_manager_->DeleteX11Window(this);
+
   auto* event_source = X11EventSourceLibevent::GetInstance();
   if (event_source) {
     event_source->RemovePlatformEventDispatcher(this);
@@ -41,11 +59,11 @@ void X11WindowOzone::PrepareForShutdown() {
 }
 
 void X11WindowOzone::SetCapture() {
-  window_manager_->GrabEvents(xwindow());
+  window_manager_->GrabEvents(this);
 }
 
 void X11WindowOzone::ReleaseCapture() {
-  window_manager_->UngrabEvents(xwindow());
+  window_manager_->UngrabEvents(this);
 }
 
 void X11WindowOzone::SetCursor(PlatformCursor cursor) {
@@ -66,9 +84,9 @@ bool X11WindowOzone::CanDispatchEvent(const PlatformEvent& platform_event) {
     return false;
 
   // If there is a grab, capture events here.
-  XID grabber = window_manager_->event_grabber();
-  if (grabber != None)
-    return grabber == xwindow();
+  X11WindowOzone* grabber = window_manager_->event_grabber();
+  if (grabber)
+    return grabber == this;
 
   // TODO(kylechar): We may need to do something special for TouchEvents similar
   // to how DrmWindowHost handles them.
@@ -93,10 +111,38 @@ uint32_t X11WindowOzone::DispatchEvent(const PlatformEvent& platform_event) {
   // (eg. double click) are broken.
   auto* ewpe = static_cast<EventWithPlatformEvent*>(platform_event);
   auto* event = static_cast<ui::Event*>(ewpe->event);
+
+  XID target = GetEventXWindow(ewpe);
+
+  // If the event came originally from another native window (was rerouted by
+  // PlatformEventSource), its location must be adapted using current window
+  // location.
+  if (target != xwindow())
+    ConvertEventLocationToCurrentWindowLocation(target, event);
+
   DispatchEventFromNativeUiEvent(
       event, base::Bind(&PlatformWindowDelegate::DispatchEvent,
                         base::Unretained(delegate())));
   return POST_DISPATCH_STOP_PROPAGATION;
+}
+
+void X11WindowOzone::OnLostCapture() {
+  delegate()->OnLostCapture();
+}
+
+void X11WindowOzone::ConvertEventLocationToCurrentWindowLocation(
+    const XID& target,
+    ui::Event* event) {
+  X11WindowOzone* x11_window = window_manager_->GetX11WindowByTarget(target);
+  if (x11_window && x11_window != this && event->IsLocatedEvent()) {
+    gfx::Vector2d offset =
+        x11_window->GetBounds().origin() - GetBounds().origin();
+    ui::LocatedEvent* located_event = event->AsLocatedEvent();
+    gfx::PointF location_in_pixel_in_host =
+        located_event->location_f() + gfx::Vector2dF(offset);
+    located_event->set_location_f(location_in_pixel_in_host);
+    located_event->set_root_location_f(location_in_pixel_in_host);
+  }
 }
 
 }  // namespace ui

--- a/ui/platform_window/x11/x11_window_ozone.h
+++ b/ui/platform_window/x11/x11_window_ozone.h
@@ -35,6 +35,19 @@ class X11_WINDOW_EXPORT X11WindowOzone : public X11WindowBase,
   bool DispatchXEvent(XEvent* event) override;
 
  private:
+  // Calls OnLostCapture() and xwindow().
+  friend X11WindowManagerOzone;
+
+  // Called by |window_manager_| once capture is set to another xwindow.
+  void OnLostCapture();
+
+  // Converts events' location if they are originally from background windows,
+  // but capture is set to another foreground window.
+  // TODO(msisov, tonikitoo): share this logic with DesktopWindowTreeHostX11
+  // and WaylandWindow.
+  void ConvertEventLocationToCurrentWindowLocation(const XID& target,
+                                                   ui::Event* event);
+
   // PlatformEventDispatcher:
   bool CanDispatchEvent(const PlatformEvent& event) override;
   uint32_t DispatchEvent(const PlatformEvent& event) override;

--- a/ui/views/corewm/tooltip_controller.cc
+++ b/ui/views/corewm/tooltip_controller.cc
@@ -335,7 +335,7 @@ void TooltipController::UpdateIfRequired() {
 }
 
 void TooltipController::ShowTooltip() {
-  if (!tooltip_window_)
+  //if (!tooltip_window_)
     return;
   gfx::Point widget_loc =
       curr_mouse_loc_ + tooltip_window_->GetBoundsInScreen().OffsetFromOrigin();

--- a/ui/views/mus/mus_client.cc
+++ b/ui/views/mus/mus_client.cc
@@ -154,6 +154,12 @@ MusClient::~MusClient() {
 // static
 bool MusClient::ShouldCreateDesktopNativeWidgetAura(
     const Widget::InitParams& init_params) {
+#if defined(USE_AURA) && defined(USE_OZONE) && !defined(OS_CHROMEOS)
+  // For Ozone/Linux desktop builds (Mus code path), we mimic regular
+  // X11/Linux builds on how to create widgets.
+  return false;
+#endif
+
   // TYPE_CONTROL and child widgets require a NativeWidgetAura.
   return init_params.type != Widget::InitParams::TYPE_CONTROL &&
          !init_params.child;

--- a/ui/views/mus/mus_client.cc
+++ b/ui/views/mus/mus_client.cc
@@ -109,7 +109,12 @@ MusClient::MusClient(service_manager::Connector* connector,
       connector, this, nullptr /* window_manager_delegate */,
       nullptr /* window_tree_client_request */, std::move(io_task_runner));
   aura::Env::GetInstance()->SetWindowTreeClient(window_tree_client_.get());
+
+#if defined(OS_LINUX) && defined(USE_OZONE) && !defined(OS_CHROMEOS)
+  window_tree_client_->ConnectViaWindowTreeHostFactory();
+#else
   window_tree_client_->ConnectViaWindowTreeFactory();
+#endif
 
   pointer_watcher_event_router_ =
       base::MakeUnique<PointerWatcherEventRouter>(window_tree_client_.get());
@@ -286,7 +291,6 @@ std::unique_ptr<DesktopWindowTreeHost> MusClient::CreateDesktopWindowTreeHost(
 
 void MusClient::OnEmbed(
     std::unique_ptr<aura::WindowTreeHostMus> window_tree_host) {
-  NOTREACHED();
 }
 
 void MusClient::OnLostConnection(aura::WindowTreeClient* client) {}


### PR DESCRIPTION
The PR make the WindowManagerDisplayRoot::root_'s use the root WindowTree's id, pretending to be created by it.

As a consequence, it allows us to use WindowManagerAccessPolicy both for chrome/mus and for unit tests.

Also, also changes the deletion order a bit, so that we do not crash at shutdown.

Last, it reverts the tweaks done to the access policy code, which are now unneeded.