### PR TITLE
fixup! c++ / mojo changes for 'external window mode'

### DIFF
--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -253,7 +253,6 @@ void Display::InitDisplayRoot() {
       display_root_ptr.get();
 
   WindowTree* window_tree = window_server_->GetTreeForExternalWindowMode();
-  ServerWindow* server_window = display_root_ptr->root();
 
   std::unique_ptr<WindowManagerState> window_manager_state =
       base::MakeUnique<WindowManagerState>(window_tree);
@@ -264,9 +263,6 @@ void Display::InitDisplayRoot() {
   WindowManagerDisplayRoot* display_root = display_root_ptr.get();
   display_root->window_manager_state_->AddWindowManagerDisplayRoot(
       std::move(display_root_ptr));
-
-  window_tree->AddRoot(server_window);
-  window_tree->DoOnEmbed(nullptr /*mojom::WindowTreePtr*/, server_window);
 }
 
 void Display::InitWindowManagerDisplayRoots() {

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -274,6 +274,7 @@ void WindowTree::PrepareForWindowServerShutdown() {
 
 void WindowTree::AddRoot(const ServerWindow* root) {
   DCHECK(pending_client_window_id_ != kInvalidClientId);
+  DCHECK(window_server_->IsInExternalWindowMode());
 
   const ClientWindowId client_window_id(pending_client_window_id_);
   DCHECK_EQ(0u, client_id_to_window_id_map_.count(client_window_id));
@@ -286,6 +287,13 @@ void WindowTree::AddRoot(const ServerWindow* root) {
 
   Display* display = GetDisplay(root);
   DCHECK(display);
+
+  WindowManagerDisplayRoot* display_root =
+      GetWindowManagerDisplayRoot(root);
+  DCHECK(display_root);
+
+  DoOnEmbed(nullptr /*mojom::WindowTreePtr*/,
+            display_root->GetClientVisibleRoot());
 }
 
 void WindowTree::AddRootForWindowManager(const ServerWindow* root) {

--- a/services/ui/ws/window_tree_host_factory.cc
+++ b/services/ui/ws/window_tree_host_factory.cc
@@ -59,6 +59,15 @@ void WindowTreeHostFactory::CreatePlatformWindow(
   }
 
   ws_display->Init(metrics, std::move(display_binding));
+
+  // The call below used to be part of ws::Display::Init chain.
+  // However, in case we flip the "create displays automatically" flag
+  // off, it is needed to have the DefaultPlatformDisplay fully initialized
+  // before WindowTree::AddRoot is called. Reason: ::AddRoot creates the
+  // ServerWindow child of WindowManagerDisplayRoot::root, by calling
+  // ServerWindow::Add which can trigger a mouse update, which in turn
+  // requires the platform/ozone window to be fully created by then.
+  tree->AddRoot(ws_display->root_window()->children()[0]);
 }
 
 }  // namespace ws


### PR DESCRIPTION

    
    Another preparation work for the refactor patch
    
    Basically, it calls WindowTree::AddRoot from WindowTreeHostFactory
    rather than from Display::InitRootDisplay. This brings in no functionality
    change, but ensure we have a DefaultPlatformDisplay instance fully
    instantiated, something that is important in case we want to adopt the
    refactor branch.
