### PR TITLE
Support dragging and resizing in Ozone X11

### DIFF
--- a/ui/platform_window/x11/x11_window_base.cc
+++ b/ui/platform_window/x11/x11_window_base.cc
@@ -219,6 +219,11 @@ void X11WindowBase::Create() {
   size_hints.win_gravity = StaticGravity;
   XSetWMNormalHints(xdisplay_, xwindow_, &size_hints);
 
+  // Disable native frame by default for now.
+  // TODO(msisov, tonikitoo): check if native frame should be used by checking
+  // Widget::InitParams::remove_standard_frame.
+  ui::SetUseOSWindowFrame(xwindow_, false);
+
   // TODO(sky): provide real scale factor.
   delegate_->OnAcceleratedWidgetAvailable(xwindow_, 1.f);
 }

--- a/ui/platform_window/x11/x11_window_base.cc
+++ b/ui/platform_window/x11/x11_window_base.cc
@@ -12,6 +12,7 @@
 #include <string>
 
 #include "base/strings/utf_string_conversions.h"
+#include "ui/base/hit_test.h"
 #include "ui/base/platform_window_defaults.h"
 #include "ui/base/x/x11_util.h"
 #include "ui/base/x/x11_window_event_manager.h"
@@ -28,6 +29,56 @@
 namespace ui {
 
 namespace {
+
+// These constants are defined in the Extended Window Manager Hints
+// standard...and aren't in any header that I can find.
+const int k_NET_WM_MOVERESIZE_SIZE_TOPLEFT = 0;
+const int k_NET_WM_MOVERESIZE_SIZE_TOP = 1;
+const int k_NET_WM_MOVERESIZE_SIZE_TOPRIGHT = 2;
+const int k_NET_WM_MOVERESIZE_SIZE_RIGHT = 3;
+const int k_NET_WM_MOVERESIZE_SIZE_BOTTOMRIGHT = 4;
+const int k_NET_WM_MOVERESIZE_SIZE_BOTTOM = 5;
+const int k_NET_WM_MOVERESIZE_SIZE_BOTTOMLEFT = 6;
+const int k_NET_WM_MOVERESIZE_SIZE_LEFT = 7;
+const int k_NET_WM_MOVERESIZE_MOVE = 8;
+
+// Identifies the direction of the "hittest" for X11.
+bool IdentifyDirection(int hittest, int* direction) {
+  DCHECK(direction);
+  *direction = -1;
+  switch (hittest) {
+    case HTBOTTOM:
+      *direction = k_NET_WM_MOVERESIZE_SIZE_BOTTOM;
+      break;
+    case HTBOTTOMLEFT:
+      *direction = k_NET_WM_MOVERESIZE_SIZE_BOTTOMLEFT;
+      break;
+    case HTBOTTOMRIGHT:
+      *direction = k_NET_WM_MOVERESIZE_SIZE_BOTTOMRIGHT;
+      break;
+    case HTCAPTION:
+      *direction = k_NET_WM_MOVERESIZE_MOVE;
+      break;
+    case HTLEFT:
+      *direction = k_NET_WM_MOVERESIZE_SIZE_LEFT;
+      break;
+    case HTRIGHT:
+      *direction = k_NET_WM_MOVERESIZE_SIZE_RIGHT;
+      break;
+    case HTTOP:
+      *direction = k_NET_WM_MOVERESIZE_SIZE_TOP;
+      break;
+    case HTTOPLEFT:
+      *direction = k_NET_WM_MOVERESIZE_SIZE_TOPLEFT;
+      break;
+    case HTTOPRIGHT:
+      *direction = k_NET_WM_MOVERESIZE_SIZE_TOPRIGHT;
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
 
 // Constants that are part of EWMH.
 const int k_NET_WM_STATE_ADD = 1;
@@ -112,10 +163,10 @@ void X11WindowBase::Create() {
 
   // Setup XInput event mask.
   long event_mask = ButtonPressMask | ButtonReleaseMask | FocusChangeMask |
-                    KeyPressMask | KeyReleaseMask | EnterWindowMask |
-                    LeaveWindowMask | ExposureMask | VisibilityChangeMask |
-                    StructureNotifyMask | PropertyChangeMask |
-                    PointerMotionMask;
+                    KeyPressMask | KeyReleaseMask | ExposureMask |
+                    VisibilityChangeMask | StructureNotifyMask |
+                    PropertyChangeMask | PointerMotionMask;
+
   xwindow_events_.reset(new ui::XScopedEventSelector(xwindow_, event_mask));
 
   // Setup XInput2 event mask.
@@ -307,7 +358,31 @@ PlatformImeController* X11WindowBase::GetPlatformImeController() {
 }
 
 void X11WindowBase::PerformNativeWindowDragOrResize(uint32_t hittest) {
-  NOTIMPLEMENTED();
+  int direction;
+  if (!IdentifyDirection(hittest, &direction))
+    return;
+
+  // We most likely have an implicit grab right here. We need to dump it
+  // because what we're about to do is tell the window manager
+  // that it's now responsible for moving the window around; it immediately
+  // grabs when it receives the event below.
+  XUngrabPointer(xdisplay_, CurrentTime);
+
+  XEvent event;
+  memset(&event, 0, sizeof(event));
+  event.xclient.type = ClientMessage;
+  event.xclient.display = xdisplay_;
+  event.xclient.window = xwindow_;
+  event.xclient.message_type = gfx::GetAtom("_NET_WM_MOVERESIZE");
+  event.xclient.format = 32;
+  event.xclient.data.l[0] = xroot_window_event_location_.x();
+  event.xclient.data.l[1] = xroot_window_event_location_.y();
+  event.xclient.data.l[2] = direction;
+  event.xclient.data.l[3] = 0;
+  event.xclient.data.l[4] = 0;
+
+  XSendEvent(xdisplay_, xroot_window_, False,
+             SubstructureRedirectMask | SubstructureNotifyMask, &event);
 }
 
 bool X11WindowBase::IsEventForXWindow(const XEvent& xev) const {

--- a/ui/platform_window/x11/x11_window_base.h
+++ b/ui/platform_window/x11/x11_window_base.h
@@ -62,6 +62,11 @@ class X11_WINDOW_EXPORT X11WindowBase : public PlatformWindow {
   // Processes events for this XWindow.
   void ProcessXWindowEvent(XEvent* xev);
 
+  // Sets a location of ButtonPress event on xroot_window_.
+  void SetXRootWindowEventLocation(const gfx::Point& location) {
+    xroot_window_event_location_ = location;
+  }
+
  private:
   // Sends a message to the x11 window manager, enabling or disabling the
   // states |state1| and |state2|.
@@ -94,6 +99,10 @@ class X11_WINDOW_EXPORT X11WindowBase : public PlatformWindow {
 
   // The bounds of our window before we were maximized.
   gfx::Rect restored_bounds_in_pixels_;
+
+  // The point on xroot_window_, where a ButtonPress event occurred.
+  // Used for interactive window drag/resize.
+  gfx::Point xroot_window_event_location_;
 
   // The window manager state bits.
   std::set<::Atom> window_properties_;

--- a/ui/platform_window/x11/x11_window_ozone.cc
+++ b/ui/platform_window/x11/x11_window_ozone.cc
@@ -120,6 +120,12 @@ uint32_t X11WindowOzone::DispatchEvent(const PlatformEvent& platform_event) {
   if (target != xwindow())
     ConvertEventLocationToCurrentWindowLocation(target, event);
 
+  if (event->IsMouseEvent() && event->AsMouseEvent()->IsLeftMouseButton()) {
+    // Set location of an x root window, which will be used for interactive
+    // dragging/resize if a later hittest is positive.
+    SetXRootWindowEventLocation(event->AsMouseEvent()->root_location());
+  }
+
   DispatchEventFromNativeUiEvent(
       event, base::Bind(&PlatformWindowDelegate::DispatchEvent,
                         base::Unretained(delegate())));


### PR DESCRIPTION
This PR consists of two commits: one enables interactive dragging/resizing of x11 windows and the second one disable native frames by default.

Issue: https://github.com/Igalia/chromium/issues/64