### PR TITLE
fixup! Use WindowTreeHostMusInitParams in mus_demo_external to create…

### DIFF
--- a/services/ui/demo/mus_demo_external.cc
+++ b/services/ui/demo/mus_demo_external.cc
@@ -8,6 +8,7 @@
 #include "base/strings/string_number_conversions.h"
 #include "services/service_manager/public/cpp/service_context.h"
 #include "services/ui/demo/window_tree_data.h"
+#include "services/ui/public/cpp/property_type_converters.h"
 #include "services/ui/public/interfaces/constants.mojom.h"
 #include "services/ui/public/interfaces/window_tree_host.mojom.h"
 #include "ui/aura/mus/window_port_mus.h"
@@ -27,8 +28,15 @@ class WindowTreeDataExternal : public WindowTreeData {
   WindowTreeDataExternal(aura::WindowTreeClient* window_tree_client,
                          int square_size)
       : WindowTreeData(square_size) {
+    using WindowManager = ui::mojom::WindowManager;
+    using TransportType = std::vector<uint8_t>;
+    std::map<std::string, TransportType> properties;
+    properties[WindowManager::kBounds_InitProperty] =
+        mojo::ConvertTo<TransportType>(gfx::Rect(0, 0, 1024, 768));
+
     aura::WindowTreeHostMusInitParams init_params =
-        CreateInitParamsForTopLevel(window_tree_client);
+        CreateInitParamsForTopLevel(window_tree_client, properties);
+
     SetWindowTreeHost(
         base::MakeUnique<aura::WindowTreeHostMus>(std::move(init_params)));
   }

--- a/services/ui/ws/window_tree_host_factory.cc
+++ b/services/ui/ws/window_tree_host_factory.cc
@@ -49,10 +49,8 @@ void WindowTreeHostFactory::CreatePlatformWindow(
   metrics.ui_scale_factor = 1.0f;
 
   auto iter = properties.find(ui::mojom::WindowManager::kBounds_InitProperty);
-  if (iter != properties.end()) {
+  if (iter != properties.end())
     metrics.bounds_in_pixels = mojo::ConvertTo<gfx::Rect>(iter->second);
-  } else
-    metrics.bounds_in_pixels = gfx::Rect(1024, 768);
 
   iter = properties.find(ui::mojom::WindowManager::kWindowType_InitProperty);
   if (iter != properties.end()) {


### PR DESCRIPTION
… WindowTreeHostMus.

This commits uniforms the way we create ozone windows (via WS)
in external window mode. Now, it is client's resposibility to
pass the properties, including size of the windows.

This way, mus_demo and chrome/mus behave the same.

PS: the whole "Use WindowTreeHostMusInitParams in mus_demo_external .."
commit chain should likely be merged into "c++ mojo changes..." commit.