### PR TITLE
Revert "IdToString uses ',' for precision (not '.'). Update WindowTreeClientTest::SetOpacityNotifications"

### DIFF
--- a/services/ui/ws/window_tree_client_unittest.cc
+++ b/services/ui/ws/window_tree_client_unittest.cc
@@ -1841,7 +1841,7 @@ TEST_F(WindowTreeClientTest, SetOpacityNotifications) {
   EXPECT_TRUE(changes1()->empty());
   wt_client2()->WaitForChangeCount(1);
   EXPECT_EQ(
-      "OpacityChanged window_id=" + IdToString(window_1_1) + " opacity=0,50",
+      "OpacityChanged window_id=" + IdToString(window_1_1) + " opacity=0.50",
       SingleChangeToDescription(*changes2()));
 
   changes2()->clear();


### PR DESCRIPTION
Reverts Igalia/chromium#139