### PR TITLE
Deploy the refactor branch

### DIFF
--- a/services/ui/demo/mus_demo_external.h
+++ b/services/ui/demo/mus_demo_external.h
@@ -32,6 +32,8 @@ class MusDemoExternal : public MusDemo {
   void OnEmbedRootDestroyed(aura::WindowTreeHostMus* window_tree_host) final;
 
   size_t number_of_windows_ = 1;
+  size_t number_of_windows_created_ = 0;
+  bool create_windows_sequentially_ = false;
 
   DISALLOW_COPY_AND_ASSIGN(MusDemoExternal);
 };

--- a/services/ui/service.cc
+++ b/services/ui/service.cc
@@ -323,6 +323,8 @@ void Service::OnWillCreateTreeForWindowManager(
       ws::DisplayCreationConfig::MANUAL) {
 #if defined(USE_OZONE) && defined(OS_CHROMEOS)
     screen_manager_ = base::MakeUnique<display::ScreenManagerForwarding>();
+#elif defined(USE_OZONE) && !defined(OS_CHROMEOS)
+    screen_manager_ = display::ScreenManager::Create();
 #else
     CHECK(false);
 #endif

--- a/services/ui/ws/default_access_policy.cc
+++ b/services/ui/ws/default_access_policy.cc
@@ -4,8 +4,6 @@
 
 #include "services/ui/ws/default_access_policy.h"
 
-#include "base/command_line.h"
-#include "services/ui/common/switches.h"
 #include "services/ui/ws/access_policy_delegate.h"
 #include "services/ui/ws/server_window.h"
 
@@ -113,14 +111,6 @@ bool DefaultAccessPolicy::CanSetWindowCompositorFrameSink(
 }
 
 bool DefaultAccessPolicy::CanSetWindowBounds(const ServerWindow* window) const {
-  base::CommandLine* cmd_line = base::CommandLine::ForCurrentProcess();
-  // TODO(tonikitoo, msisov): our access policy model is not good enough
-  // at the moment and we rely on |delegate_->HasRootForAccessPolicy(window)|,
-  // when the browser runs, otherwise we fail to change bounds. But in case of
-  // unittests, there shouldn't be a call to |delegate_|. Fix this as soon as
-  // we have refactored the way how windows are created.
-  if (cmd_line->HasSwitch(switches::kUseTestConfig))
-    return WasCreatedByThisClient(window);
   return WasCreatedByThisClient(window) ||
          delegate_->HasRootForAccessPolicy(window);
 }

--- a/services/ui/ws/default_access_policy.cc
+++ b/services/ui/ws/default_access_policy.cc
@@ -111,8 +111,7 @@ bool DefaultAccessPolicy::CanSetWindowCompositorFrameSink(
 }
 
 bool DefaultAccessPolicy::CanSetWindowBounds(const ServerWindow* window) const {
-  return WasCreatedByThisClient(window) ||
-         delegate_->HasRootForAccessPolicy(window);
+  return WasCreatedByThisClient(window);
 }
 
 bool DefaultAccessPolicy::CanSetWindowTransform(

--- a/services/ui/ws/default_access_policy.cc
+++ b/services/ui/ws/default_access_policy.cc
@@ -121,9 +121,7 @@ bool DefaultAccessPolicy::CanSetWindowTransform(
 
 bool DefaultAccessPolicy::CanSetWindowProperties(
     const ServerWindow* window) const {
-  // TODO(msisov, tonikitoo): resolve policies issues.
-  return WasCreatedByThisClient(window) ||
-         delegate_->HasRootForAccessPolicy(window);
+  return WasCreatedByThisClient(window);
 }
 
 bool DefaultAccessPolicy::CanSetWindowTextInputState(

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -363,9 +363,18 @@ void Display::OnBoundsChanged(const gfx::Rect& new_bounds) {
 
   // WindowManagerDisplayRoot::root_ needs to be at 0,0 position relative
   // to its parent not to break mouse/touch events.
-  for (auto& pair : window_manager_display_root_map_)
+  for (auto& pair : window_manager_display_root_map_) {
     pair.second->root()->SetBounds(
         gfx::Rect(new_bounds.size()), allocator_.GenerateId());
+
+    // Null-check the ServerWindow here, because this call might be in
+    // the middle of a PlatformDisplay creation, before WT::AddRoot,
+    // where the visible root for the client is set.
+    if (pair.second->GetClientVisibleRoot()) {
+      pair.second->GetClientVisibleRoot()->SetBounds(
+          gfx::Rect(new_bounds.size()), allocator_.GenerateId());
+    }
+  }
 }
 
 void Display::OnCloseRequest() {
@@ -472,7 +481,8 @@ void Display::OnFocusChanged(FocusControllerChangeSource change_source,
     }
     embedded_tree_old = window_server_->GetTreeWithRoot(old_focused_window);
     if (embedded_tree_old) {
-      DCHECK_NE(owning_tree_old, embedded_tree_old);
+      // In external window mode, old and new tree can be the same.
+      // DCHECK_NE(owning_tree_old, embedded_tree_old);
       embedded_tree_old->ProcessFocusChanged(old_focused_window,
                                              new_focused_window);
     }
@@ -490,7 +500,8 @@ void Display::OnFocusChanged(FocusControllerChangeSource change_source,
     embedded_tree_new = window_server_->GetTreeWithRoot(new_focused_window);
     if (embedded_tree_new && embedded_tree_new != owning_tree_old &&
         embedded_tree_new != embedded_tree_old) {
-      DCHECK_NE(owning_tree_new, embedded_tree_new);
+      // In external window mode, old and new tree can be the same.
+      // DCHECK_NE(owning_tree_new, embedded_tree_new);
       embedded_tree_new->ProcessFocusChanged(old_focused_window,
                                              new_focused_window);
     }

--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -863,6 +863,19 @@ void WindowServer::OnWindowCursorChanged(ServerWindow* window,
   if (in_destructor_)
     return;
 
+  // In external window mode, cursor changes are forwarded to
+  // the visible root for the client associated ws::Display.
+  // This is because we are not using the WindowTree::WmSetGlobalOverrideCursor
+  // that mushrome uses. It arrive here via WindowTree::SetCursor.
+  // See comments in EventDispatcher::GetWindowForMouseCursor for details.
+  if (IsInExternalWindowMode()) {
+    WindowManagerDisplayRoot* display_root =
+        display_manager_->GetWindowManagerDisplayRoot(window);
+    if (display_root && display_root->GetClientVisibleRoot() == window) {
+      display_root->root()->SetCursor(cursor);
+    }
+  }
+
   ProcessWillChangeWindowCursor(window, cursor);
 
   UpdateNativeCursorIfOver(window);

--- a/services/ui/ws/window_tree_client_unittest.cc
+++ b/services/ui/ws/window_tree_client_unittest.cc
@@ -711,8 +711,11 @@ class WindowTreeClientTest : public WindowServerServiceTestBase {
                                 MakeRequest(&window_tree),
                                 std::move(tree_client_ptr));
     wt_client1_->set_tree(std::move(window_tree));
+    Id window_1_101 = wt_client1_->NewWindowWithCompleteId(BuildWindowId(1, 101));
+    ASSERT_EQ(0u, changes1()->size());
+
     std::unordered_map<std::string, std::vector<uint8_t>> transport_properties;
-    factory->CreatePlatformWindow(MakeRequest(&host_), BuildWindowId(1, 0),
+    factory->CreatePlatformWindow(MakeRequest(&host_), window_1_101,
                                   transport_properties);
 
     // Next we should get an embed call on the "window manager" client.

--- a/services/ui/ws/window_tree_host_factory_registrar.cc
+++ b/services/ui/ws/window_tree_host_factory_registrar.cc
@@ -4,10 +4,7 @@
 
 #include "services/ui/ws/window_tree_host_factory_registrar.h"
 
-#include "base/command_line.h"
-#include "services/ui/common/switches.h"
 #include "services/ui/ws/default_access_policy.h"
-#include "services/ui/ws/window_manager_access_policy.h"
 #include "services/ui/ws/window_server.h"
 #include "services/ui/ws/window_server_delegate.h"
 #include "services/ui/ws/window_tree.h"
@@ -43,20 +40,10 @@ void WindowTreeHostFactoryRegistrar::Register(
   window_server_->delegate()->OnWillCreateTreeForWindowManager(
     automatically_create_display_roots);
 
-  std::unique_ptr<ws::WindowTree> tree;
-  base::CommandLine* cmd_line = base::CommandLine::ForCurrentProcess();
-  if (cmd_line->HasSwitch(switches::kUseTestConfig)) {
-    // TODO(tonikitoo, msisov): unittests require WindowManagerAccessPolicy to
-    // pass. Figure out how to make them work with Default one if we are going
-    // to use that one as our main policy.
-    tree.reset(
-        new ws::WindowTree(window_server_, user_id_, nullptr /*ServerWindow*/,
-                           base::WrapUnique(new WindowManagerAccessPolicy())));
-  } else {
-    tree.reset(new ws::WindowTree(window_server_, user_id_,
-                                  nullptr /*ServerWindow*/,
-                                  base::WrapUnique(new DefaultAccessPolicy())));
-  }
+  // FIXME(tonikitoo,msisov,fwang): Do we need our own AccessPolicy?
+  std::unique_ptr<ws::WindowTree> tree(
+      new ws::WindowTree(window_server_, user_id_, nullptr /*ServerWindow*/,
+                         base::WrapUnique(new DefaultAccessPolicy())));
 
   std::unique_ptr<ws::DefaultWindowTreeBinding> tree_binding(
       new ws::DefaultWindowTreeBinding(tree.get(), window_server_,

--- a/services/ui/ws/window_tree_host_factory_registrar.cc
+++ b/services/ui/ws/window_tree_host_factory_registrar.cc
@@ -36,7 +36,7 @@ void WindowTreeHostFactoryRegistrar::Register(
   // but for the sake of an easier rebase, we are concentrating additions
   // like this here.
 
-  bool automatically_create_display_roots = true;
+  bool automatically_create_display_roots = false;
 
   // TODO(tonikitoo,msisov): Maybe remove the "window manager" suffix
   // if the method name?

--- a/services/ui/ws/window_tree_host_factory_registrar.cc
+++ b/services/ui/ws/window_tree_host_factory_registrar.cc
@@ -4,7 +4,7 @@
 
 #include "services/ui/ws/window_tree_host_factory_registrar.h"
 
-#include "services/ui/ws/default_access_policy.h"
+#include "services/ui/ws/window_manager_access_policy.h"
 #include "services/ui/ws/window_server.h"
 #include "services/ui/ws/window_server_delegate.h"
 #include "services/ui/ws/window_tree.h"
@@ -43,7 +43,7 @@ void WindowTreeHostFactoryRegistrar::Register(
   // FIXME(tonikitoo,msisov,fwang): Do we need our own AccessPolicy?
   std::unique_ptr<ws::WindowTree> tree(
       new ws::WindowTree(window_server_, user_id_, nullptr /*ServerWindow*/,
-                         base::WrapUnique(new DefaultAccessPolicy())));
+                         base::WrapUnique(new WindowManagerAccessPolicy)));
 
   std::unique_ptr<ws::DefaultWindowTreeBinding> tree_binding(
       new ws::DefaultWindowTreeBinding(tree.get(), window_server_,

--- a/ui/aura/mus/window_tree_host_mus.cc
+++ b/ui/aura/mus/window_tree_host_mus.cc
@@ -41,6 +41,11 @@ WindowTreeHostMus::WindowTreeHostMus(WindowTreeHostMusInitParams init_params)
       delegate_(init_params.window_tree_client) {
   gfx::Rect bounds_in_pixels;
   display_init_params_ = std::move(init_params.display_init_params);
+
+  // Copy the mus properties here in the display init paramaters instance,
+  // so that it is accessible from WTC::OnWindowMusCreated.
+  mus_init_properties_ = init_params.properties;
+
   if (display_init_params_)
     bounds_in_pixels = display_init_params_->viewport_metrics.bounds_in_pixels;
   window()->SetProperty(kWindowTreeHostMusKey, this);

--- a/ui/aura/mus/window_tree_host_mus.h
+++ b/ui/aura/mus/window_tree_host_mus.h
@@ -88,6 +88,14 @@ class AURA_EXPORT WindowTreeHostMus : public aura::WindowTreeHostPlatform {
   // supplied to the constructor.
   std::unique_ptr<DisplayInitParams> ReleaseDisplayInitParams();
 
+  // Used during the initial set up (in external window mode). It holds a
+  // copy of the properties needed by the window server when creating a
+  // root server window.
+  const std::map<std::string, std::vector<uint8_t>>& mus_init_properties()
+      const {
+    return mus_init_properties_;
+  }
+
   // Intended only for WindowTreeClient to call.
   void set_display_id(int64_t id) { display_id_ = id; }
   int64_t display_id() const { return display_id_; }
@@ -113,6 +121,8 @@ class AURA_EXPORT WindowTreeHostMus : public aura::WindowTreeHostPlatform {
   std::unique_ptr<InputMethodMus> input_method_;
 
   std::unique_ptr<DisplayInitParams> display_init_params_;
+
+  std::map<std::string, std::vector<uint8_t>> mus_init_properties_;
 
   DISALLOW_COPY_AND_ASSIGN(WindowTreeHostMus);
 };


### PR DESCRIPTION
This allows us to have the same three hiearchy as ChromeOS and use WindowManagerAccessPolicy for both chrome/mus and unit tests.