### PR TITLE
Avoid too much glitching at chrome/mus start up

### DIFF
--- a/chrome/browser/ui/views/frame/browser_frame_mus.cc
+++ b/chrome/browser/ui/views/frame/browser_frame_mus.cc
@@ -33,7 +33,6 @@ views::Widget::InitParams BrowserFrameMus::GetWidgetParams() {
   views::Widget::InitParams params;
   params.name = "BrowserFrame";
   params.native_widget = this;
-  params.bounds = gfx::Rect(10, 10, 640, 480);
   params.delegate = browser_view_;
   std::map<std::string, std::vector<uint8_t>> properties =
       views::MusClient::ConfigurePropertiesFromParams(params);
@@ -42,6 +41,7 @@ views::Widget::InitParams BrowserFrameMus::GetWidgetParams() {
   properties[ui::mojom::WindowManager::kDisableImmersive_InitProperty] =
       mojo::ConvertTo<std::vector<uint8_t>>(true);
 #if defined(OS_CHROMEOS)
+  params.bounds = gfx::Rect(10, 10, 640, 480);
   properties[ash::mojom::kAshWindowStyle_InitProperty] =
       mojo::ConvertTo<std::vector<uint8_t>>(
           static_cast<int32_t>(ash::mojom::WindowStyle::BROWSER));


### PR DESCRIPTION
The standard size that chrome is created for Mus is
hardcoded at browser_frame_mus.cc: 640x480. But
when run in external window mode, chrome's startup
logic takes place and sizes it accordingly to the default
browser bounds, in [1].
This conflict in the startup bounds cause glitches.

Patch makes the property that specific Chrome/mus size
in browser_frame_mus.cc ChromeOS specific, avoid some
glitches at start up.

[1] chrome/browser/ui/window_sizer/window_sizer.cc