### PR TITLE
Tie synchronizing_with_child_on_next_frame_ and holding_pointer_moves…

### DIFF
--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -745,7 +745,7 @@ void WindowTreeClient::ScheduleInFlightBoundsChange(
       window->window_mus_type() == WindowMusType::DISPLAY_MANUALLY_CREATED ||
       window->HasLocalLayerTreeFrameSink()) {
     local_surface_id = window->GetOrAllocateLocalSurfaceId(new_bounds.size());
-    synchronizing_with_child_on_next_frame_ = true;
+    host_sync_data_[GetWindowTreeHostMus(window)] = { true, false };
   }
   tree_->SetWindowBounds(change_id, window->server_id(), new_bounds,
                          local_surface_id);
@@ -2261,26 +2261,32 @@ void WindowTreeClient::OnCompositingDidCommit(ui::Compositor* compositor) {}
 
 void WindowTreeClient::OnCompositingStarted(ui::Compositor* compositor,
                                             base::TimeTicks start_time) {
-  if (!synchronizing_with_child_on_next_frame_)
-    return;
-  synchronizing_with_child_on_next_frame_ = false;
   WindowTreeHost* host =
       WindowTreeHost::GetForAcceleratedWidget(compositor->widget());
+
+  auto it = host_sync_data_.find(host);
+  DCHECK(it != host_sync_data_.end());
+  if (!it->second.synchronizing_with_child_on_next_frame_)
+    return;
+  it->second.synchronizing_with_child_on_next_frame_ = false;
   // Unit tests have a null widget and thus may not have an associated
   // WindowTreeHost.
   if (host) {
     host->dispatcher()->HoldPointerMoves();
-    holding_pointer_moves_ = true;
+    it->second.holding_pointer_moves_ = true;
   }
 }
 
 void WindowTreeClient::OnCompositingEnded(ui::Compositor* compositor) {
-  if (!holding_pointer_moves_)
-    return;
   WindowTreeHost* host =
       WindowTreeHost::GetForAcceleratedWidget(compositor->widget());
+
+  auto it = host_sync_data_.find(host);
+  DCHECK(it != host_sync_data_.end());
+  if (!it->second.holding_pointer_moves_)
+    return;
   host->dispatcher()->ReleasePointerMoves();
-  holding_pointer_moves_ = false;
+  it->second.holding_pointer_moves_ = false;
 }
 
 void WindowTreeClient::OnCompositingLockStateChanged(

--- a/ui/aura/mus/window_tree_client.h
+++ b/ui/aura/mus/window_tree_client.h
@@ -78,6 +78,7 @@ class WindowTreeClientPrivate;
 class WindowTreeClientObserver;
 class WindowTreeClientTestObserver;
 class WindowTreeHostMus;
+class WindowTreeHost;
 
 using EventResultCallback = base::Callback<void(ui::mojom::EventResult)>;
 
@@ -665,11 +666,14 @@ class AURA_EXPORT WindowTreeClient
   // Set to true once OnWmDisplayAdded() is called.
   bool got_initial_displays_ = false;
 
-  // Set to true if the next CompositorFrame will block on a new child surface.
-  bool synchronizing_with_child_on_next_frame_ = false;
+  struct SyncData {
+    // Set to true if the next CompositorFrame will block on a new child surface.
+    bool synchronizing_with_child_on_next_frame_;
 
-  // Set to true if this WindowTreeClient is currently holding pointer moves.
-  bool holding_pointer_moves_ = false;
+    // Set to true if this WindowTreeClient is currently holding pointer moves.
+    bool holding_pointer_moves_;
+  };
+  std::map<WindowTreeHost*, SyncData> host_sync_data_;
 
   gfx::Insets normal_client_area_insets_;
 


### PR DESCRIPTION
…_ to host instances

Today, we have two control variables that are per WindowTreeClient instance:
synchronizing_with_child_on_next_frame_ and holding_pointer_moves_, although
they control the state of WindowTreeHostMus instances.

This design works for internal window mode, where it is unexpected more than
one WindowTreeHostMus instance (the one for the window manager), but it does
not work nicely for external window mode, where each browser window and even
specific widgets (3-dot menus) are associated with their own WindowTreeHostMus
instances.

This causes assert to be hit when browser with multiple windows, or creating
and closing (3-dot) menus extensively.

PR ties both class variables (synchronizing_with_child_on_next_frame_
and holding_pointer_moves_) to WindowTreeHostMus instances, through
a std::map.

Issue #125