### PR TITLE
[Wayland] Add xdg_v6 support

### DIFF
--- a/ui/ozone/platform/wayland/BUILD.gn
+++ b/ui/ozone/platform/wayland/BUILD.gn
@@ -32,6 +32,16 @@ source_set("wayland") {
     "wayland_surface_factory.h",
     "wayland_window.cc",
     "wayland_window.h",
+    "xdg_popup_wrapper.h",
+    "xdg_popup_wrapper_v5.cc",
+    "xdg_popup_wrapper_v5.h",
+    "xdg_popup_wrapper_v6.cc",
+    "xdg_popup_wrapper_v6.h",
+    "xdg_surface_wrapper.h",
+    "xdg_surface_wrapper_v5.cc",
+    "xdg_surface_wrapper_v5.h",
+    "xdg_surface_wrapper_v6.cc",
+    "xdg_surface_wrapper_v6.h",
   ]
 
   import("//ui/base/ui_features.gni")

--- a/ui/ozone/platform/wayland/wayland_connection.cc
+++ b/ui/ozone/platform/wayland/wayland_connection.cc
@@ -5,6 +5,7 @@
 #include "ui/ozone/platform/wayland/wayland_connection.h"
 
 #include <xdg-shell-unstable-v5-client-protocol.h>
+#include <xdg-shell-unstable-v6-client-protocol.h>
 
 #include "base/bind.h"
 #include "base/logging.h"
@@ -61,7 +62,7 @@ bool WaylandConnection::Initialize() {
     LOG(ERROR) << "No wl_seat object";
     return false;
   }
-  if (!shell_) {
+  if (!shell_v6_ && !shell_) {
     LOG(ERROR) << "No xdg_shell object";
     return false;
   }
@@ -159,6 +160,9 @@ void WaylandConnection::Global(void* data,
   static const wl_seat_listener seat_listener = {
       &WaylandConnection::Capabilities, &WaylandConnection::Name,
   };
+  static const zxdg_shell_v6_listener shell_v6_listener = {
+      &WaylandConnection::PingV6,
+  };
   static const xdg_shell_listener shell_listener = {
       &WaylandConnection::Ping,
   };
@@ -182,7 +186,19 @@ void WaylandConnection::Global(void* data,
       return;
     }
     wl_seat_add_listener(connection->seat_.get(), &seat_listener, connection);
-  } else if (!connection->shell_ && strcmp(interface, "xdg_shell") == 0) {
+  } else if (!connection->shell_v6_ &&
+             strcmp(interface, "zxdg_shell_v6") == 0) {
+    // Check for zxdg_shell_v6 first.
+    connection->shell_v6_ = wl::Bind<zxdg_shell_v6>(
+        registry, name, std::min(version, kMaxXdgShellVersion));
+    if (!connection->shell_v6_) {
+      LOG(ERROR) << "Failed to  bind to zxdg_shell_v6 global";
+      return;
+    }
+    zxdg_shell_v6_add_listener(connection->shell_v6_.get(), &shell_v6_listener,
+                               connection);
+  } else if (!connection->shell_v6_ && !connection->shell_ &&
+             strcmp(interface, "xdg_shell") == 0) {
     connection->shell_ = wl::Bind<xdg_shell>(
         registry, name, std::min(version, kMaxXdgShellVersion));
     if (!connection->shell_) {
@@ -261,6 +277,15 @@ void WaylandConnection::Capabilities(void* data,
 
 // static
 void WaylandConnection::Name(void* data, wl_seat* seat, const char* name) {}
+
+// static
+void WaylandConnection::PingV6(void* data,
+                               zxdg_shell_v6* shell_v6,
+                               uint32_t serial) {
+  WaylandConnection* connection = static_cast<WaylandConnection*>(data);
+  zxdg_shell_v6_pong(shell_v6, serial);
+  connection->ScheduleFlush();
+}
 
 // static
 void WaylandConnection::Ping(void* data, xdg_shell* shell, uint32_t serial) {

--- a/ui/ozone/platform/wayland/wayland_connection.h
+++ b/ui/ozone/platform/wayland/wayland_connection.h
@@ -35,6 +35,7 @@ class WaylandConnection : public PlatformEventSource,
   wl_compositor* compositor() { return compositor_.get(); }
   wl_shm* shm() { return shm_.get(); }
   xdg_shell* shell() { return shell_.get(); }
+  zxdg_shell_v6* shell_v6() { return shell_v6_.get(); }
   wl_seat* seat() { return seat_.get(); }
 
   WaylandWindow* GetWindow(gfx::AcceleratedWidget widget);
@@ -71,6 +72,9 @@ class WaylandConnection : public PlatformEventSource,
   static void Capabilities(void* data, wl_seat* seat, uint32_t capabilities);
   static void Name(void* data, wl_seat* seat, const char* name);
 
+  // zxdg_shell_v6_listener
+  static void PingV6(void* data, zxdg_shell_v6* zxdg_shell_v6, uint32_t serial);
+
   // xdg_shell_listener
   static void Ping(void* data, xdg_shell* shell, uint32_t serial);
 
@@ -82,6 +86,7 @@ class WaylandConnection : public PlatformEventSource,
   wl::Object<wl_seat> seat_;
   wl::Object<wl_shm> shm_;
   wl::Object<xdg_shell> shell_;
+  wl::Object<zxdg_shell_v6> shell_v6_;
 
   std::unique_ptr<WaylandPointer> pointer_;
   std::unique_ptr<WaylandKeyboard> keyboard_;

--- a/ui/ozone/platform/wayland/wayland_object.cc
+++ b/ui/ozone/platform/wayland/wayland_object.cc
@@ -6,6 +6,7 @@
 
 #include <wayland-client.h>
 #include <xdg-shell-unstable-v5-client-protocol.h>
+#include <xdg-shell-unstable-v6-client-protocol.h>
 
 namespace wl {
 namespace {
@@ -32,6 +33,31 @@ void delete_seat(wl_seat* seat) {
 }
 
 }  // namespace
+
+const wl_interface* ObjectTraits<zxdg_shell_v6>::interface =
+    &zxdg_shell_v6_interface;
+void (*ObjectTraits<zxdg_shell_v6>::deleter)(zxdg_shell_v6*) =
+    &zxdg_shell_v6_destroy;
+
+const wl_interface* ObjectTraits<zxdg_surface_v6>::interface =
+    &zxdg_surface_v6_interface;
+void (*ObjectTraits<zxdg_surface_v6>::deleter)(zxdg_surface_v6*) =
+    &zxdg_surface_v6_destroy;
+
+const wl_interface* ObjectTraits<zxdg_toplevel_v6>::interface =
+    &zxdg_toplevel_v6_interface;
+void (*ObjectTraits<zxdg_toplevel_v6>::deleter)(zxdg_toplevel_v6*) =
+    &zxdg_toplevel_v6_destroy;
+
+const wl_interface* ObjectTraits<zxdg_popup_v6>::interface =
+    &zxdg_popup_v6_interface;
+void (*ObjectTraits<zxdg_popup_v6>::deleter)(zxdg_popup_v6*) =
+    &zxdg_popup_v6_destroy;
+
+const wl_interface* ObjectTraits<zxdg_positioner_v6>::interface =
+    &zxdg_positioner_v6_interface;
+void (*ObjectTraits<zxdg_positioner_v6>::deleter)(zxdg_positioner_v6*) =
+    &zxdg_positioner_v6_destroy;
 
 const wl_interface* ObjectTraits<wl_buffer>::interface = &wl_buffer_interface;
 void (*ObjectTraits<wl_buffer>::deleter)(wl_buffer*) = &wl_buffer_destroy;

--- a/ui/ozone/platform/wayland/wayland_object.h
+++ b/ui/ozone/platform/wayland/wayland_object.h
@@ -9,6 +9,12 @@
 
 #include <memory>
 
+struct zxdg_shell_v6;
+struct zxdg_surface_v6;
+struct zxdg_toplevel_v6;
+struct zxdg_popup_v6;
+struct zxdg_positioner_v6;
+
 struct wl_buffer;
 struct wl_compositor;
 struct wl_keyboard;
@@ -27,6 +33,36 @@ namespace wl {
 
 template <typename T>
 struct ObjectTraits;
+
+template <>
+struct ObjectTraits<zxdg_shell_v6> {
+  static const wl_interface* interface;
+  static void (*deleter)(zxdg_shell_v6*);
+};
+
+template <>
+struct ObjectTraits<zxdg_surface_v6> {
+  static const wl_interface* interface;
+  static void (*deleter)(zxdg_surface_v6*);
+};
+
+template <>
+struct ObjectTraits<zxdg_toplevel_v6> {
+  static const wl_interface* interface;
+  static void (*deleter)(zxdg_toplevel_v6*);
+};
+
+template <>
+struct ObjectTraits<zxdg_popup_v6> {
+  static const wl_interface* interface;
+  static void (*deleter)(zxdg_popup_v6*);
+};
+
+template <>
+struct ObjectTraits<zxdg_positioner_v6> {
+  static const wl_interface* interface;
+  static void (*deleter)(zxdg_positioner_v6*);
+};
 
 template <>
 struct ObjectTraits<wl_buffer> {

--- a/ui/ozone/platform/wayland/xdg_popup_wrapper.h
+++ b/ui/ozone/platform/wayland/xdg_popup_wrapper.h
@@ -1,0 +1,29 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_OZONE_PLATFORM_WAYLAND_XDG_POPUP_WRAPPER_H_
+#define UI_OZONE_PLATFORM_WAYLAND_XDG_POPUP_WRAPPER_H_
+
+#include "ui/gfx/geometry/rect.h"
+#include "ui/ozone/platform/wayland/wayland_object.h"
+
+namespace ui {
+
+class WaylandConnection;
+
+// A wrapper around different versions of xdg popups.
+class XDGPopupWrapper {
+ public:
+  virtual ~XDGPopupWrapper() {}
+
+  // Creates actual xdg popup object and sets a listener to it.
+  virtual bool Initialize(WaylandConnection* connection,
+                          wl_surface* surface,
+                          wl_surface* parent_surface,
+                          const gfx::Rect& bounds) = 0;
+};
+
+}  // namespace ui
+
+#endif  // UI_OZONE_PLATFORM_WAYLAND_XDG_POPUP_WRAPPER_H_

--- a/ui/ozone/platform/wayland/xdg_popup_wrapper_v5.cc
+++ b/ui/ozone/platform/wayland/xdg_popup_wrapper_v5.cc
@@ -1,0 +1,50 @@
+L  // Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/ozone/platform/wayland/xdg_popup_wrapper_v5.h"
+
+#include <xdg-shell-unstable-v5-client-protocol.h>
+
+#include "ui/gfx/geometry/rect.h"
+#include "ui/ozone/platform/wayland/wayland_connection.h"
+#include "ui/ozone/platform/wayland/wayland_window.h"
+
+    namespace ui {
+
+  XDGPopupWrapperV5::XDGPopupWrapperV5(WaylandWindow * wayland_window)
+      : wayland_window_(wayland_window) {}
+
+  XDGPopupWrapperV5::~XDGPopupWrapperV5() {
+    wl_surface_attach(surface_, NULL, 0, 0);
+    wl_surface_commit(surface_);
+  }
+
+  bool XDGPopupWrapperV5::Initialize(
+      WaylandConnection * connection, wl_surface * surface,
+      wl_surface * parent_surface, const gfx::Rect& bounds) {
+    DCHECK(connection && surface && parent_surface);
+    static const xdg_popup_listener xdg_popup_listener = {
+        &XDGPopupWrapperV5::PopupDone,
+    };
+
+    surface_ = surface;
+    xdg_popup_.reset(xdg_shell_get_xdg_popup(
+        connection->shell(), surface, parent_surface, connection->seat(),
+        connection->serial(), bounds.x(), bounds.y()));
+
+    xdg_popup_add_listener(xdg_popup_.get(), &xdg_popup_listener, this);
+
+    return true;
+  }
+
+  // static
+  void XDGPopupWrapperV5::PopupDone(void* data, xdg_popup* obj) {
+    WaylandWindow* window =
+        static_cast<XDGPopupWrapperV5*>(data)->wayland_window_;
+    DCHECK(window);
+    window->Hide();
+    window->OnCloseRequest();
+  }
+
+}  // namespace ui

--- a/ui/ozone/platform/wayland/xdg_popup_wrapper_v5.h
+++ b/ui/ozone/platform/wayland/xdg_popup_wrapper_v5.h
@@ -1,0 +1,38 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_OZONE_PLATFORM_WAYLAND_XDG_POPUP_WRAPPER_V5_H_
+#define UI_OZONE_PLATFORM_WAYLAND_XDG_POPUP_WRAPPER_V5_H_
+
+#include "ui/ozone/platform/wayland/xdg_popup_wrapper.h"
+
+namespace ui {
+
+class WaylandConnection;
+class WaylandWindow;
+
+class XDGPopupWrapperV5 : public XDGPopupWrapper {
+ public:
+  XDGPopupWrapperV5(WaylandWindow* wayland_window);
+  ~XDGPopupWrapperV5() override;
+
+  bool Initialize(WaylandConnection* connection,
+                  wl_surface* surface,
+                  wl_surface* parent_surface,
+                  const gfx::Rect& bounds) override;
+
+  // xdg_popup_listener
+  static void PopupDone(void* data, xdg_popup* obj);
+
+ private:
+  WaylandWindow* wayland_window_;
+  wl_surface* surface_;
+  wl::Object<xdg_popup> xdg_popup_;
+
+  DISALLOW_COPY_AND_ASSIGN(XDGPopupWrapperV5);
+};
+
+}  // namespace ui
+
+#endif  // UI_OZONE_PLATFORM_WAYLAND_XDG_POPUP_WRAPPER_V5_H_

--- a/ui/ozone/platform/wayland/xdg_popup_wrapper_v6.cc
+++ b/ui/ozone/platform/wayland/xdg_popup_wrapper_v6.cc
@@ -1,0 +1,118 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/ozone/platform/wayland/xdg_popup_wrapper_v6.h"
+
+#include <xdg-shell-unstable-v6-client-protocol.h>
+
+#include "ui/gfx/geometry/rect.h"
+#include "ui/ozone/platform/wayland/wayland_connection.h"
+#include "ui/ozone/platform/wayland/wayland_window.h"
+#include "ui/ozone/platform/wayland/xdg_surface_wrapper_v6.h"
+
+namespace ui {
+
+XDGPopupWrapperV6::XDGPopupWrapperV6(std::unique_ptr<XDGSurfaceWrapper> surface,
+                                     WaylandWindow* wayland_window)
+    : wayland_window_(wayland_window), zxdg_surface_v6_(std::move(surface)) {
+  DCHECK(zxdg_surface_v6_);
+}
+
+XDGPopupWrapperV6::~XDGPopupWrapperV6() {}
+
+// TODO(msisov): pass parent window here.
+bool XDGPopupWrapperV6::Initialize(WaylandConnection* connection,
+                                   wl_surface* surface,
+                                   wl_surface* parent_surface,
+                                   const gfx::Rect& bounds) {
+  static const struct zxdg_popup_v6_listener zxdg_popup_v6_listener = {
+      &XDGPopupWrapperV6::Configure, &XDGPopupWrapperV6::PopupDone,
+  };
+
+  XDGSurfaceWrapperV6* xdg_surface =
+      static_cast<XDGSurfaceWrapperV6*>(zxdg_surface_v6_.get());
+  if (!xdg_surface)
+    return false;
+
+  WaylandWindow* parent_window = WaylandWindow::FromSurface(parent_surface);
+  DCHECK(parent_window);
+
+  XDGSurfaceWrapperV6* parent_xdg_surface;
+  // If the parent window is a popup, the surface of that popup must be used as
+  // a parent.
+  if (parent_window->is_popup()) {
+    XDGPopupWrapperV6* popup =
+        reinterpret_cast<XDGPopupWrapperV6*>(parent_window->xdg_popup());
+    parent_xdg_surface =
+        reinterpret_cast<XDGSurfaceWrapperV6*>(popup->xdg_surface());
+  } else {
+    parent_xdg_surface =
+        reinterpret_cast<XDGSurfaceWrapperV6*>(parent_window->xdg_surface());
+  }
+  if (!parent_xdg_surface)
+    return false;
+
+  zxdg_positioner_v6* positioner = CreatePositioner(connection, bounds);
+  if (!positioner)
+    return false;
+
+  xdg_popup_.reset(zxdg_surface_v6_get_popup(xdg_surface->xdg_surface(),
+                                             parent_xdg_surface->xdg_surface(),
+                                             positioner));
+  if (!xdg_popup_)
+    return false;
+
+  zxdg_positioner_v6_destroy(positioner);
+
+  zxdg_popup_v6_grab(xdg_popup_.get(), connection->seat(),
+                     connection->serial());
+  zxdg_popup_v6_add_listener(xdg_popup_.get(), &zxdg_popup_v6_listener, this);
+
+  wl_surface_commit(surface);
+  return true;
+}
+
+zxdg_positioner_v6* XDGPopupWrapperV6::CreatePositioner(
+    WaylandConnection* connection,
+    const gfx::Rect& bounds) {
+  struct zxdg_positioner_v6* positioner;
+  positioner = zxdg_shell_v6_create_positioner(connection->shell_v6());
+  if (!positioner)
+    return nullptr;
+
+  zxdg_positioner_v6_set_anchor_rect(positioner, bounds.x(), bounds.y(), 1, 1);
+  zxdg_positioner_v6_set_size(positioner, bounds.width(), bounds.height());
+  zxdg_positioner_v6_set_anchor(
+      positioner,
+      ZXDG_POSITIONER_V6_ANCHOR_TOP | ZXDG_POSITIONER_V6_ANCHOR_RIGHT);
+  zxdg_positioner_v6_set_gravity(
+      positioner,
+      ZXDG_POSITIONER_V6_ANCHOR_BOTTOM | ZXDG_POSITIONER_V6_ANCHOR_RIGHT);
+  return positioner;
+}
+
+// static
+void XDGPopupWrapperV6::Configure(void* data,
+                                  struct zxdg_popup_v6* zxdg_popup_v6,
+                                  int32_t x,
+                                  int32_t y,
+                                  int32_t width,
+                                  int32_t height) {}
+
+// static
+void XDGPopupWrapperV6::PopupDone(void* data,
+                                  struct zxdg_popup_v6* zxdg_popup_v6) {
+  WaylandWindow* window =
+      static_cast<XDGPopupWrapperV6*>(data)->wayland_window_;
+  DCHECK(window);
+  window->Hide();
+  window->OnCloseRequest();
+}
+
+XDGSurfaceWrapper* XDGPopupWrapperV6::xdg_surface() {
+  DCHECK(zxdg_surface_v6_.get());
+  return zxdg_surface_v6_.get();
+}
+
+}  // namespace ui

--- a/ui/ozone/platform/wayland/xdg_popup_wrapper_v6.h
+++ b/ui/ozone/platform/wayland/xdg_popup_wrapper_v6.h
@@ -1,0 +1,52 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_OZONE_PLATFORM_WAYLAND_XDG_POPUP_WRAPPER_V6_H_
+#define UI_OZONE_PLATFORM_WAYLAND_XDG_POPUP_WRAPPER_V6_H_
+
+#include "ui/ozone/platform/wayland/xdg_popup_wrapper.h"
+
+namespace ui {
+
+class XDGSurfaceWrapper;
+class WaylandConnection;
+class WaylandWindow;
+
+class XDGPopupWrapperV6 : public XDGPopupWrapper {
+ public:
+  XDGPopupWrapperV6(std::unique_ptr<XDGSurfaceWrapper> surface,
+                    WaylandWindow* wayland_window);
+  ~XDGPopupWrapperV6() override;
+
+  // XDGPopupWrapper:
+  bool Initialize(WaylandConnection* connection,
+                  wl_surface* surface,
+                  wl_surface* parent_surface,
+                  const gfx::Rect& bounds) override;
+
+  zxdg_positioner_v6* CreatePositioner(WaylandConnection* connection,
+                                       const gfx::Rect& bounds);
+
+  // xdg_popup_listener
+  static void Configure(void* data,
+                        struct zxdg_popup_v6* zxdg_popup_v6,
+                        int32_t x,
+                        int32_t y,
+                        int32_t width,
+                        int32_t height);
+  static void PopupDone(void* data, struct zxdg_popup_v6* zxdg_popup_v6);
+
+  XDGSurfaceWrapper* xdg_surface();
+
+ private:
+  WaylandWindow* wayland_window_;
+  std::unique_ptr<XDGSurfaceWrapper> zxdg_surface_v6_;
+  wl::Object<zxdg_popup_v6> xdg_popup_;
+
+  DISALLOW_COPY_AND_ASSIGN(XDGPopupWrapperV6);
+};
+
+}  // namespace ui
+
+#endif  // UI_OZONE_PLATFORM_WAYLAND_XDG_POPUP_WRAPPER_V6_H_

--- a/ui/ozone/platform/wayland/xdg_surface_wrapper.h
+++ b/ui/ozone/platform/wayland/xdg_surface_wrapper.h
@@ -1,0 +1,57 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_OZONE_PLATFORM_WAYLAND_XDG_SURFACE_WRAPPER_H_
+#define UI_OZONE_PLATFORM_WAYLAND_XDG_SURFACE_WRAPPER_H_
+
+#include "base/strings/string16.h"
+#include "ui/ozone/platform/wayland/wayland_object.h"
+
+namespace ui {
+
+class WaylandConnection;
+
+// Wrapper interface for different xdg shell versions.
+class XDGSurfaceWrapper {
+ public:
+  virtual ~XDGSurfaceWrapper() {}
+
+  // Initializes the surface. If |with_toplevel| is true, the surface is
+  // assigned a top level role, which results in a normal native window.
+  virtual bool Initialize(WaylandConnection* connection,
+                          wl_surface* surface,
+                          bool with_toplevel) = 0;
+
+  // Sets a native window to maximized state.
+  virtual void SetMaximized() = 0;
+
+  // Unsets a native window from maximized state.
+  virtual void UnSetMaximized() = 0;
+
+  // Sets a native window to fullscreen state.
+  virtual void SetFullScreen() = 0;
+
+  // Unsets a native window from fullscreen state.
+  virtual void UnSetFullScreen() = 0;
+
+  // Sets a native window to minimized state.
+  virtual void SetMinimized() = 0;
+
+  // Tells wayland to start interactive window drag.
+  virtual void SurfaceMove(WaylandConnection* connection) = 0;
+
+  // Tells wayland to start interactive window resize.
+  virtual void SurfaceResize(WaylandConnection* connection,
+                             uint32_t hittest) = 0;
+
+  // Sets a title of a native window.
+  virtual void SetTitle(const base::string16& title) = 0;
+
+  // Sends acknowledge configure event back to wayland.
+  virtual void AckConfigure() = 0;
+};
+
+}  // namespace ui
+
+#endif  // UI_OZONE_PLATFORM_WAYLAND_XDG_SURFACE_WRAPPER_H_

--- a/ui/ozone/platform/wayland/xdg_surface_wrapper_v5.cc
+++ b/ui/ozone/platform/wayland/xdg_surface_wrapper_v5.cc
@@ -1,0 +1,162 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/ozone/platform/wayland/xdg_surface_wrapper_v5.h"
+
+#include <xdg-shell-unstable-v5-client-protocol.h>
+
+#include "base/strings/utf_string_conversions.h"
+#include "ui/base/hit_test.h"
+#include "ui/ozone/platform/wayland/wayland_connection.h"
+#include "ui/ozone/platform/wayland/wayland_window.h"
+
+namespace ui {
+
+namespace {
+
+// Identifies the direction of the "hittest" for Wayland.
+bool IdentifyDirection(int hittest, int* direction) {
+  DCHECK(direction);
+  *direction = -1;
+  switch (hittest) {
+    case HTBOTTOM:
+      *direction = xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_BOTTOM;
+      break;
+    case HTBOTTOMLEFT:
+      *direction = xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_BOTTOM_LEFT;
+      break;
+    case HTBOTTOMRIGHT:
+      *direction =
+          xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_BOTTOM_RIGHT;
+      break;
+    case HTLEFT:
+      *direction = xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_LEFT;
+      break;
+    case HTRIGHT:
+      *direction = xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_RIGHT;
+      break;
+    case HTTOP:
+      *direction = xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_TOP;
+      break;
+    case HTTOPLEFT:
+      *direction = xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_TOP_LEFT;
+      break;
+    case HTTOPRIGHT:
+      *direction = xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_TOP_RIGHT;
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+XDGSurfaceWrapperV5::XDGSurfaceWrapperV5(WaylandWindow* wayland_window)
+    : wayland_window_(wayland_window) {}
+
+XDGSurfaceWrapperV5::~XDGSurfaceWrapperV5() {}
+
+bool XDGSurfaceWrapperV5::Initialize(WaylandConnection* connection,
+                                     wl_surface* surface,
+                                     bool with_toplevel /* not used */) {
+  static const xdg_surface_listener xdg_surface_listener = {
+      &XDGSurfaceWrapperV5::Configure, &XDGSurfaceWrapperV5::Close,
+  };
+  xdg_surface_.reset(xdg_shell_get_xdg_surface(connection->shell(), surface));
+  if (!xdg_surface_) {
+    LOG(ERROR) << "Failed to create xdg_surface";
+    return false;
+  }
+  xdg_surface_add_listener(xdg_surface_.get(), &xdg_surface_listener, this);
+  return true;
+}
+
+void XDGSurfaceWrapperV5::SetMaximized() {
+  xdg_surface_set_maximized(xdg_surface_.get());
+}
+
+void XDGSurfaceWrapperV5::UnSetMaximized() {
+  xdg_surface_unset_maximized(xdg_surface_.get());
+}
+
+void XDGSurfaceWrapperV5::SetFullScreen() {
+  xdg_surface_set_fullscreen(xdg_surface_.get(), nullptr);
+}
+
+void XDGSurfaceWrapperV5::UnSetFullScreen() {
+  xdg_surface_unset_fullscreen(xdg_surface_.get());
+}
+
+void XDGSurfaceWrapperV5::SetMinimized() {
+  xdg_surface_set_minimized(xdg_surface_.get());
+}
+
+void XDGSurfaceWrapperV5::SurfaceMove(WaylandConnection* connection) {
+  xdg_surface_move(xdg_surface_.get(), connection->seat(),
+                   connection->serial());
+}
+
+void XDGSurfaceWrapperV5::SurfaceResize(WaylandConnection* connection,
+                                        uint32_t hittest) {
+  int direction;
+  if (!IdentifyDirection(hittest, &direction))
+    return;
+  xdg_surface_resize(xdg_surface_.get(), connection->seat(),
+                     connection->serial(), direction);
+}
+
+void XDGSurfaceWrapperV5::SetTitle(const base::string16& title) {
+  xdg_surface_set_title(xdg_surface_.get(), UTF16ToUTF8(title).c_str());
+}
+
+void XDGSurfaceWrapperV5::AckConfigure() {
+  xdg_surface_ack_configure(xdg_surface_.get(), pending_configure_serial_);
+}
+
+// static
+void XDGSurfaceWrapperV5::Configure(void* data,
+                                    xdg_surface* obj,
+                                    int32_t width,
+                                    int32_t height,
+                                    wl_array* states,
+                                    uint32_t serial) {
+  XDGSurfaceWrapperV5* surface = static_cast<XDGSurfaceWrapperV5*>(data);
+
+  bool is_maximized = false;
+  bool is_fullscreen = false;
+
+  // wl_array_for_each has a bug in upstream. It tries to assign void* to
+  // uint32_t *, which is not allowed in C++. Explicit cast should be
+  // performed. In other words, one just cannot assign void * to other pointer
+  // type implicitly in C++ as in C. We can't modify wayland-util.h, because
+  // it is fetched with gclient sync. Thus, use own loop.
+  // TODO(msisov, tonikitoo): use wl_array_for_each as soon as
+  // https://bugs.freedesktop.org/show_bug.cgi?id=101618 is resolved.
+  uint32_t* state = reinterpret_cast<uint32_t*>(states->data);
+  size_t array_size = states->size / sizeof(uint32_t);
+  for (size_t i = 0; i < array_size; i++) {
+    switch (state[i]) {
+      case (XDG_SURFACE_STATE_MAXIMIZED):
+        is_maximized = true;
+        break;
+      case (XDG_SURFACE_STATE_FULLSCREEN):
+        is_fullscreen = true;
+        break;
+      default:
+        break;
+    }
+  }
+
+  surface->pending_configure_serial_ = serial;
+  surface->wayland_window_->HandleSurfaceConfigure(width, height, is_maximized,
+                                                   is_fullscreen);
+}
+
+// static
+void XDGSurfaceWrapperV5::Close(void* data, xdg_surface* obj) {
+  NOTIMPLEMENTED();
+}
+
+}  // namespace ui

--- a/ui/ozone/platform/wayland/xdg_surface_wrapper_v5.h
+++ b/ui/ozone/platform/wayland/xdg_surface_wrapper_v5.h
@@ -1,0 +1,55 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_OZONE_PLATFORM_WAYLAND_XDG_SURFACE_WRAPPER_V5_H_
+#define UI_OZONE_PLATFORM_WAYLAND_XDG_SURFACE_WRAPPER_V5_H_
+
+#include "ui/ozone/platform/wayland/xdg_surface_wrapper.h"
+
+#include "base/macros.h"
+
+namespace ui {
+
+class WaylandConnection;
+class WaylandWindow;
+
+class XDGSurfaceWrapperV5 : public XDGSurfaceWrapper {
+ public:
+  XDGSurfaceWrapperV5(WaylandWindow* wayland_window);
+  ~XDGSurfaceWrapperV5() override;
+
+  // XDGSurfaceWrapper:
+  bool Initialize(WaylandConnection* connection,
+                  wl_surface* surface,
+                  bool with_toplevel /* not used */) override;
+  void SetMaximized() override;
+  void UnSetMaximized() override;
+  void SetFullScreen() override;
+  void UnSetFullScreen() override;
+  void SetMinimized() override;
+  void SurfaceMove(WaylandConnection* connection) override;
+  void SurfaceResize(WaylandConnection* connection, uint32_t hittest) override;
+  void SetTitle(const base::string16& title) override;
+  void AckConfigure() override;
+
+  // xdg_surface_listener
+  static void Configure(void* data,
+                        xdg_surface* obj,
+                        int32_t width,
+                        int32_t height,
+                        wl_array* states,
+                        uint32_t serial);
+  static void Close(void* data, xdg_surface* obj);
+
+ private:
+  WaylandWindow* wayland_window_;
+  uint32_t pending_configure_serial_;
+  wl::Object<xdg_surface> xdg_surface_;
+
+  DISALLOW_COPY_AND_ASSIGN(XDGSurfaceWrapperV5);
+};
+
+}  // namespace ui
+
+#endif  // UI_OZONE_PLATFORM_WAYLAND_XDG_SURFACE_WRAPPER_V5_H_

--- a/ui/ozone/platform/wayland/xdg_surface_wrapper_v6.cc
+++ b/ui/ozone/platform/wayland/xdg_surface_wrapper_v6.cc
@@ -1,0 +1,221 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/ozone/platform/wayland/xdg_surface_wrapper_v6.h"
+
+#include <xdg-shell-unstable-v6-client-protocol.h>
+
+#include "base/strings/utf_string_conversions.h"
+#include "ui/base/hit_test.h"
+#include "ui/ozone/platform/wayland/wayland_connection.h"
+#include "ui/ozone/platform/wayland/wayland_window.h"
+
+namespace ui {
+
+namespace {
+
+// Identifies the direction of the "hittest" for Wayland.
+bool IdentifyDirection(int hittest, int* direction) {
+  DCHECK(direction);
+  *direction = -1;
+  switch (hittest) {
+    case HTBOTTOM:
+      *direction =
+          zxdg_toplevel_v6_resize_edge::ZXDG_TOPLEVEL_V6_RESIZE_EDGE_BOTTOM;
+      break;
+    case HTBOTTOMLEFT:
+      *direction = zxdg_toplevel_v6_resize_edge::
+          ZXDG_TOPLEVEL_V6_RESIZE_EDGE_BOTTOM_LEFT;
+      break;
+    case HTBOTTOMRIGHT:
+      *direction = zxdg_toplevel_v6_resize_edge::
+          ZXDG_TOPLEVEL_V6_RESIZE_EDGE_BOTTOM_RIGHT;
+      break;
+    case HTLEFT:
+      *direction =
+          zxdg_toplevel_v6_resize_edge::ZXDG_TOPLEVEL_V6_RESIZE_EDGE_LEFT;
+      break;
+    case HTRIGHT:
+      *direction =
+          zxdg_toplevel_v6_resize_edge::ZXDG_TOPLEVEL_V6_RESIZE_EDGE_RIGHT;
+      break;
+    case HTTOP:
+      *direction =
+          zxdg_toplevel_v6_resize_edge::ZXDG_TOPLEVEL_V6_RESIZE_EDGE_TOP;
+      break;
+    case HTTOPLEFT:
+      *direction =
+          zxdg_toplevel_v6_resize_edge::ZXDG_TOPLEVEL_V6_RESIZE_EDGE_TOP_LEFT;
+      break;
+    case HTTOPRIGHT:
+      *direction =
+          zxdg_toplevel_v6_resize_edge::ZXDG_TOPLEVEL_V6_RESIZE_EDGE_TOP_RIGHT;
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+XDGSurfaceWrapperV6::XDGSurfaceWrapperV6(WaylandWindow* wayland_window)
+    : wayland_window_(wayland_window) {}
+
+XDGSurfaceWrapperV6::~XDGSurfaceWrapperV6() {}
+
+bool XDGSurfaceWrapperV6::Initialize(WaylandConnection* connection,
+                                     wl_surface* surface,
+                                     bool with_toplevel) {
+  static const zxdg_surface_v6_listener zxdg_surface_v6_listener = {
+      &XDGSurfaceWrapperV6::Configure,
+  };
+  static const zxdg_toplevel_v6_listener zxdg_toplevel_v6_listener = {
+      &XDGSurfaceWrapperV6::ConfigureTopLevel,
+      &XDGSurfaceWrapperV6::CloseTopLevel,
+  };
+
+  // If this surface is created for the popup role, mark it like that as long as
+  // acknowledge configure must be sent back on each configure event.
+  surface_for_popup_ = !with_toplevel;
+
+  zxdg_surface_v6_.reset(
+      zxdg_shell_v6_get_xdg_surface(connection->shell_v6(), surface));
+  if (!zxdg_surface_v6_) {
+    LOG(ERROR) << "Failed to create zxdg_surface";
+    return false;
+  }
+  zxdg_surface_v6_add_listener(zxdg_surface_v6_.get(),
+                               &zxdg_surface_v6_listener, this);
+  // XDGPopupV6 requires a separate surface to be created, so this is just a
+  // request to get an xdg_surface for it.
+  if (surface_for_popup_)
+    return true;
+
+  zxdg_toplevel_v6_.reset(zxdg_surface_v6_get_toplevel(zxdg_surface_v6_.get()));
+  if (!zxdg_toplevel_v6_) {
+    LOG(ERROR) << "Failed to create zxdg_toplevel";
+    return false;
+  }
+  zxdg_toplevel_v6_add_listener(zxdg_toplevel_v6_.get(),
+                                &zxdg_toplevel_v6_listener, this);
+  wl_surface_commit(surface);
+  return true;
+}
+
+void XDGSurfaceWrapperV6::SetMaximized() {
+  DCHECK(zxdg_toplevel_v6_);
+  zxdg_toplevel_v6_set_maximized(zxdg_toplevel_v6_.get());
+}
+
+void XDGSurfaceWrapperV6::UnSetMaximized() {
+  DCHECK(zxdg_toplevel_v6_);
+  zxdg_toplevel_v6_unset_maximized(zxdg_toplevel_v6_.get());
+}
+
+void XDGSurfaceWrapperV6::SetFullScreen() {
+  DCHECK(zxdg_toplevel_v6_);
+  zxdg_toplevel_v6_set_fullscreen(zxdg_toplevel_v6_.get(), nullptr);
+}
+
+void XDGSurfaceWrapperV6::UnSetFullScreen() {
+  DCHECK(zxdg_toplevel_v6_);
+  zxdg_toplevel_v6_unset_fullscreen(zxdg_toplevel_v6_.get());
+}
+
+void XDGSurfaceWrapperV6::SetMinimized() {
+  DCHECK(zxdg_toplevel_v6_);
+  zxdg_toplevel_v6_set_minimized(zxdg_toplevel_v6_.get());
+}
+
+void XDGSurfaceWrapperV6::SurfaceMove(WaylandConnection* connection) {
+  DCHECK(zxdg_toplevel_v6_);
+  zxdg_toplevel_v6_move(zxdg_toplevel_v6_.get(), connection->seat(),
+                        connection->serial());
+}
+
+void XDGSurfaceWrapperV6::SurfaceResize(WaylandConnection* connection,
+                                        uint32_t hittest) {
+  int direction;
+  if (!IdentifyDirection(hittest, &direction))
+    return;
+  DCHECK(zxdg_toplevel_v6_);
+  zxdg_toplevel_v6_resize(zxdg_toplevel_v6_.get(), connection->seat(),
+                          connection->serial(), direction);
+}
+
+void XDGSurfaceWrapperV6::SetTitle(const base::string16& title) {
+  DCHECK(zxdg_toplevel_v6_);
+  zxdg_toplevel_v6_set_title(zxdg_toplevel_v6_.get(),
+                             UTF16ToUTF8(title).c_str());
+}
+
+void XDGSurfaceWrapperV6::AckConfigure() {
+  DCHECK(zxdg_surface_v6_);
+  zxdg_surface_v6_ack_configure(zxdg_surface_v6_.get(),
+                                pending_configure_serial_);
+}
+
+// static
+void XDGSurfaceWrapperV6::Configure(void* data,
+                                    struct zxdg_surface_v6* zxdg_surface_v6,
+                                    uint32_t serial) {
+  XDGSurfaceWrapperV6* surface = static_cast<XDGSurfaceWrapperV6*>(data);
+  surface->pending_configure_serial_ = serial;
+
+  if (surface->surface_for_popup_)
+    surface->AckConfigure();
+}
+
+// static
+void XDGSurfaceWrapperV6::ConfigureTopLevel(
+    void* data,
+    struct zxdg_toplevel_v6* zxdg_toplevel_v6,
+    int32_t width,
+    int32_t height,
+    struct wl_array* states) {
+  XDGSurfaceWrapperV6* surface = static_cast<XDGSurfaceWrapperV6*>(data);
+
+  bool is_maximized = false;
+  bool is_fullscreen = false;
+
+  // wl_array_for_each has a bug in upstream. It tries to assign void* to
+  // uint32_t *, which is not allowed in C++. Explicit cast should be
+  // performed. In other words, one just cannot assign void * to other pointer
+  // type implicitly in C++ as in C. We can't modify wayland-util.h, because
+  // it is fetched with gclient sync. Thus, use own loop.
+  // TODO(msisov, tonikitoo): use wl_array_for_each as soon as
+  // https://bugs.freedesktop.org/show_bug.cgi?id=101618 is resolved.
+  uint32_t* state = reinterpret_cast<uint32_t*>(states->data);
+  size_t array_size = states->size / sizeof(uint32_t);
+  for (size_t i = 0; i < array_size; i++) {
+    switch (state[i]) {
+      case (ZXDG_TOPLEVEL_V6_STATE_MAXIMIZED):
+        is_maximized = true;
+        break;
+      case (ZXDG_TOPLEVEL_V6_STATE_FULLSCREEN):
+        is_fullscreen = true;
+        break;
+      default:
+        break;
+    }
+  }
+
+  surface->wayland_window_->HandleSurfaceConfigure(width, height, is_maximized,
+                                                   is_fullscreen);
+}
+
+// static
+void XDGSurfaceWrapperV6::CloseTopLevel(
+    void* data,
+    struct zxdg_toplevel_v6* zxdg_toplevel_v6) {
+  NOTIMPLEMENTED();
+}
+
+zxdg_surface_v6* XDGSurfaceWrapperV6::xdg_surface() const {
+  DCHECK(zxdg_surface_v6_);
+  return zxdg_surface_v6_.get();
+}
+
+}  // namespace ui

--- a/ui/ozone/platform/wayland/xdg_surface_wrapper_v6.h
+++ b/ui/ozone/platform/wayland/xdg_surface_wrapper_v6.h
@@ -1,0 +1,64 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_OZONE_PLATFORM_WAYLAND_XDG_SURFACE_WRAPPER_V6_H_
+#define UI_OZONE_PLATFORM_WAYLAND_XDG_SURFACE_WRAPPER_V6_H_
+
+#include "ui/ozone/platform/wayland/xdg_surface_wrapper.h"
+
+#include "base/macros.h"
+
+namespace ui {
+
+class WaylandConnection;
+class WaylandWindow;
+
+class XDGSurfaceWrapperV6 : public XDGSurfaceWrapper {
+ public:
+  XDGSurfaceWrapperV6(WaylandWindow* wayland_window);
+  ~XDGSurfaceWrapperV6() override;
+
+  bool Initialize(WaylandConnection* connection,
+                  wl_surface* surface,
+                  bool with_toplevel) override;
+  void SetMaximized() override;
+  void UnSetMaximized() override;
+  void SetFullScreen() override;
+  void UnSetFullScreen() override;
+  void SetMinimized() override;
+  void SurfaceMove(WaylandConnection* connection) override;
+  void SurfaceResize(WaylandConnection* connection, uint32_t hittest) override;
+  void SetTitle(const base::string16& title) override;
+  void AckConfigure() override;
+
+  // xdg_surface_listener
+  static void Configure(void* data,
+                        struct zxdg_surface_v6* zxdg_surface_v6,
+                        uint32_t serial);
+  static void ConfigureTopLevel(void* data,
+                                struct zxdg_toplevel_v6* zxdg_toplevel_v6,
+                                int32_t width,
+                                int32_t height,
+                                struct wl_array* states);
+
+  // xdg_toplevel_listener
+  static void CloseTopLevel(void* data,
+                            struct zxdg_toplevel_v6* zxdg_toplevel_v6);
+
+  zxdg_surface_v6* xdg_surface() const;
+
+ private:
+  WaylandWindow* wayland_window_;
+  uint32_t pending_configure_serial_;
+  wl::Object<zxdg_surface_v6> zxdg_surface_v6_;
+  wl::Object<zxdg_toplevel_v6> zxdg_toplevel_v6_;
+
+  bool surface_for_popup_ = false;
+
+  DISALLOW_COPY_AND_ASSIGN(XDGSurfaceWrapperV6);
+};
+
+}  // namespace ui
+
+#endif  // UI_OZONE_PLATFORM_WAYLAND_XDG_SURFACE_WRAPPER_V6_H_


### PR DESCRIPTION
This commit adds support for xdg_v6 by having a wrapper for different
xdg shell versions.

The interfaces xdg_popup_wrapper and xdg_surface_wrapper are
implemented by different xdg objects with different versions.
WaylandWindow doesn't know what version is used and relies on
XDGShellObjectsFactory, which decides which version of objects
to use by checking the shell version. What is more, this design
should allow to add ivi shell support quite easily in the future.

The decision of what xdg shell version to connect to is the following:
when WaylandConnection::Global is called back,
it checks what shell versions are available. The first version to
be checked is V6. If V6 is not available, V5 is checked and
the interface is binded. Otherwise V6 is used.

Known issues: when V6 is used, child of a 3-dot menu is placed from the left side of the menu even though there is a space to fit it from the right side.