### PR TITLE
Prepare our branch to revert to "automatically created display" mode.

### DIFF
--- a/chrome/browser/ui/views/frame/browser_frame.cc
+++ b/chrome/browser/ui/views/frame/browser_frame.cc
@@ -74,11 +74,16 @@ void BrowserFrame::InitBrowserFrame() {
   views::Widget::InitParams params = native_browser_frame_->GetWidgetParams();
   params.delegate = browser_view_;
   if (browser_view_->browser()->is_type_tabbed()) {
+// In Ozone/Linux, we call chrome::GetSavedWindowBoundsAndShowState from
+// BrowserFrameMus::GetWidgetParams, given that it triggers a call to
+// create the native Ozone.
+#if !defined(USE_OZONE) || !defined (OS_LINUX) || defined(OS_CHROMEOS)
     // Typed panel/popup can only return a size once the widget has been
     // created.
     chrome::GetSavedWindowBoundsAndShowState(browser_view_->browser(),
                                              &params.bounds,
                                              &params.show_state);
+#endif
 
     params.workspace = browser_view_->browser()->initial_workspace();
     const base::CommandLine& parsed_command_line =

--- a/chrome/browser/ui/views/frame/browser_frame_mus.cc
+++ b/chrome/browser/ui/views/frame/browser_frame_mus.cc
@@ -7,6 +7,7 @@
 #include <stdint.h>
 
 #include "base/memory/ptr_util.h"
+#include "chrome/browser/ui/browser_window_state.h"
 #include "chrome/browser/ui/views/frame/browser_frame.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/common/extensions/extension_constants.h"
@@ -33,6 +34,13 @@ views::Widget::InitParams BrowserFrameMus::GetWidgetParams() {
   views::Widget::InitParams params;
   params.name = "BrowserFrame";
   params.native_widget = this;
+#if defined(USE_OZONE) && defined (OS_LINUX) && !defined(OS_CHROMEOS)
+  chrome::GetSavedWindowBoundsAndShowState(browser_view_->browser(),
+                                           &params.bounds,
+                                           &params.show_state);
+#else
+  params.bounds = gfx::Rect(10, 10, 640, 480);
+#endif
   params.delegate = browser_view_;
   std::map<std::string, std::vector<uint8_t>> properties =
       views::MusClient::ConfigurePropertiesFromParams(params);
@@ -41,7 +49,6 @@ views::Widget::InitParams BrowserFrameMus::GetWidgetParams() {
   properties[ui::mojom::WindowManager::kDisableImmersive_InitProperty] =
       mojo::ConvertTo<std::vector<uint8_t>>(true);
 #if defined(OS_CHROMEOS)
-  params.bounds = gfx::Rect(10, 10, 640, 480);
   properties[ash::mojom::kAshWindowStyle_InitProperty] =
       mojo::ConvertTo<std::vector<uint8_t>>(
           static_cast<int32_t>(ash::mojom::WindowStyle::BROWSER));

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -745,7 +745,7 @@ void WindowTreeClient::ScheduleInFlightBoundsChange(
       window->window_mus_type() == WindowMusType::DISPLAY_MANUALLY_CREATED ||
       window->HasLocalLayerTreeFrameSink()) {
     local_surface_id = window->GetOrAllocateLocalSurfaceId(new_bounds.size());
-    host_sync_data_[GetWindowTreeHostMus(window)] = { true, false };
+    host_sync_data_[GetWindowTreeHostMus(window)] = {true, false};
   }
   tree_->SetWindowBounds(change_id, window->server_id(), new_bounds,
                          local_surface_id);
@@ -2289,8 +2289,8 @@ void WindowTreeClient::OnCompositingStarted(ui::Compositor* compositor,
       WindowTreeHost::GetForAcceleratedWidget(compositor->widget());
 
   auto it = host_sync_data_.find(host);
-  DCHECK(it != host_sync_data_.end());
-  if (!it->second.synchronizing_with_child_on_next_frame_)
+  if (it == host_sync_data_.end() ||
+      !it->second.synchronizing_with_child_on_next_frame_)
     return;
   it->second.synchronizing_with_child_on_next_frame_ = false;
   // Unit tests have a null widget and thus may not have an associated
@@ -2306,8 +2306,7 @@ void WindowTreeClient::OnCompositingEnded(ui::Compositor* compositor) {
       WindowTreeHost::GetForAcceleratedWidget(compositor->widget());
 
   auto it = host_sync_data_.find(host);
-  DCHECK(it != host_sync_data_.end());
-  if (!it->second.holding_pointer_moves_)
+  if (it == host_sync_data_.end() || !it->second.holding_pointer_moves_)
     return;
   host->dispatcher()->ReleasePointerMoves();
   it->second.holding_pointer_moves_ = false;


### PR DESCRIPTION
The latest 'ozone-wayland-dev' branch works great in "manually created display" mode, after the PR #141 . There has been discussions between @msisov and I about reverting our implementation back to "automatically created display" mode.

This CL fixes things for this configuration.