### PR TITLE
rework our "access policy" implementation

### DIFF
--- a/services/ui/service.cc
+++ b/services/ui/service.cc
@@ -323,8 +323,6 @@ void Service::OnWillCreateTreeForWindowManager(
       ws::DisplayCreationConfig::MANUAL) {
 #if defined(USE_OZONE) && defined(OS_CHROMEOS)
     screen_manager_ = base::MakeUnique<display::ScreenManagerForwarding>();
-#elif defined(USE_OZONE) && !defined(OS_CHROMEOS)
-    screen_manager_ = display::ScreenManager::Create();
 #else
     CHECK(false);
 #endif

--- a/services/ui/ws/BUILD.gn
+++ b/services/ui/ws/BUILD.gn
@@ -49,6 +49,8 @@ static_library("lib") {
     "event_targeter.cc",
     "event_targeter.h",
     "event_targeter_delegate.h",
+    "external_window_access_policy.cc",
+    "external_window_access_policy.h",
     "focus_controller.cc",
     "focus_controller.h",
     "focus_controller_delegate.h",

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -363,18 +363,9 @@ void Display::OnBoundsChanged(const gfx::Rect& new_bounds) {
 
   // WindowManagerDisplayRoot::root_ needs to be at 0,0 position relative
   // to its parent not to break mouse/touch events.
-  for (auto& pair : window_manager_display_root_map_) {
+  for (auto& pair : window_manager_display_root_map_)
     pair.second->root()->SetBounds(
         gfx::Rect(new_bounds.size()), allocator_.GenerateId());
-
-    // Null-check the ServerWindow here, because this call might be in
-    // the middle of a PlatformDisplay creation, before WT::AddRoot,
-    // where the visible root for the client is set.
-    if (pair.second->GetClientVisibleRoot()) {
-      pair.second->GetClientVisibleRoot()->SetBounds(
-          gfx::Rect(new_bounds.size()), allocator_.GenerateId());
-    }
-  }
 }
 
 void Display::OnCloseRequest() {
@@ -481,8 +472,7 @@ void Display::OnFocusChanged(FocusControllerChangeSource change_source,
     }
     embedded_tree_old = window_server_->GetTreeWithRoot(old_focused_window);
     if (embedded_tree_old) {
-      // In external window mode, old and new tree can be the same.
-      // DCHECK_NE(owning_tree_old, embedded_tree_old);
+      DCHECK_NE(owning_tree_old, embedded_tree_old);
       embedded_tree_old->ProcessFocusChanged(old_focused_window,
                                              new_focused_window);
     }
@@ -500,8 +490,7 @@ void Display::OnFocusChanged(FocusControllerChangeSource change_source,
     embedded_tree_new = window_server_->GetTreeWithRoot(new_focused_window);
     if (embedded_tree_new && embedded_tree_new != owning_tree_old &&
         embedded_tree_new != embedded_tree_old) {
-      // In external window mode, old and new tree can be the same.
-      // DCHECK_NE(owning_tree_new, embedded_tree_new);
+      DCHECK_NE(owning_tree_new, embedded_tree_new);
       embedded_tree_new->ProcessFocusChanged(old_focused_window,
                                              new_focused_window);
     }

--- a/services/ui/ws/external_window_access_policy.cc
+++ b/services/ui/ws/external_window_access_policy.cc
@@ -1,0 +1,23 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "services/ui/ws/external_window_access_policy.h"
+
+#include "services/ui/ws/access_policy_delegate.h"
+#include "services/ui/ws/server_window.h"
+
+namespace ui {
+namespace ws {
+
+ExternalWindowAccessPolicy::ExternalWindowAccessPolicy() {}
+
+ExternalWindowAccessPolicy::~ExternalWindowAccessPolicy() {}
+
+bool ExternalWindowAccessPolicy::CanSetWindowBounds(const ServerWindow* window) const {
+  return WasCreatedByThisClient(window) ||
+         delegate_->HasRootForAccessPolicy(window);
+}
+
+}  // namespace ws
+}  // namespace ui

--- a/services/ui/ws/external_window_access_policy.h
+++ b/services/ui/ws/external_window_access_policy.h
@@ -1,0 +1,33 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SERVICES_UI_WS_DEFAULT_ACCESS_POLICY_H_
+#define SERVICES_UI_WS_DEFAULT_ACCESS_POLICY_H_
+
+#include <stdint.h>
+
+#include "base/macros.h"
+#include "services/ui/ws/window_manager_access_policy.h"
+
+namespace ui {
+namespace ws {
+
+class AccessPolicyDelegate;
+
+// AccessPolicy for all clients, except the window manager.
+class ExternalWindowAccessPolicy : public WindowManagerAccessPolicy {
+ public:
+  ExternalWindowAccessPolicy();
+  ~ExternalWindowAccessPolicy() override;
+
+  // WindowManagerAccessPolicy:
+  bool CanSetWindowBounds(const ServerWindow* window) const override;
+
+  DISALLOW_COPY_AND_ASSIGN(ExternalWindowAccessPolicy);
+};
+
+}  // namespace ws
+}  // namespace ui
+
+#endif  // SERVICES_UI_WS_DEFAULT_ACCESS_POLICY_H_

--- a/services/ui/ws/window_manager_access_policy.h
+++ b/services/ui/ws/window_manager_access_policy.h
@@ -68,7 +68,7 @@ class WindowManagerAccessPolicy : public AccessPolicy {
   bool CanSetWindowManager() const override;
   bool IsValidIdForNewWindow(const ClientWindowId& id) const override;
 
- private:
+ protected:
   bool IsWindowKnown(const ServerWindow* window) const;
   bool WasCreatedByThisClient(const ServerWindow* window) const;
 

--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -863,19 +863,6 @@ void WindowServer::OnWindowCursorChanged(ServerWindow* window,
   if (in_destructor_)
     return;
 
-  // In external window mode, cursor changes are forwarded to
-  // the visible root for the client associated ws::Display.
-  // This is because we are not using the WindowTree::WmSetGlobalOverrideCursor
-  // that mushrome uses. It arrive here via WindowTree::SetCursor.
-  // See comments in EventDispatcher::GetWindowForMouseCursor for details.
-  if (IsInExternalWindowMode()) {
-    WindowManagerDisplayRoot* display_root =
-        display_manager_->GetWindowManagerDisplayRoot(window);
-    if (display_root && display_root->GetClientVisibleRoot() == window) {
-      display_root->root()->SetCursor(cursor);
-    }
-  }
-
   ProcessWillChangeWindowCursor(window, cursor);
 
   UpdateNativeCursorIfOver(window);

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -10,12 +10,9 @@
 
 #include "base/bind.h"
 #include "base/callback_helpers.h"
-#include "base/command_line.h"
 #include "base/macros.h"
 #include "base/memory/ptr_util.h"
 #include "mojo/public/cpp/bindings/map.h"
-#include "services/service_manager/public/interfaces/connector.mojom.h"
-#include "services/ui/common/switches.h"
 #include "services/ui/display/screen_manager.h"
 #include "services/ui/ws/cursor_location_manager.h"
 #include "services/ui/ws/default_access_policy.h"
@@ -280,36 +277,16 @@ void WindowTree::AddRoot(const ServerWindow* root) {
   DCHECK(window_server_->IsInExternalWindowMode());
 
   const ClientWindowId client_window_id(pending_client_window_id_);
+  DCHECK_EQ(0u, client_id_to_window_id_map_.count(client_window_id));
+
+  client_id_to_window_id_map_[client_window_id] = root->id();
+  window_id_to_client_id_map_[root->id()] = client_window_id;
   pending_client_window_id_ = kInvalidClientId;
 
-  // TODO(tonikitoo,msisov): Code below duplicates some of the
-  // ::ProcessSetDisplayRoot code.
-  ServerWindow* window = GetWindowByClientId(client_window_id);
-  // The window must not have a parent.
-  if (!window || window->parent()) {
-    DVLOG(1) << "AddRoot called with invalid window id "
-             << client_window_id.id;
-    return;
-  }
+  roots_.insert(root);
 
-  if (base::ContainsKey(roots_, window)) {
-    DVLOG(1) << "AddRoot called with existing root";
-    return;
-  }
-
-  DCHECK(root->children().empty());
-
-  // NOTE: this doesn't resize the window in anyway. We assume the client takes
-  // care of any modifications it needs to do.
-  roots_.insert(window);
-  Operation op(this, window_server_, OperationType::ADD_WINDOW);
-  const_cast<ServerWindow*>(root)->Add(window);
-
-  window->SetVisible(true);
-
-  ClientWindowId window_id;
-  IsWindowKnown(window, &window_id);
-  DCHECK(client_window_id == window_id);
+  Display* display = GetDisplay(root);
+  DCHECK(display);
 
   WindowManagerDisplayRoot* display_root =
       GetWindowManagerDisplayRoot(root);
@@ -1153,19 +1130,6 @@ bool WindowTree::IsValidIdForNewWindow(const ClientWindowId& id) const {
 }
 
 WindowId WindowTree::GenerateNewWindowId() {
-  // TODO(tonikitoo, msisov): When running unittests (more specifically
-  // WindowTreeClientTest), the new 'external window mode' path is taken.
-  // This assumes root ServerWindow, child of WindowManagerDisplayRoot::root_,
-  // which tests were not accounting for.
-  // In order to keep the tests untouched, and still benefit from running them,
-  // use a ClientSpecificId that differs from the rest of the expected id's
-  // in the tests.
-  base::CommandLine* cmd_line = base::CommandLine::ForCurrentProcess();
-  if (cmd_line->HasSwitch(switches::kUseTestConfig) &&
-      created_window_map_.size() == 0u &&
-      roots_.empty())
-    return WindowId(id_, std::numeric_limits<ClientSpecificId>::max());
-
   // TODO(sky): deal with wrapping and uniqueness.
   return WindowId(id_, next_window_id_++);
 }
@@ -1690,15 +1654,10 @@ void WindowTree::SetWindowBounds(
   // Only the owner of the window can change the bounds.
   bool success = access_policy_->CanSetWindowBounds(window);
   if (success) {
-    // In external window mode, we propagate bounds changes in the visible
-    // root for the client to the roots associated to the ws::Display.
     if (window_server_->IsInExternalWindowMode()) {
       WindowManagerDisplayRoot* display_root =
           GetWindowManagerDisplayRoot(window);
       if (display_root && display_root->GetClientVisibleRoot() == window) {
-        Operation op(this, window_server_, OperationType::SET_WINDOW_BOUNDS);
-        window->SetBounds(gfx::Rect(bounds.size()), local_surface_id);
-
         Display* display = GetDisplay(window);
         DCHECK(display);
         display->SetBounds(bounds);

--- a/services/ui/ws/window_tree_client_unittest.cc
+++ b/services/ui/ws/window_tree_client_unittest.cc
@@ -711,11 +711,8 @@ class WindowTreeClientTest : public WindowServerServiceTestBase {
                                 MakeRequest(&window_tree),
                                 std::move(tree_client_ptr));
     wt_client1_->set_tree(std::move(window_tree));
-    Id window_1_101 = wt_client1_->NewWindowWithCompleteId(BuildWindowId(1, 101));
-    ASSERT_EQ(0u, changes1()->size());
-
     std::unordered_map<std::string, std::vector<uint8_t>> transport_properties;
-    factory->CreatePlatformWindow(MakeRequest(&host_), window_1_101,
+    factory->CreatePlatformWindow(MakeRequest(&host_), BuildWindowId(1, 0),
                                   transport_properties);
 
     // Next we should get an embed call on the "window manager" client.

--- a/services/ui/ws/window_tree_host_factory_registrar.cc
+++ b/services/ui/ws/window_tree_host_factory_registrar.cc
@@ -33,7 +33,7 @@ void WindowTreeHostFactoryRegistrar::Register(
   // but for the sake of an easier rebase, we are concentrating additions
   // like this here.
 
-  bool automatically_create_display_roots = false;
+  bool automatically_create_display_roots = true;
 
   // TODO(tonikitoo,msisov): Maybe remove the "window manager" suffix
   // if the method name?

--- a/services/ui/ws/window_tree_host_factory_registrar.cc
+++ b/services/ui/ws/window_tree_host_factory_registrar.cc
@@ -4,7 +4,7 @@
 
 #include "services/ui/ws/window_tree_host_factory_registrar.h"
 
-#include "services/ui/ws/window_manager_access_policy.h"
+#include "services/ui/ws/external_window_access_policy.h"
 #include "services/ui/ws/window_server.h"
 #include "services/ui/ws/window_server_delegate.h"
 #include "services/ui/ws/window_tree.h"
@@ -40,10 +40,9 @@ void WindowTreeHostFactoryRegistrar::Register(
   window_server_->delegate()->OnWillCreateTreeForWindowManager(
     automatically_create_display_roots);
 
-  // FIXME(tonikitoo,msisov,fwang): Do we need our own AccessPolicy?
   std::unique_ptr<ws::WindowTree> tree(
       new ws::WindowTree(window_server_, user_id_, nullptr /*ServerWindow*/,
-                         base::WrapUnique(new WindowManagerAccessPolicy)));
+                         base::WrapUnique(new ExternalWindowAccessPolicy)));
 
   std::unique_ptr<ws::DefaultWindowTreeBinding> tree_binding(
       new ws::DefaultWindowTreeBinding(tree.get(), window_server_,

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -758,8 +758,7 @@ void WindowTreeClient::OnWindowMusCreated(WindowMus* window) {
   window->set_server_id(MakeTransportId(client_id_, next_window_id_++));
   RegisterWindowMus(window);
 
-  DCHECK(window_manager_delegate_ || !IsRoot(window) ||
-         in_external_window_mode_);
+  DCHECK(window_manager_delegate_ || !IsRoot(window));
 
   std::unordered_map<std::string, std::vector<uint8_t>> transport_properties;
   std::set<const void*> property_keys =
@@ -782,35 +781,6 @@ void WindowTreeClient::OnWindowMusCreated(WindowMus* window) {
                    std::move(transport_properties));
   if (window->window_mus_type() == WindowMusType::DISPLAY_MANUALLY_CREATED) {
     WindowTreeHostMus* window_tree_host = GetWindowTreeHostMus(window);
-
-    if (in_external_window_mode_) {
-      // Provide an initial size for the Display.
-      const std::map<std::string, std::vector<uint8_t>> properties =
-          window_tree_host->mus_init_properties();
-
-      auto iter =
-          properties.find(ui::mojom::WindowManager::kBounds_InitProperty);
-      if (iter != properties.end()) {
-        gfx::Rect bounds = mojo::ConvertTo<gfx::Rect>(iter->second);
-
-        DCHECK(kRootWindowBoundsChangesAreIgnored);
-        ScheduleInFlightBoundsChange(window, gfx::Rect(), bounds);
-      }
-
-      std::unordered_map<std::string, std::vector<uint8_t>>
-          transport_properties;
-      for (const auto& property_pair : properties)
-        transport_properties[property_pair.first] = property_pair.second;
-
-      // Triggers the creation of a mojom::WindowTreeHost (aka ws::Display)
-      // instance on the server side.
-      // Ends up calling back to client side, aura::WindowTreeClient::OnEmbed.
-      ui::mojom::WindowTreeHostPtr host;
-      window_tree_host_factory_ptr_->CreatePlatformWindow(
-          MakeRequest(&host), window->server_id(), transport_properties);
-      return;
-    }
-
     std::unique_ptr<DisplayInitParams> display_init_params =
         window_tree_host->ReleaseDisplayInitParams();
     DCHECK(display_init_params);
@@ -2161,15 +2131,12 @@ void WindowTreeClient::OnWindowTreeHostMoveCursorToDisplayLocation(
 std::unique_ptr<WindowPortMus> WindowTreeClient::CreateWindowPortForTopLevel(
     const std::map<std::string, std::vector<uint8_t>>* properties) {
   WindowMusType window_type = in_external_window_mode_
-                                  ? WindowMusType::DISPLAY_MANUALLY_CREATED
+                                  ? WindowMusType::EMBED
                                   : WindowMusType::TOP_LEVEL;
 
   std::unique_ptr<WindowPortMus> window_port =
       base::MakeUnique<WindowPortMus>(this, window_type);
   roots_.insert(window_port.get());
-
-  if (in_external_window_mode_)
-    return window_port;
 
   window_port->set_server_id(MakeTransportId(client_id_, next_window_id_++));
   RegisterWindowMus(window_port.get());
@@ -2180,11 +2147,20 @@ std::unique_ptr<WindowPortMus> WindowTreeClient::CreateWindowPortForTopLevel(
       transport_properties[property_pair.first] = property_pair.second;
   }
 
-  const uint32_t change_id =
-      ScheduleInFlightChange(base::MakeUnique<CrashInFlightChange>(
-          window_port.get(), ChangeType::NEW_TOP_LEVEL_WINDOW));
-  tree_->NewTopLevelWindow(change_id, window_port->server_id(),
-                           transport_properties);
+  if (in_external_window_mode_) {
+    // Triggers the creation of a mojom::WindowTreeHost (aka ws::Display)
+    // instance on the server side.
+    // Ends up calling back to client side, aura::WindowTreeClient::OnEmbed.
+    ui::mojom::WindowTreeHostPtr host;
+    window_tree_host_factory_ptr_->CreatePlatformWindow(
+        MakeRequest(&host), window_port->server_id(), transport_properties);
+  } else {
+    const uint32_t change_id =
+        ScheduleInFlightChange(base::MakeUnique<CrashInFlightChange>(
+            window_port.get(), ChangeType::NEW_TOP_LEVEL_WINDOW));
+    tree_->NewTopLevelWindow(change_id, window_port->server_id(),
+                             transport_properties);
+  }
 
   return window_port;
 }

--- a/ui/aura/mus/window_tree_host_mus.cc
+++ b/ui/aura/mus/window_tree_host_mus.cc
@@ -41,11 +41,6 @@ WindowTreeHostMus::WindowTreeHostMus(WindowTreeHostMusInitParams init_params)
       delegate_(init_params.window_tree_client) {
   gfx::Rect bounds_in_pixels;
   display_init_params_ = std::move(init_params.display_init_params);
-
-  // Copy the mus properties here in the display init paramaters instance,
-  // so that it is accessible from WTC::OnWindowMusCreated.
-  mus_init_properties_ = init_params.properties;
-
   if (display_init_params_)
     bounds_in_pixels = display_init_params_->viewport_metrics.bounds_in_pixels;
   window()->SetProperty(kWindowTreeHostMusKey, this);

--- a/ui/aura/mus/window_tree_host_mus.h
+++ b/ui/aura/mus/window_tree_host_mus.h
@@ -88,14 +88,6 @@ class AURA_EXPORT WindowTreeHostMus : public aura::WindowTreeHostPlatform {
   // supplied to the constructor.
   std::unique_ptr<DisplayInitParams> ReleaseDisplayInitParams();
 
-  // Used during the initial set up (in external window mode). It holds a
-  // copy of the properties needed by the window server when creating a
-  // root server window.
-  const std::map<std::string, std::vector<uint8_t>>& mus_init_properties()
-      const {
-    return mus_init_properties_;
-  }
-
   // Intended only for WindowTreeClient to call.
   void set_display_id(int64_t id) { display_id_ = id; }
   int64_t display_id() const { return display_id_; }
@@ -121,8 +113,6 @@ class AURA_EXPORT WindowTreeHostMus : public aura::WindowTreeHostPlatform {
   std::unique_ptr<InputMethodMus> input_method_;
 
   std::unique_ptr<DisplayInitParams> display_init_params_;
-
-  std::map<std::string, std::vector<uint8_t>> mus_init_properties_;
 
   DISALLOW_COPY_AND_ASSIGN(WindowTreeHostMus);
 };


### PR DESCRIPTION
This PR does two things:

- reverts the "refactor branch" worked out in PR #141.
- introduces a "external window access policy" that unifies the way we use it (both for chrome/mus and unit tests).