### PR TITLE
fixup! Rework our "access policy" implementation

### DIFF
--- a/services/ui/ws/external_window_access_policy.cc
+++ b/services/ui/ws/external_window_access_policy.cc
@@ -14,7 +14,14 @@ ExternalWindowAccessPolicy::ExternalWindowAccessPolicy() {}
 
 ExternalWindowAccessPolicy::~ExternalWindowAccessPolicy() {}
 
-bool ExternalWindowAccessPolicy::CanSetWindowBounds(const ServerWindow* window) const {
+bool ExternalWindowAccessPolicy::CanSetWindowBounds(
+    const ServerWindow* window) const {
+  return WasCreatedByThisClient(window) ||
+         delegate_->HasRootForAccessPolicy(window);
+}
+
+bool ExternalWindowAccessPolicy::CanSetWindowProperties(
+    const ServerWindow* window) const {
   return WasCreatedByThisClient(window) ||
          delegate_->HasRootForAccessPolicy(window);
 }

--- a/services/ui/ws/external_window_access_policy.h
+++ b/services/ui/ws/external_window_access_policy.h
@@ -23,6 +23,7 @@ class ExternalWindowAccessPolicy : public WindowManagerAccessPolicy {
 
   // WindowManagerAccessPolicy:
   bool CanSetWindowBounds(const ServerWindow* window) const override;
+  bool CanSetWindowProperties(const ServerWindow* window) const override;
 
   DISALLOW_COPY_AND_ASSIGN(ExternalWindowAccessPolicy);
 };


### PR DESCRIPTION
Adding one more method needed: ::CanSetWindowProperties.
This allows maximize/minimize/restore.

Issue #134