### PR TITLE
Add entries for content editable and date/time field in Mojo's text input state

### DIFF
--- a/ui/platform_window/mojo/text_input_state.mojom
+++ b/ui/platform_window/mojo/text_input_state.mojom
@@ -21,7 +21,9 @@ enum TextInputType {
   TIME,
   WEEK,
   TEXT_AREA,
-  LAST = TEXT_AREA,
+  CONTENT_EDITABLE,
+  DATE_TIME_FIELD,
+  LAST = DATE_TIME_FIELD,
 };
 
 // Text input flag which is based on blink::WebTextInputFlags.


### PR DESCRIPTION
Both chrome --mash and chrome --mus --use-ime-service use
InputMethodMus for IME. In such cases, pages with 'content editable'
elements simply hang with the following error and stack trace:

  [ERROR:validation_errors.cc(90)] Invalid message: VALIDATION_ERROR_UNKNOWN_ENUM_VALUE

  #1 0x56228f4e5a9e mojo::internal::ReportValidationError()
  #2 0x56228c7ee648 mojo::internal::TextInputState_Data::Validate()
  #3 0x56228c7e2da9 ui::mojom::internal::WindowTree_SetImeVisibility_Params_Data::Validate()
  #4 0x56228c9dfbe2 ui::mojom::WindowTreeRequestValidator::Accept()
  #5 0x56228f4d423c mojo::FilterChain::Accept()
  #6 0x56228f4d5755 mojo::InterfaceEndpointClient::HandleIncomingMessage()
  #7 0x56228f4dc84c mojo::internal::MultiplexRouter::ProcessIncomingMessage()
  #8 0x56228f4dc03f mojo::internal::MultiplexRouter::Accept()
  #9 0x56228f4d4256 mojo::FilterChain::Accept()
  (...)

This happens because in InputMethodMus::UpdateTextInputType()
ui::TextInputType::TEXT_INPUT_TYPE_CONTENT_EDITABLE is the value
(correctly) used to construct the mojo::TextInputState instance
to be sent to Mus.
Down the road, WindowTreeClient::SetImeVisibility calls out to Mus
passing the mojo::TextInputState instance created previously.

At the mojo validation step, it fails (see stack above) because
text_input_state.mojom does not declare CONTENT_EDITABLE
(see IsKnownValue impl in <out>/gen/ui/platform_window/mojo/text_input_state.mojom-shared-internal.h).

Patch fixes this, and syncs up ui::TextInputType, blink::WebTextInputType
and mojo::TextInputType.

Issue #111