### PR TITLE
Use classic IME until InputMethodMus is fully implemented for non-ChromeOS

### DIFF
--- a/chrome/browser/ui/views/frame/browser_frame_mus.cc
+++ b/chrome/browser/ui/views/frame/browser_frame_mus.cc
@@ -22,6 +22,10 @@
 #include "ash/public/interfaces/window_style.mojom.h"
 #endif
 
+#if defined(USE_OZONE) && defined (OS_LINUX) && !defined(OS_CHROMEOS)
+#include "base/command_line.h"
+#endif
+
 BrowserFrameMus::BrowserFrameMus(BrowserFrame* browser_frame,
                                  BrowserView* browser_view)
     : views::DesktopNativeWidgetAura(browser_frame),
@@ -56,6 +60,10 @@ views::Widget::InitParams BrowserFrameMus::GetWidgetParams() {
   aura::WindowTreeHostMusInitParams window_tree_host_init_params =
       aura::CreateInitParamsForTopLevel(
           views::MusClient::Get()->window_tree_client(), std::move(properties));
+#if defined(USE_OZONE) && defined (OS_LINUX) && !defined(OS_CHROMEOS)
+  window_tree_host_init_params.use_classic_ime =
+      !base::CommandLine::ForCurrentProcess()->HasSwitch("use-ime-service");
+#endif
   std::unique_ptr<views::DesktopWindowTreeHostMus> desktop_window_tree_host =
       base::MakeUnique<views::DesktopWindowTreeHostMus>(
           std::move(window_tree_host_init_params), browser_frame_, this);


### PR DESCRIPTION
In PR #45, SimpleInputMethod class was extended to make keyboard events
minimally functional for non-ChromeOS/Mus builds.

Although it made basic inputting possible, it still has bugs and limitations.
Until there is an more robustic implementation, it seems safer to
use the classic IME rather than the servicified Input Method by default.

chrome --mus (ChromeOS) also does the same.

Issue #153