### PR TITLE
Consider ResizeParams.local_surface_id when comparing whether size changed

### DIFF
--- a/content/browser/renderer_host/render_widget_host_impl.cc
+++ b/content/browser/renderer_host/render_widget_host_impl.cc
@@ -716,6 +716,7 @@ bool RenderWidgetHostImpl::GetResizeParams(ResizeParams* resize_params) {
        !resize_params->physical_backing_size.IsEmpty());
   bool dirty =
       size_changed ||
+      old_resize_params_->local_surface_id != resize_params->local_surface_id ||
       old_resize_params_->screen_info != resize_params->screen_info ||
       old_resize_params_->physical_backing_size !=
           resize_params->physical_backing_size ||


### PR DESCRIPTION
(In external window mode specially) It is possible that a new surface_local_id
is assigned to a WindowPort(Mus), without its size having necessarily changed.

This happens for example, when starting chrome/mus, restoring
non-default bounds and loading an URL from a previous session.

What was happening was the a new local_surface_id was assigned
to the WindowPortMus associated with RenderViewHostAura instance,
but it was not sync'ed up with its associated RenderWidget's local_surface_id.
This mismatch caused the Compositor to enter a "defer commits" state.

Any manual resize on the chrome/mus window (with a mouse, for example) would
make RenderViewHostAura's WindowPortMus to produce a new local_surface_id,
it would sync up (browser -> renderer) through the ViewMsg_Resize IPC message,
and "unlock" the compositor.

Patch fixes this by sending ViewMsg_Resize message through when
the local_surface_id changed, allowing RenderViewHostAura's and RenderWidget's
local_surface_id sync up.

Issue #158