### PR TITLE
[chrome/mus/linux] Restore previous session's bounds and state of a w…

### DIFF
--- a/chrome/browser/ui/views/frame/browser_frame_mus.cc
+++ b/chrome/browser/ui/views/frame/browser_frame_mus.cc
@@ -24,6 +24,8 @@
 
 #if defined(USE_OZONE) && defined (OS_LINUX) && !defined(OS_CHROMEOS)
 #include "base/command_line.h"
+#include "ui/aura/client/aura_constants.h"
+#include "ui/aura/window.h"
 #endif
 
 BrowserFrameMus::BrowserFrameMus(BrowserFrame* browser_frame,
@@ -83,13 +85,35 @@ bool BrowserFrameMus::UsesNativeSystemMenu() const {
 }
 
 bool BrowserFrameMus::ShouldSaveWindowPlacement() const {
+#if defined(USE_OZONE) && defined(OS_LINUX) && !defined(OS_CHROMEOS)
+  return nullptr == GetWidget()->GetNativeWindow()->GetProperty(
+                        aura::client::kRestoreBoundsKey);
+#else
   return false;
+#endif
 }
 
 void BrowserFrameMus::GetWindowPlacement(
     gfx::Rect* bounds, ui::WindowShowState* show_state) const {
+#if defined(USE_OZONE) && defined(OS_LINUX) && !defined(OS_CHROMEOS)
+  DesktopNativeWidgetAura::GetWindowPlacement(bounds, show_state);
+
+  gfx::Rect* override_bounds = GetWidget()->GetNativeWindow()->GetProperty(
+      aura::client::kRestoreBoundsKey);
+  if (override_bounds) {
+    *bounds = *override_bounds;
+    *show_state = GetWidget()->GetNativeWindow()->GetProperty(
+        aura::client::kShowStateKey);
+  }
+
+  if (*show_state != ui::SHOW_STATE_MAXIMIZED &&
+      *show_state != ui::SHOW_STATE_MINIMIZED) {
+    *show_state = ui::SHOW_STATE_NORMAL;
+  }
+#else
   *bounds = gfx::Rect(10, 10, 800, 600);
   *show_state = ui::SHOW_STATE_NORMAL;
+#endif
 }
 
 bool BrowserFrameMus::PreHandleKeyboardEvent(


### PR DESCRIPTION
…indow

This patch makes it possible to store and restore bounds and window state
so that chrome/mus behaves exactly the same way as stock X11.

In details: two problems are fixed with this patch.
1) BrowserView::SaveWindowPlacement() had always been failing before,
because frame_->ShouldSaveWindowPlacement() (or BrowserFrameMus)
had false value hardcoded to be returned. Now we have a check, which ends up with
true if kRestoreBoundsKey is not stored in the aura::window's properties.
2) BrowserFrameMus::GetWindowPlacement(), which is used by Widget::SaveWindowPlacement, where
native_widget_->GetWindowPlacement() is called, had always been returning
hardcoded bounds (10, 10, 800, 600). Now bounds are taken from |content_window_|
and kRestoreBoundsKey is stored, restored bounds and restored state are taken from gfx::NativeWindow.

Issue: #162