### PR TITLE
Revert "Make 3-dot menu to be drawn"

### DIFF
--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -160,9 +160,6 @@ void WindowTree::DoOnEmbed(mojom::WindowTreePtr tree,
     ClientWindowId window_id;
     IsWindowKnown(root_window, &window_id);
 
-    // In external window mode, every platform window is an activation parent.
-    AddActivationParent(window_id);
-
     // In case of external window mode, when aura/mus sets the initial focus
     // to the Chrome's server window (WindowManagerDisplayRoot::root_), the
     // call chain checks either WindowManagerDisplayRoot::root_'s parent window


### PR DESCRIPTION
This reverts commit 835fb5dc032e7c0598253511923d522c242323df.

AddActivationParent(window_id) is redundant here and not needed any more
as long as after "Set focus to newly created chrome/mus windows" commit,
we add the root window of ws::Display to be an activation parent,
which can have active children.

This also reduces the amount of commits we have.