### PR TITLE
fixup! First attemp to remove decorations from small windows

### DIFF
--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -7,6 +7,8 @@
 #include <wayland-client.h>
 
 #include "base/bind.h"
+#include "base/memory/ptr_util.h"
+#include "services/ui/public/interfaces/window_manager_constants.mojom.h"
 #include "ui/base/hit_test.h"
 #include "ui/events/event.h"
 #include "ui/events/ozone/events_ozone.h"

--- a/ui/platform_window/platform_window_delegate.h
+++ b/ui/platform_window/platform_window_delegate.h
@@ -5,7 +5,6 @@
 #ifndef UI_PLATFORM_WINDOW_PLATFORM_WINDOW_DELEGATE_H_
 #define UI_PLATFORM_WINDOW_PLATFORM_WINDOW_DELEGATE_H_
 
-#include "services/ui/public/interfaces/window_manager_constants.mojom.h"
 #include "ui/gfx/native_widget_types.h"
 
 namespace gfx {
@@ -13,6 +12,9 @@ class Rect;
 }
 
 namespace ui {
+namespace mojom {
+enum class WindowType;
+}
 
 class Event;
 

--- a/ui/platform_window/x11/x11_window_base.cc
+++ b/ui/platform_window/x11/x11_window_base.cc
@@ -12,6 +12,7 @@
 #include <string>
 
 #include "base/strings/utf_string_conversions.h"
+#include "services/ui/public/interfaces/window_manager_constants.mojom.h"
 #include "ui/base/hit_test.h"
 #include "ui/base/platform_window_defaults.h"
 #include "ui/base/x/x11_util.h"

--- a/ui/platform_window/x11/x11_window_base.h
+++ b/ui/platform_window/x11/x11_window_base.h
@@ -9,6 +9,8 @@
 
 #include <X11/Xutil.h>
 
+#include <set>
+
 #include "base/callback.h"
 #include "base/macros.h"
 #include "ui/gfx/geometry/rect.h"


### PR DESCRIPTION
Rework includes of window manager constants.
Include window manager constants only in cc files, where necessary.
Otherwise use forward-declarations.

This fixes compilation problem, when window manager constants are
not generated when x11 or wayland window is compiled.