### PR TITLE
fixup! First attemp to remove decorations from small windows

### DIFF
--- a/services/ui/ws/platform_display_default.cc
+++ b/services/ui/ws/platform_display_default.cc
@@ -11,6 +11,7 @@
 #include "gpu/ipc/client/gpu_channel_host.h"
 #include "services/ui/display/screen_manager.h"
 #include "services/ui/public/interfaces/cursor/cursor_struct_traits.h"
+#include "services/ui/public/interfaces/window_manager_constants.mojom.h"
 #include "services/ui/ws/server_window.h"
 #include "services/ui/ws/threaded_image_cursors.h"
 #include "ui/display/display.h"
@@ -145,9 +146,16 @@ void PlatformDisplayDefault::SetNativeWindowState(ui::mojom::ShowState state) {
   }
 }
 
-void PlatformDisplayDefault::GetWindowType(ui::mojom::WindowType* result) {
-  DCHECK(result);
-  *result = metrics_.window_type;
+void PlatformDisplayDefault::GetWindowType(
+    ui::PlatformWindowType* window_type) {
+  DCHECK(window_type);
+  // TODO(tonikitoo, msisov): it might be better to pass more params through
+  // Widget::InitParams to ozone windows. For now, just do a check whether it's
+  // a normal window or menu..
+  if (metrics_.window_type == ui::mojom::WindowType::WINDOW)
+    *window_type = ui::PlatformWindowType::PLATFORM_WINDOW_TYPE_WINDOW;
+  else
+    *window_type = ui::PlatformWindowType::PLATFORM_WINDOW_TYPE_MENU;
 }
 
 void PlatformDisplayDefault::PerformNativeWindowDragOrResize(uint32_t hittest) {

--- a/services/ui/ws/platform_display_default.h
+++ b/services/ui/ws/platform_display_default.h
@@ -57,7 +57,7 @@ class PlatformDisplayDefault : public PlatformDisplay,
   void SetViewportBounds(const gfx::Rect& rect) override;
   void SetWindowVisibility(bool visible) override;
   void SetNativeWindowState(ui::mojom::ShowState state) override;
-  void GetWindowType(ui::mojom::WindowType* result) override;
+  void GetWindowType(PlatformWindowType* window_type) override;
   void PerformNativeWindowDragOrResize(uint32_t hittest) override;
 
  private:

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -7,6 +7,7 @@
 #include <wayland-client.h>
 
 #include "base/bind.h"
+#include "base/memory/ptr_util.h"
 #include "ui/base/hit_test.h"
 #include "ui/events/event.h"
 #include "ui/events/ozone/events_ozone.h"
@@ -101,9 +102,10 @@ bool WaylandWindow::Initialize() {
   // There is now default initialization for this type. Initialize it
   // to ::WINDOW here. It will be changed by delelgate if it know the
   // type of the window.
-  ui::mojom::WindowType window_type = ui::mojom::WindowType::WINDOW;
-  delegate_->GetWindowType(&window_type);
-  if (window_type == ui::mojom::WindowType::WINDOW) {
+  ui::PlatformWindowType ui_window_type =
+      ui::PlatformWindowType::PLATFORM_WINDOW_TYPE_WINDOW;
+  delegate_->GetWindowType(&ui_window_type);
+  if (ui_window_type == ui::PlatformWindowType::PLATFORM_WINDOW_TYPE_WINDOW) {
     xdg_surface_ =
         xdg_shell_objects_factory_->CreateXDGSurface(connection_, this);
     if (!xdg_surface_ ||

--- a/ui/platform_window/platform_window_delegate.h
+++ b/ui/platform_window/platform_window_delegate.h
@@ -5,7 +5,6 @@
 #ifndef UI_PLATFORM_WINDOW_PLATFORM_WINDOW_DELEGATE_H_
 #define UI_PLATFORM_WINDOW_PLATFORM_WINDOW_DELEGATE_H_
 
-#include "services/ui/public/interfaces/window_manager_constants.mojom.h"
 #include "ui/gfx/native_widget_types.h"
 
 namespace gfx {
@@ -22,6 +21,11 @@ enum PlatformWindowState {
   PLATFORM_WINDOW_STATE_MINIMIZED,
   PLATFORM_WINDOW_STATE_NORMAL,
   PLATFORM_WINDOW_STATE_FULLSCREEN,
+};
+
+enum PlatformWindowType {
+  PLATFORM_WINDOW_TYPE_WINDOW,
+  PLATFORM_WINDOW_TYPE_MENU,
 };
 
 class PlatformWindowDelegate {
@@ -56,7 +60,7 @@ class PlatformWindowDelegate {
   // TODO(tonikitoo,msisov): Adding this method with an out parameter so that
   // we can have a default implementation here and not need to add stubs to
   // all subclasses. To be discussed when upstraming.
-  virtual void GetWindowType(ui::mojom::WindowType* result) {}
+  virtual void GetWindowType(PlatformWindowType* window_type) {}
 };
 
 }  // namespace ui

--- a/ui/platform_window/x11/x11_window_base.cc
+++ b/ui/platform_window/x11/x11_window_base.cc
@@ -133,9 +133,10 @@ void X11WindowBase::Create() {
   // There is now default initialization for this type. Initialize it
   // to ::WINDOW here. It will be changed by delelgate if it know the
   // type of the window.
-  ui::mojom::WindowType ui_window_type = ui::mojom::WindowType::WINDOW;
+  ui::PlatformWindowType ui_window_type =
+      ui::PlatformWindowType::PLATFORM_WINDOW_TYPE_WINDOW;
   delegate_->GetWindowType(&ui_window_type);
-  if (ui_window_type != ui::mojom::WindowType::WINDOW) {
+  if (ui_window_type != ui::PlatformWindowType::PLATFORM_WINDOW_TYPE_WINDOW) {
     // Setting this to True, doesn't allow X server to set different
     // properties, e.g. decorations.
     // TODO(msisov): Investigate further.

--- a/ui/platform_window/x11/x11_window_base.h
+++ b/ui/platform_window/x11/x11_window_base.h
@@ -9,6 +9,8 @@
 
 #include <X11/Xutil.h>
 
+#include <set>
+
 #include "base/callback.h"
 #include "base/macros.h"
 #include "ui/gfx/geometry/rect.h"


### PR DESCRIPTION
Updated: instead of using ui::mojom::WindowType, use own enum in the platform_window_delegate. 
PlatformWindowDefault::GetWindowType will check the mojom::WindowType and send back PlatformWindowState to ozone windows. I did the same for mojom::WindowState some time ago. This fixes the compilation problem for sure.