### PR TITLE
fixup! [ozone/wayland] Fix Showing/Hiding, Placing and Events for Men…

### DIFF
--- a/ui/ozone/platform/wayland/wayland_connection.cc
+++ b/ui/ozone/platform/wayland/wayland_connection.cc
@@ -28,7 +28,9 @@ const uint32_t kMaxXdgShellVersion = 1;
 
 WaylandConnection::WaylandConnection() : controller_(FROM_HERE) {}
 
-WaylandConnection::~WaylandConnection() {}
+WaylandConnection::~WaylandConnection() {
+  DCHECK(window_map_.empty());
+}
 
 bool WaylandConnection::Initialize() {
   static const wl_registry_listener registry_listener = {

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -79,10 +79,10 @@ WaylandWindow::WaylandWindow(PlatformWindowDelegate* delegate,
       bounds_(bounds) {}
 
 WaylandWindow::~WaylandWindow() {
-  if (xdg_surface_) {
-    PlatformEventSource::GetInstance()->RemovePlatformEventDispatcher(this);
-    connection_->RemoveWindow(surface_.id());
-  }
+  PlatformEventSource::GetInstance()->RemovePlatformEventDispatcher(this);
+  connection_->RemoveWindow(surface_.id());
+  if (parent_window_)
+    parent_window_->set_child_window(nullptr);
 }
 
 // static


### PR DESCRIPTION
…u Windows (#73)

Fix crash when menus are destroyed, but aura is still trying to hide them.
It may happen when wayland decides to destroy the menu (wrong serial number, for example).

The exact problem is that we set a child window pointer to the parent, but never remove it. And the parent may try to reach the child window despite the fact that it has already been destroyed.

What is more, xdg popup wayland windows has never removed self from window_map_ and has not removed self from event dispatcher. This has been fixed as well.