### PR TITLE
instantiate window_manager_internal (needed for touch support)

### DIFF
--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -217,7 +217,8 @@ void WindowTree::ConfigureRootWindowTreeClient(
     bool automatically_create_display_roots) {
   DCHECK(window_server_->IsInExternalWindowMode());
   automatically_create_display_roots_ = automatically_create_display_roots;
-  binding_->GetWindowManager()->OnConnect(id_);
+  window_manager_internal_ = binding_->GetWindowManager();
+  window_manager_internal_->OnConnect(id_);
 
   window_tree_host_factory_.reset(
       new WindowTreeHostFactory(window_server_, user_id_));


### PR DESCRIPTION
fixup! c++ / mojo changes for 'external window mode'

This fixes a crash in touch handling.
    
Issue #100