### PR TITLE
fixup! c++ / mojo changes for 'external window mode'

### DIFF
--- a/services/ui/public/interfaces/external_window_tree_factory.mojom
+++ b/services/ui/public/interfaces/external_window_tree_factory.mojom
@@ -1,0 +1,23 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+module ui.mojom;
+
+import "services/ui/public/interfaces/window_tree.mojom";
+import "services/ui/public/interfaces/window_tree_host.mojom";
+
+// ExternalWindowTreeFactory is the entry point to obtain a
+// WindowTree instance in 'external window mode'.
+// Callers obtain a mojo handle to the unique ws::WindowTree instance,
+// on the server-side.
+//
+// NOTE: WindowTreeHostFactoryRegistrar::Register and
+// WindowTreeHostFactory::CreatePlatformWindow are put on separate interfaces,
+// so that the interface containing ::CreatePlatformWindow is obtained by
+// calling ::Register. That eliminates the possibility of ::CreatePlatformWindow
+// being called before ::Register.
+interface ExternalWindowTreeFactory {
+   Register(WindowTree& tree_request,
+            WindowTreeClient client);
+};


### PR DESCRIPTION
git add'ing the missing external_window_tree_factory.mojom file.

Issue #161