### PR TITLE
[ozone/wayland] Add initial support for wayland touch.

### DIFF
--- a/ui/ozone/platform/wayland/BUILD.gn
+++ b/ui/ozone/platform/wayland/BUILD.gn
@@ -30,6 +30,8 @@ source_set("wayland") {
     "wayland_pointer.h",
     "wayland_surface_factory.cc",
     "wayland_surface_factory.h",
+    "wayland_touch.cc",
+    "wayland_touch.h",
     "wayland_window.cc",
     "wayland_window.h",
     "xdg_popup_wrapper.h",
@@ -93,6 +95,7 @@ source_set("wayland_unittests") {
     "wayland_surface_factory_unittest.cc",
     "wayland_test.cc",
     "wayland_test.h",
+    "wayland_touch_unittest.cc",
     "wayland_window_unittest.cc",
   ]
 

--- a/ui/ozone/platform/wayland/fake_server.cc
+++ b/ui/ozone/platform/wayland/fake_server.cc
@@ -148,10 +148,21 @@ void GetKeyboard(wl_client* client, wl_resource* resource, uint32_t id) {
   seat->keyboard.reset(new MockKeyboard(keyboard_resource));
 }
 
+void GetTouch(wl_client* client, wl_resource* resource, uint32_t id) {
+  auto* seat = static_cast<MockSeat*>(wl_resource_get_user_data(resource));
+  wl_resource* touch_resource = wl_resource_create(
+      client, &wl_touch_interface, wl_resource_get_version(resource), id);
+  if (!touch_resource) {
+    wl_client_post_no_memory(client);
+    return;
+  }
+  seat->touch.reset(new MockTouch(touch_resource));
+}
+
 const struct wl_seat_interface seat_impl = {
     &GetPointer,       // get_pointer
     &GetKeyboard,      // get_keyboard
-    nullptr,           // get_touch,
+    &GetTouch,         // get_touch,
     &DestroyResource,  // release
 };
 
@@ -165,6 +176,12 @@ const struct wl_keyboard_interface keyboard_impl = {
 
 const struct wl_pointer_interface pointer_impl = {
     nullptr,           // set_cursor
+    &DestroyResource,  // release
+};
+
+// wl_touch
+
+const struct wl_touch_interface touch_impl = {
     &DestroyResource,  // release
 };
 
@@ -280,6 +297,13 @@ MockKeyboard::MockKeyboard(wl_resource* resource) : ServerObject(resource) {
 }
 
 MockKeyboard::~MockKeyboard() {}
+
+MockTouch::MockTouch(wl_resource* resource) : ServerObject(resource) {
+  wl_resource_set_implementation(resource, &touch_impl, this,
+                                 &ServerObject::OnResourceDestroyed);
+}
+
+MockTouch::~MockTouch() {}
 
 void GlobalDeleter::operator()(wl_global* global) {
   wl_global_destroy(global);

--- a/ui/ozone/platform/wayland/fake_server.h
+++ b/ui/ozone/platform/wayland/fake_server.h
@@ -95,6 +95,15 @@ class MockKeyboard : public ServerObject {
   DISALLOW_COPY_AND_ASSIGN(MockKeyboard);
 };
 
+class MockTouch : public ServerObject {
+ public:
+  MockTouch(wl_resource* resource);
+  ~MockTouch() override;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(MockTouch);
+};
+
 struct GlobalDeleter {
   void operator()(wl_global* global);
 };
@@ -172,6 +181,7 @@ class MockSeat : public Global {
 
   std::unique_ptr<MockPointer> pointer;
   std::unique_ptr<MockKeyboard> keyboard;
+  std::unique_ptr<MockTouch> touch;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(MockSeat);

--- a/ui/ozone/platform/wayland/wayland_connection.h
+++ b/ui/ozone/platform/wayland/wayland_connection.h
@@ -14,6 +14,7 @@
 #include "ui/ozone/platform/wayland/wayland_object.h"
 #include "ui/ozone/platform/wayland/wayland_output.h"
 #include "ui/ozone/platform/wayland/wayland_pointer.h"
+#include "ui/ozone/platform/wayland/wayland_touch.h"
 
 namespace ui {
 
@@ -90,6 +91,7 @@ class WaylandConnection : public PlatformEventSource,
 
   std::unique_ptr<WaylandPointer> pointer_;
   std::unique_ptr<WaylandKeyboard> keyboard_;
+  std::unique_ptr<WaylandTouch> touch_;
 
   bool scheduled_flush_ = false;
   bool watching_ = false;

--- a/ui/ozone/platform/wayland/wayland_object.cc
+++ b/ui/ozone/platform/wayland/wayland_object.cc
@@ -25,6 +25,13 @@ void delete_pointer(wl_pointer* pointer) {
     wl_pointer_destroy(pointer);
 }
 
+void delete_touch(wl_touch* touch) {
+  if (wl_touch_get_version(touch) >= WL_TOUCH_RELEASE_SINCE_VERSION)
+    wl_touch_release(touch);
+  else
+    wl_touch_destroy(touch);
+}
+
 void delete_seat(wl_seat* seat) {
   if (wl_seat_get_version(seat) >= WL_SEAT_RELEASE_SINCE_VERSION)
     wl_seat_release(seat);
@@ -79,6 +86,9 @@ void (*ObjectTraits<wl_keyboard>::deleter)(wl_keyboard*) = &delete_keyboard;
 
 const wl_interface* ObjectTraits<wl_pointer>::interface = &wl_pointer_interface;
 void (*ObjectTraits<wl_pointer>::deleter)(wl_pointer*) = &delete_pointer;
+
+const wl_interface* ObjectTraits<wl_touch>::interface = &wl_touch_interface;
+void (*ObjectTraits<wl_touch>::deleter)(wl_touch*) = &delete_touch;
 
 const wl_interface* ObjectTraits<wl_registry>::interface =
     &wl_registry_interface;

--- a/ui/ozone/platform/wayland/wayland_object.h
+++ b/ui/ozone/platform/wayland/wayland_object.h
@@ -20,6 +20,7 @@ struct wl_compositor;
 struct wl_keyboard;
 struct wl_output;
 struct wl_pointer;
+struct wl_touch;
 struct wl_registry;
 struct wl_seat;
 struct wl_shm;
@@ -98,6 +99,12 @@ template <>
 struct ObjectTraits<wl_pointer> {
   static const wl_interface* interface;
   static void (*deleter)(wl_pointer*);
+};
+
+template <>
+struct ObjectTraits<wl_touch> {
+  static const wl_interface* interface;
+  static void (*deleter)(wl_touch*);
 };
 
 template <>

--- a/ui/ozone/platform/wayland/wayland_touch.cc
+++ b/ui/ozone/platform/wayland/wayland_touch.cc
@@ -1,0 +1,155 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/ozone/platform/wayland/wayland_touch.h"
+
+#include <sys/mman.h>
+#include <wayland-client.h>
+
+#include "base/files/scoped_file.h"
+#include "ui/base/ui_features.h"
+#include "ui/events/event.h"
+#include "ui/ozone/platform/wayland/wayland_connection.h"
+#include "ui/ozone/platform/wayland/wayland_window.h"
+
+namespace ui {
+
+WaylandTouch::WaylandTouch(wl_touch* touch,
+                           const EventDispatchCallback& callback)
+    : obj_(touch), callback_(callback) {
+  // TODO(linkmauve): Add support for wl_touch version 6.
+  static const wl_touch_listener listener = {
+      &WaylandTouch::Down,  &WaylandTouch::Up,     &WaylandTouch::Motion,
+      &WaylandTouch::Frame, &WaylandTouch::Cancel,
+  };
+
+  wl_touch_add_listener(obj_.get(), &listener, this);
+}
+
+WaylandTouch::~WaylandTouch() {}
+
+void WaylandTouch::Down(void* data,
+                        wl_touch* obj,
+                        uint32_t serial,
+                        uint32_t time,
+                        struct wl_surface* surface,
+                        int32_t id,
+                        wl_fixed_t x,
+                        wl_fixed_t y) {
+  WaylandTouch* touch = static_cast<WaylandTouch*>(data);
+  touch->SetSerial(serial);
+  WaylandWindow::FromSurface(surface)->set_touch_focus(true);
+
+  // Make sure this touch point wasn't present before.
+  DCHECK(touch->current_points_.find(id) == touch->current_points_.end());
+
+  EventType type = ET_TOUCH_PRESSED;
+  gfx::Point location(wl_fixed_to_double(x), wl_fixed_to_double(y));
+  base::TimeTicks time_stamp =
+      base::TimeTicks() + base::TimeDelta::FromMilliseconds(time);
+  PointerDetails pointer_details(EventPointerType::POINTER_TYPE_TOUCH, id);
+  std::unique_ptr<TouchEvent> event(
+      new TouchEvent(type, location, time_stamp, pointer_details));
+  touch->callback_.Run(event.get());
+  touch->current_points_[id] = {surface, std::move(event), location};
+}
+
+static void MaybeUnsetFocus(
+    const std::unordered_map<int32_t, TouchPoint>& points,
+    int32_t id) {
+  wl_surface* surface = points.find(id)->second.surface;
+
+  for (const auto& point : points) {
+    // Return early on the first other point having this surface.
+    if (surface == point.second.surface && id != point.first)
+      return;
+  }
+  WaylandWindow::FromSurface(surface)->set_touch_focus(false);
+}
+
+void WaylandTouch::Up(void* data,
+                      wl_touch* obj,
+                      uint32_t serial,
+                      uint32_t time,
+                      int32_t id) {
+  WaylandTouch* touch = static_cast<WaylandTouch*>(data);
+  touch->SetSerial(serial);
+  const auto iterator = touch->current_points_.find(id);
+
+  // Make sure this touch point was present before.
+  DCHECK(iterator != touch->current_points_.end());
+
+  EventType type = ET_TOUCH_RELEASED;
+  base::TimeTicks time_stamp =
+      base::TimeTicks() + base::TimeDelta::FromMilliseconds(time);
+  PointerDetails pointer_details(EventPointerType::POINTER_TYPE_TOUCH, id);
+  TouchEvent event(type, touch->current_points_[id].last_known_location,
+                   time_stamp, pointer_details);
+  touch->callback_.Run(&event);
+
+  MaybeUnsetFocus(touch->current_points_, id);
+  touch->current_points_.erase(iterator);
+}
+
+void WaylandTouch::Motion(void* data,
+                          wl_touch* obj,
+                          uint32_t time,
+                          int32_t id,
+                          wl_fixed_t x,
+                          wl_fixed_t y) {
+  WaylandTouch* touch = static_cast<WaylandTouch*>(data);
+
+  // Make sure this touch point wasn't present before.
+  DCHECK(touch->current_points_.find(id) != touch->current_points_.end());
+
+  EventType type = ET_TOUCH_MOVED;
+  gfx::Point location(wl_fixed_to_double(x), wl_fixed_to_double(y));
+  base::TimeTicks time_stamp =
+      base::TimeTicks() + base::TimeDelta::FromMilliseconds(time);
+  PointerDetails pointer_details(EventPointerType::POINTER_TYPE_TOUCH, id);
+  std::unique_ptr<TouchEvent> event(
+      new TouchEvent(type, location, time_stamp, pointer_details));
+  touch->callback_.Run(event.get());
+  touch->current_points_[id].event = std::move(event);
+  touch->current_points_[id].last_known_location = location;
+}
+
+void WaylandTouch::Frame(void* data, wl_touch* obj) {
+  WaylandTouch* touch = static_cast<WaylandTouch*>(data);
+  for (auto& point : touch->current_points_) {
+    // Replaces the TouchEvent created in a previous event in the frame with
+    // nullptr.
+    std::unique_ptr<TouchEvent> event = nullptr;
+    event.swap(point.second.event);
+
+    // Not all ids have to had been changed in a single frame.
+    if (event)
+      touch->callback_.Run(event.get());
+  }
+}
+
+void WaylandTouch::Cancel(void* data, wl_touch* obj) {
+  WaylandTouch* touch = static_cast<WaylandTouch*>(data);
+  for (auto& point : touch->current_points_) {
+    int32_t id = point.first;
+
+    DCHECK(!point.second.event);
+
+    EventType type = ET_TOUCH_CANCELLED;
+    base::TimeTicks time_stamp = base::TimeTicks::Now();
+    PointerDetails pointer_details(EventPointerType::POINTER_TYPE_TOUCH, id);
+    TouchEvent event(type, gfx::Point(), time_stamp, pointer_details);
+    touch->callback_.Run(&event);
+
+    WaylandWindow::FromSurface(point.second.surface)->set_touch_focus(false);
+  }
+  touch->current_points_.clear();
+}
+
+void WaylandTouch::SetSerial(uint32_t serial) {
+  DCHECK(connection_);
+  connection_->set_serial(serial);
+}
+
+}  // namespace ui

--- a/ui/ozone/platform/wayland/wayland_touch.h
+++ b/ui/ozone/platform/wayland/wayland_touch.h
@@ -1,0 +1,71 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_TOUCH_H_
+#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_TOUCH_H_
+
+#include <memory>
+#include <unordered_map>
+
+#include "ui/events/ozone/evdev/event_dispatch_callback.h"
+#include "ui/gfx/geometry/rect.h"
+#include "ui/ozone/platform/wayland/wayland_object.h"
+
+namespace ui {
+
+class WaylandConnection;
+class TouchEvent;
+
+// TODO(msisov, tonikitoo): fix the "warning: [chromium-style] Complex
+// class/struct needs an explicit out-of-line constructor."
+struct TouchPoint {
+  wl_surface* surface;
+  std::unique_ptr<TouchEvent> event;
+  gfx::Point last_known_location;
+};
+
+class WaylandTouch {
+ public:
+  WaylandTouch(wl_touch* touch, const EventDispatchCallback& callback);
+  virtual ~WaylandTouch();
+
+  void set_connection(WaylandConnection* connection) {
+    connection_ = connection;
+  }
+
+ private:
+  // wl_touch_listener
+  static void Down(void* data,
+                   wl_touch* obj,
+                   uint32_t serial,
+                   uint32_t time,
+                   struct wl_surface* surface,
+                   int32_t id,
+                   wl_fixed_t x,
+                   wl_fixed_t y);
+  static void Up(void* data,
+                 wl_touch* obj,
+                 uint32_t serial,
+                 uint32_t time,
+                 int32_t id);
+  static void Motion(void* data,
+                     wl_touch* obj,
+                     uint32_t time,
+                     int32_t id,
+                     wl_fixed_t x,
+                     wl_fixed_t y);
+  static void Frame(void* data, wl_touch* obj);
+  static void Cancel(void* data, wl_touch* obj);
+
+  void SetSerial(uint32_t serial);
+
+  WaylandConnection* connection_ = nullptr;
+  wl::Object<wl_touch> obj_;
+  EventDispatchCallback callback_;
+  std::unordered_map<int32_t, TouchPoint> current_points_;
+};
+
+}  // namespace ui
+
+#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_TOUCH_H_

--- a/ui/ozone/platform/wayland/wayland_touch_unittest.cc
+++ b/ui/ozone/platform/wayland/wayland_touch_unittest.cc
@@ -1,0 +1,76 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <linux/input.h>
+#include <wayland-server.h>
+
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "ui/events/event.h"
+#include "ui/ozone/platform/wayland/fake_server.h"
+#include "ui/ozone/platform/wayland/mock_platform_window_delegate.h"
+#include "ui/ozone/platform/wayland/wayland_test.h"
+#include "ui/ozone/platform/wayland/wayland_window.h"
+
+using ::testing::SaveArg;
+using ::testing::_;
+
+namespace ui {
+
+namespace {
+
+ACTION_P(CloneEvent, ptr) {
+  *ptr = Event::Clone(*arg0);
+}
+
+}  // namespace
+
+class WaylandTouchTest : public WaylandTest {
+ public:
+  WaylandTouchTest() {}
+
+  void SetUp() override {
+    WaylandTest::SetUp();
+
+    wl_seat_send_capabilities(server.seat()->resource(),
+                              WL_SEAT_CAPABILITY_TOUCH);
+
+    Sync();
+
+    touch = server.seat()->touch.get();
+    ASSERT_TRUE(touch);
+  }
+
+ protected:
+  void CheckEventType(ui::EventType event_type, ui::Event* event) {
+    ASSERT_TRUE(event);
+    ASSERT_TRUE(event->IsTouchEvent());
+
+    auto* key_event = event->AsTouchEvent();
+    EXPECT_EQ(event_type, key_event->type());
+  }
+
+  wl::MockTouch* touch;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(WaylandTouchTest);
+};
+
+TEST_F(WaylandTouchTest, Keypress) {
+  std::unique_ptr<Event> event;
+  EXPECT_CALL(delegate, DispatchEvent(_)).WillOnce(CloneEvent(&event));
+
+  wl_touch_send_down(touch->resource(), 1, 0, surface->resource(), 0 /* id */,
+                     wl_fixed_from_int(50), wl_fixed_from_int(100));
+
+  wl_touch_send_motion(touch->resource(), 500, 0 /* id */,
+                       wl_fixed_from_int(100), wl_fixed_from_int(100));
+
+  wl_touch_send_up(touch->resource(), 1, 1000, 0 /* id */);
+
+  Sync();
+  CheckEventType(ui::ET_TOUCH_RELEASED, event.get());
+}
+
+}  // namespace ui

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -308,22 +308,24 @@ bool WaylandWindow::CanDispatchEvent(const PlatformEvent& native_event) {
   Event* event = static_cast<Event*>(native_event);
   if (event->IsMouseEvent()) {
     if (g_current_capture_ == this) {
-      if (has_pointer_focus_ || child_window_->is_focused_popup())
+      if (has_pointer_or_touch_focus() || child_window_->is_focused_popup())
         return true;
       else
         return false;
     } else {
-      return has_pointer_focus_;
+      return has_pointer_or_touch_focus();
     }
   }
   if (event->IsKeyEvent())
     return has_keyboard_focus_;
+  if (event->IsTouchEvent())
+    return has_touch_focus_;
   return false;
 }
 
 uint32_t WaylandWindow::DispatchEvent(const PlatformEvent& native_event) {
   Event* event = static_cast<Event*>(native_event);
-  if (event->IsLocatedEvent() && !has_pointer_focus_)
+  if (event->IsLocatedEvent() && !has_pointer_or_touch_focus())
     ConvertEventLocationToCurrentWindowLocation(event);
 
   DispatchEventFromNativeUiEvent(

--- a/ui/ozone/platform/wayland/wayland_window.h
+++ b/ui/ozone/platform/wayland/wayland_window.h
@@ -47,10 +47,15 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
   // Set whether this window has keyboard focus and should dispatch key events.
   void set_keyboard_focus(bool focus) { has_keyboard_focus_ = focus; }
 
-  bool has_pointer_focus() { return has_pointer_focus_; }
+  // Set whether this window has touch focus and should dispatch touch events.
+  void set_touch_focus(bool focus) { has_touch_focus_ = focus; }
+
+  bool has_pointer_or_touch_focus() {
+    return has_pointer_focus_ || has_touch_focus_;
+  }
 
   // Tells if it is a focused popup.
-  bool is_focused_popup() { return is_popup() && has_pointer_focus(); }
+  bool is_focused_popup() { return is_popup() && has_pointer_or_touch_focus(); }
 
   // Tells if this is a popup.
   bool is_popup() { return !!xdg_popup_.get(); }
@@ -129,6 +134,7 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
   gfx::Rect pending_bounds_;
   bool has_pointer_focus_ = false;
   bool has_keyboard_focus_ = false;
+  bool has_touch_focus_ = false;
 
   bool is_minimized_ = false;
   bool is_maximized_ = false;


### PR DESCRIPTION
This is an adapted patch provided by Collabora, which adds
touch support to wayland backend.

Fixed: unittests and window focusing.

There are still some known problems like opening a submenu window,
opening a context menu (all windows just freeze and nothing
is touchable).