### PR TITLE
fixup! [ozone/wayland] Fix Showing/Hiding, Placing and Events for Men…

### DIFF
--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -163,6 +163,7 @@ void WaylandWindow::Show() {
   if (!xdg_popup_) {
     if (!CreatePopupWindow())
       CHECK(false) << "Failed to create popup window";
+    parent_window_->set_child_window(this);
     connection_->ScheduleFlush();
   }
 }
@@ -172,8 +173,10 @@ void WaylandWindow::Show() {
 void WaylandWindow::Hide() {
   if (child_window_)
     child_window_->Hide();
-  if (xdg_popup_)
+  if (xdg_popup_) {
+    parent_window_->set_child_window(nullptr);
     xdg_popup_.reset();
+  }
 }
 
 void WaylandWindow::Close() {


### PR DESCRIPTION
…u Windows

Ensure that a pointer to a child window is invalidated as soon as xdg_popup_ is
destroyed. This fixes a random crash, when the wrong pointer to a child
deletes not the top most popup window, which results in a dismiss signal from
wayland and all windows are being closed.