### PR TITLE
Issues #152 and #181

### DIFF
--- a/chrome/browser/sessions/session_restore.cc
+++ b/chrome/browser/sessions/session_restore.cc
@@ -620,8 +620,11 @@ class SessionRestoreImpl : public content::NotificationObserver {
     if (!is_selected_tab)
       return;
 
+    WebContents::SetDisallowReactionToWindowVisibilityChange(true);
     ShowBrowser(browser, browser->tab_strip_model()->GetIndexOfWebContents(
                              web_contents));
+    WebContents::SetDisallowReactionToWindowVisibilityChange(false);
+
     // TODO(sky): remove. For debugging 368236.
     CHECK_EQ(browser->tab_strip_model()->GetActiveWebContents(), web_contents);
   }

--- a/content/browser/web_contents/web_contents_impl.cc
+++ b/content/browser/web_contents/web_contents_impl.cc
@@ -170,6 +170,9 @@
 #endif  // ENABLE_PLUGINS
 
 namespace content {
+
+bool g_can_react_to_visibility_change = true;
+
 namespace {
 
 const int kMinimumDelayBetweenLoadingUpdatesMS = 100;
@@ -366,6 +369,10 @@ WebContents* WebContents::FromFrameTreeNodeId(int frame_tree_node_id) {
 void WebContents::SetScreenOrientationDelegate(
     ScreenOrientationDelegate* delegate) {
   ScreenOrientationProvider::SetDelegate(delegate);
+}
+
+void WebContents::SetDisallowReactionToWindowVisibilityChange(bool value) {
+  g_can_react_to_visibility_change = !value;
 }
 
 // WebContentsImpl::DestructionObserver ----------------------------------------
@@ -5809,6 +5816,9 @@ int WebContentsImpl::GetCurrentlyPlayingVideoCount() {
 }
 
 void WebContentsImpl::UpdateWebContentsVisibility(bool visible) {
+  if (!g_can_react_to_visibility_change)
+    return;
+
   if (!did_first_set_visible_) {
     // If this WebContents has not yet been set to be visible for the first
     // time, ignore any requests to make it hidden, since resources would

--- a/content/public/browser/web_contents.h
+++ b/content/public/browser/web_contents.h
@@ -204,6 +204,18 @@ class WebContents : public PageNavigator,
   CONTENT_EXPORT static void SetScreenOrientationDelegate(
       ScreenOrientationDelegate* delegate);
 
+  // Disallow WebContents instances to react to window visibility changes.
+  // This is useful during session restore, where there are assumptions
+  // (see SessionRestoreStatsCollector) that only the last active tab is
+  // loaded by the time browser is shown.
+  // In setups like chromeos/mash, DesktopWindowTreeHostMus::Show will
+  // trigger Window::Show calls, which will notify its observers of the
+  // visibility change, being WebContentsViewAura one of them.
+  // This might call WebContents::UpdateWebContentsVisibility which might
+  // trigger an expected load.
+  CONTENT_EXPORT static void SetDisallowReactionToWindowVisibilityChange(
+      bool value);
+
   ~WebContents() override {}
 
   // Intrinsic tab state -------------------------------------------------------

--- a/ui/views/mus/desktop_window_tree_host_mus.cc
+++ b/ui/views/mus/desktop_window_tree_host_mus.cc
@@ -310,7 +310,6 @@ void DesktopWindowTreeHostMus::Init(aura::Window* content_window,
       base::MakeUnique<NativeCursorManagerMus>(window()));
   aura::client::SetCursorClient(window(), cursor_manager_.get());
   InitHost();
-  window()->Show();
 
   NativeWidgetAura::SetShadowElevationFromInitParams(window(), params);
 


### PR DESCRIPTION
PR #168 changed the default visibility of DesktopWindowTreeHostMus::window_ at the time ::Init is called. This visibility set earlier as it is causes unexpected activation and focus changes on aura::Window and also chromeos/mash|mus unittest failures.

This PR tries a simpler approach.