### PR TITLE
fixup! c++ / mojo changes for 'external window mode'

### DIFF
--- a/services/ui/demo/mus_demo_external.cc
+++ b/services/ui/demo/mus_demo_external.cc
@@ -37,8 +37,10 @@ class WindowTreeDataExternal : public WindowTreeData {
     aura::WindowTreeHostMusInitParams init_params =
         CreateInitParamsForTopLevel(window_tree_client, properties);
 
-    SetWindowTreeHost(
-        base::MakeUnique<aura::WindowTreeHostMus>(std::move(init_params)));
+    std::unique_ptr<aura::WindowTreeHostMus> tree_host =
+        base::MakeUnique<aura::WindowTreeHostMus>(std::move(init_params));
+    tree_host->InitHost();
+    SetWindowTreeHost(std::move(tree_host));
   }
 
   DISALLOW_COPY_AND_ASSIGN(WindowTreeDataExternal);

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -1098,7 +1098,10 @@ void WindowTreeClient::OnEmbed(
     DCHECK(it != windows_.end());
 
     WindowTreeHostMus* window_tree_host = GetWindowTreeHostMus(it->second);
-    window_tree_host->InitHost();
+    // By this time, the window_tree_host and the compositor it owns must
+    // be initialized. It is done during start up as soon as
+    // BrowserFrame::InitBrowserFrame() is called.
+    DCHECK(window_tree_host->compositor()->root_layer());
     ConfigureWindowDataFromServer(window_tree_host, *root_data,
                                   local_surface_id);
 


### PR DESCRIPTION
Avoid double initialization of WindowTreeHost: after
https://chromium-review.googlesource.com/c/606933 commit, the
chromium browser on Linux build with ozone has stopped to
start. It has always been observing a crash due to a DCHECK
in WindowTreeHost::InitCompositor(), which checked that
the compositor must not have a root_layer() set.

The reason of hitting the DCHECK is that the very first initialization
is always done during the browser start up:

4 0x7f4ff1be87d9 aura::WindowTreeHost::InitHost()
5 0x7f4fed9d2739 views::DesktopWindowTreeHostMus::Init()
6 0x7f4ff06c0981 views::DesktopNativeWidgetAura::InitNativeWidget()
7 0x7f4ff0682405 views::Widget::Init()
8 0x55e62a03742c BrowserFrame::InitBrowserFrame()
9 0x55e629d227e9 BrowserWindow::CreateBrowserWindow()
10 0x55e629b3d4e5 (anonymous namespace)::CreateBrowserWindow()
11 0x55e629b3cb79 Browser::Browser()
12 0x55e629b9b1b2 StartupBrowserCreatorImpl::OpenTabsInBrowser()
13 0x55e629b9cffa StartupBrowserCreatorImpl::RestoreOrCreateBrowser()
14 0x55e629b9a6a6 StartupBrowserCreatorImpl::ProcessLaunchUrlsUsingConsolidatedFlow()
15 0x55e629b99742 StartupBrowserCreatorImpl::Launch()
16 0x55e629b93a72 StartupBrowserCreator::LaunchBrowser()
17 0x55e629b929d4 StartupBrowserCreator::ProcessCmdLineImpl()
18 0x55e629b91102 StartupBrowserCreator::Start()
19 0x55e626f60fc7 ChromeBrowserMainParts::PreMainMessageLoopRunImpl()
20 0x55e626f5f8bc ChromeBrowserMainParts::PreMainMessageLoopRun()
21 0x7f4ff563c574 content::BrowserMainLoop::PreMainMessageLoopRun()

After this when WindowTreeClient::OnEmbed() is called,
we used to call window_tree_host->InitHost() second time and then
crash.


What is more, in order to mimic standart browser creation,
make WindowTreeDataExternal to call InitHost() before allowing
to calling to create an actual window.