### PR TITLE
fixup! [ozone/wayland] Implement basic keyboard handling support

### DIFF
--- a/ui/ozone/platform/wayland/wayland_keyboard.cc
+++ b/ui/ozone/platform/wayland/wayland_keyboard.cc
@@ -73,7 +73,8 @@ void WaylandKeyboard::Enter(void* data,
                             wl_array* keys) {
   WaylandKeyboard* keyboard = static_cast<WaylandKeyboard*>(data);
   keyboard->SetSerial(serial);
-  WaylandWindow::FromSurface(surface)->set_keyboard_focus(true);
+  if (surface)
+    WaylandWindow::FromSurface(surface)->set_keyboard_focus(true);
 }
 
 void WaylandKeyboard::Leave(void* data,
@@ -82,7 +83,8 @@ void WaylandKeyboard::Leave(void* data,
                             wl_surface* surface) {
   WaylandKeyboard* keyboard = static_cast<WaylandKeyboard*>(data);
   keyboard->SetSerial(serial);
-  WaylandWindow::FromSurface(surface)->set_keyboard_focus(false);
+  if (surface)
+    WaylandWindow::FromSurface(surface)->set_keyboard_focus(false);
 }
 
 void WaylandKeyboard::Key(void* data,


### PR DESCRIPTION
Fix crash that happens when a user has two windows and then
one of the window is being closed, which results in the
following backtrace:

0 0x55f08fb842d7 base::debug::StackTrace::StackTrace()
1 0x55f08fb83daf base::debug::(anonymous namespace)::StackDumpSignalHandler()
2 0x7fd346c972c0 <unknown>
3 0x55f08debe7e0 <unknown>
4 0x55f08dec1dad ui::WaylandKeyboard::Leave()
5 0x7fd343322bde ffi_call_unix64
6 0x7fd34332254f ffi_call
7 0x55f0908ebbd7 wl_closure_invoke
8 0x55f0908ea613 dispatch_event
9 0x55f0908ea169 wl_display_dispatch_queue_pending
10 0x55f0908e9bbe wl_display_dispatch_queue
11 0x55f08dec1430 ui::WaylandConnection::OnFileCanReadWithoutBlocking()
12 0x55f08fba7a50 base::MessagePumpLibevent::OnLibeventNotification()


This happened because the pointer of wl_surface* surface was
invalid when WaylandKeyboard::Leave() was called.