### PR TITLE
fixup! [ozone/wayland] Fix Showing/Hiding, Placing and Events for Men…

### DIFF
--- a/ui/ozone/platform/wayland/wayland_connection.h
+++ b/ui/ozone/platform/wayland/wayland_connection.h
@@ -99,6 +99,8 @@ class WaylandConnection : public PlatformEventSource,
 
   std::vector<std::unique_ptr<WaylandOutput>> output_list_;
 
+  // This serial number corresponds to key press, mouse button press or touch
+  // press event. It is used to create new subsurfaces.
   uint32_t serial_ = 0;
 
   DISALLOW_COPY_AND_ASSIGN(WaylandConnection);

--- a/ui/ozone/platform/wayland/wayland_keyboard.cc
+++ b/ui/ozone/platform/wayland/wayland_keyboard.cc
@@ -71,8 +71,6 @@ void WaylandKeyboard::Enter(void* data,
                             uint32_t serial,
                             wl_surface* surface,
                             wl_array* keys) {
-  WaylandKeyboard* keyboard = static_cast<WaylandKeyboard*>(data);
-  keyboard->SetSerial(serial);
   if (surface)
     WaylandWindow::FromSurface(surface)->set_keyboard_focus(true);
 }
@@ -81,8 +79,6 @@ void WaylandKeyboard::Leave(void* data,
                             wl_keyboard* obj,
                             uint32_t serial,
                             wl_surface* surface) {
-  WaylandKeyboard* keyboard = static_cast<WaylandKeyboard*>(data);
-  keyboard->SetSerial(serial);
   if (surface)
     WaylandWindow::FromSurface(surface)->set_keyboard_focus(false);
 }

--- a/ui/ozone/platform/wayland/wayland_pointer.cc
+++ b/ui/ozone/platform/wayland/wayland_pointer.cc
@@ -36,7 +36,6 @@ void WaylandPointer::Enter(void* data,
                            wl_fixed_t surface_x,
                            wl_fixed_t surface_y) {
   WaylandPointer* pointer = static_cast<WaylandPointer*>(data);
-  pointer->SetSerial(serial);
   pointer->location_.SetPoint(wl_fixed_to_double(surface_x),
                               wl_fixed_to_double(surface_y));
   if (surface)
@@ -48,8 +47,6 @@ void WaylandPointer::Leave(void* data,
                            wl_pointer* obj,
                            uint32_t serial,
                            wl_surface* surface) {
-  WaylandPointer* pointer = static_cast<WaylandPointer*>(data);
-  pointer->SetSerial(serial);
   if (surface)
     WaylandWindow::FromSurface(surface)->set_pointer_focus(false);
 }
@@ -79,7 +76,6 @@ void WaylandPointer::Button(void* data,
                             uint32_t button,
                             uint32_t state) {
   WaylandPointer* pointer = static_cast<WaylandPointer*>(data);
-  pointer->SetSerial(serial);
   int flag;
   switch (button) {
     case BTN_LEFT:
@@ -104,6 +100,9 @@ void WaylandPointer::Button(void* data,
   EventType type;
   if (state == WL_POINTER_BUTTON_STATE_PRESSED) {
     type = ET_MOUSE_PRESSED;
+    // We are especially interested in mouse press serial as long as it is one
+    // of the serials that can be used to create new subsurfaces.
+    pointer->SetSerial(serial);
     pointer->flags_ |= flag;
   } else {
     type = ET_MOUSE_RELEASED;

--- a/ui/ozone/platform/wayland/wayland_touch.cc
+++ b/ui/ozone/platform/wayland/wayland_touch.cc
@@ -91,7 +91,6 @@ void WaylandTouch::Up(void* data,
                       uint32_t time,
                       int32_t id) {
   WaylandTouch* touch = static_cast<WaylandTouch*>(data);
-  touch->SetSerial(serial);
   const auto iterator = touch->current_points_.find(id);
 
   // Make sure this touch point was present before.


### PR DESCRIPTION
…u Windows (#73)

This patch makes opening submenus on mouse hover to work. Basically, creating
popups requires serials, which correspond to grab events (those
are touch, key press or button press events). As long as other
events' serials are not used by us, don't save such serials that
correspond to Enter/Leave and etc.