### PR TITLE
fixup! Tie synchronizing_with_child_on_next_frame_ and holding_pointer_moves_ to host instances

### DIFF
--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -766,7 +766,11 @@ void WindowTreeClient::ScheduleInFlightBoundsChange(
       window->window_mus_type() == WindowMusType::DISPLAY_MANUALLY_CREATED ||
       window->HasLocalLayerTreeFrameSink()) {
     local_surface_id = window->GetOrAllocateLocalSurfaceId(new_bounds.size());
-    host_sync_data_[GetWindowTreeHostMus(window)] = {true, false};
+
+    WindowTreeHostMus* host = GetWindowTreeHostMus(window);
+    DCHECK(host);
+    if (host_sync_data_.find(host) == host_sync_data_.end())
+      host_sync_data_[host] = {true, false};
   }
   tree_->SetWindowBounds(change_id, window->server_id(), new_bounds,
                          local_surface_id);
@@ -2443,6 +2447,7 @@ void WindowTreeClient::OnCompositingEnded(ui::Compositor* compositor) {
     return;
   host->dispatcher()->ReleasePointerMoves();
   it->second.holding_pointer_moves_ = false;
+  host_sync_data_.erase(it);
 }
 
 void WindowTreeClient::OnCompositingLockStateChanged(


### PR DESCRIPTION
It is possible that multiple WindowTreeClient::ScheduleInFlightBoundsChange
happen after compositing has started (::OnCompositingStarted).
In such cases, we can not reset 'host_sync_data_', because it would
prevent ::OnCompositingEnded calls to the do right thing.

Patch tightens up our custom controls to prevent cases like this.

In practice, it fixes a problem where content dragging (including scrollbars),
text selection, and other common use cases were not behaving well.

Issue #185