### PR TITLE
Aligns chrome/mus process model with chromeos/mus

### DIFF
--- a/chrome/app/BUILD.gn
+++ b/chrome/app/BUILD.gn
@@ -422,6 +422,8 @@ service_manifest("chrome_content_packaged_services_manifest_overlay") {
       "//ash/mus:manifest",
       "//services/ui:manifest",
     ]
+  } else if (use_ozone && is_linux) {
+    packaged_services += [ "//services/ui:manifest" ]
   }
 }
 

--- a/chrome/app/chrome_main_delegate.cc
+++ b/chrome/app/chrome_main_delegate.cc
@@ -1130,14 +1130,6 @@ service_manager::ProcessType ChromeMainDelegate::OverrideProcessType() {
 #if BUILDFLAG(ENABLE_PACKAGE_MASH_SERVICES)
   if (command_line.HasSwitch(switches::kMash))
     return service_manager::ProcessType::kServiceManager;
-// Chrome/mus on Linux still runs the UI service on its own process,
-// differently from Chrome/mus on ChromeOS.
-// See BrowserProcessPlatformPart::BrowserProcessPlatformPart for details.
-#if !defined(OS_CHROMEOS) && defined(OS_LINUX) && defined(USE_OZONE)
-  if (command_line.HasSwitch(switches::kMus)) {
-    return service_manager::ProcessType::kServiceManager;
-  }
-#endif
 #endif
 
   return service_manager::ProcessType::kDefault;

--- a/chrome/app/mash/BUILD.gn
+++ b/chrome/app/mash/BUILD.gn
@@ -136,12 +136,6 @@ if (is_chromeos || (use_ozone && is_linux)) {
       # TODO(sky): verify if we need this.
       "//services/ui/ime/test_ime_driver:manifest",
     ]
-
-    # TODO(tonikitoo,msisov): Upstream and non-chromeos bits.
-    if (use_ozone && is_linux && !is_chromeos) {
-      embedded_services += [ "//services/ui:manifest" ]
-    }
-
     if (enable_nacl) {
       embedded_services += [ "//components/nacl/loader:nacl_loader_manifest" ]
     }

--- a/chrome/browser/BUILD.gn
+++ b/chrome/browser/BUILD.gn
@@ -141,6 +141,8 @@ split_static_library("browser") {
     "browser_process_platform_part_chromeos.h",
     "browser_process_platform_part_mac.h",
     "browser_process_platform_part_mac.mm",
+    "browser_process_platform_part_ozone.cc",
+    "browser_process_platform_part_ozone.h",
     "browser_process_platform_part_win.cc",
     "browser_process_platform_part_win.h",
     "browser_shutdown.cc",

--- a/chrome/browser/BUILD.gn
+++ b/chrome/browser/BUILD.gn
@@ -1470,6 +1470,13 @@ split_static_library("browser") {
     "win/titlebar_config.h",
   ]
 
+  if (!is_android) {
+    sources += [
+      "embedded_ui_service_info_factory.cc",
+      "embedded_ui_service_info_factory.h",
+    ]
+  }
+
   configs += [
     "//build/config/compiler:wexit_time_destructors",
     "//build/config:precompiled_headers",

--- a/chrome/browser/browser_process_platform_part.h
+++ b/chrome/browser/browser_process_platform_part.h
@@ -16,6 +16,8 @@
 #include "chrome/browser/browser_process_platform_part_mac.h"
 #elif defined(OS_WIN)
 #include "chrome/browser/browser_process_platform_part_win.h"
+#elif defined(USE_OZONE) && defined(OS_LINUX)
+#include "chrome/browser/browser_process_platform_part_ozone.h"
 #else
 #include "chrome/browser/browser_process_platform_part_base.h"
 typedef BrowserProcessPlatformPartBase BrowserProcessPlatformPart;

--- a/chrome/browser/browser_process_platform_part_chromeos.cc
+++ b/chrome/browser/browser_process_platform_part_chromeos.cc
@@ -24,6 +24,7 @@
 #include "chrome/browser/chromeos/system/system_clock.h"
 #include "chrome/browser/chromeos/system/timezone_resolver_manager.h"
 #include "chrome/browser/chromeos/system/timezone_util.h"
+#include "chrome/browser/embedded_ui_service_info_factory.h"
 #include "chrome/browser/lifetime/keep_alive_types.h"
 #include "chrome/browser/lifetime/scoped_keep_alive.h"
 #include "chrome/browser/prefs/active_profile_pref_service.h"
@@ -34,14 +35,11 @@
 #include "chromeos/timezone/timezone_resolver.h"
 #include "components/session_manager/core/session_manager.h"
 #include "components/user_manager/user_manager.h"
-#include "content/public/browser/discardable_shared_memory_manager.h"
 #include "services/preferences/public/interfaces/preferences.mojom.h"
 #include "services/service_manager/public/cpp/binder_registry.h"
 #include "services/service_manager/public/cpp/interface_provider.h"
 #include "services/service_manager/public/cpp/service.h"
 #include "services/ui/common/image_cursors_set.h"
-#include "services/ui/public/interfaces/constants.mojom.h"
-#include "services/ui/service.h"
 
 #if defined(USE_OZONE)
 #include "content/public/common/service_manager_connection.h"
@@ -50,21 +48,6 @@
 #include "services/ui/public/cpp/input_devices/input_device_controller_client.h"
 #include "services/ui/public/interfaces/constants.mojom.h"
 #endif
-
-namespace {
-
-std::unique_ptr<service_manager::Service> CreateEmbeddedUIService(
-    const scoped_refptr<base::SingleThreadTaskRunner>& task_runner,
-    base::WeakPtr<ui::ImageCursorsSet> image_cursors_set_weak_ptr,
-    discardable_memory::DiscardableSharedMemoryManager* memory_manager) {
-  ui::Service::InProcessConfig config;
-  config.resource_runner = task_runner;
-  config.image_cursors_set_weak_ptr = image_cursors_set_weak_ptr;
-  config.memory_manager = memory_manager;
-  return base::MakeUnique<ui::Service>(&config);
-}
-
-}  // namespace
 
 BrowserProcessPlatformPart::BrowserProcessPlatformPart()
     : created_profile_helper_(false) {}
@@ -204,15 +187,9 @@ void BrowserProcessPlatformPart::RegisterInProcessServices(
   }
 
   if (chromeos::GetAshConfig() == ash::Config::MUS) {
-    service_manager::EmbeddedServiceInfo info;
     image_cursors_set_ = base::MakeUnique<ui::ImageCursorsSet>();
-    info.factory = base::Bind(&CreateEmbeddedUIService,
-                              base::ThreadTaskRunnerHandle::Get(),
-                              image_cursors_set_->GetWeakPtr(),
-                              content::GetDiscardableSharedMemoryManager());
-    info.use_own_thread = true;
-    info.message_loop_type = base::MessageLoop::TYPE_UI;
-    info.thread_priority = base::ThreadPriority::DISPLAY;
+    service_manager::EmbeddedServiceInfo info =
+        CreateEmbeddedUIServiceInfo(image_cursors_set_->GetWeakPtr());
     services->insert(std::make_pair(ui::mojom::kServiceName, info));
   }
 }

--- a/chrome/browser/browser_process_platform_part_ozone.cc
+++ b/chrome/browser/browser_process_platform_part_ozone.cc
@@ -1,0 +1,22 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "chrome/browser/browser_process_platform_part_ozone.h"
+
+#include "chrome/browser/embedded_ui_service_info_factory.h"
+#include "services/ui/common/image_cursors_set.h"
+#include "services/ui/public/interfaces/constants.mojom.h"
+#include "services/ui/service.h"
+
+BrowserProcessPlatformPart::BrowserProcessPlatformPart() = default;
+
+BrowserProcessPlatformPart::~BrowserProcessPlatformPart() = default;
+
+void BrowserProcessPlatformPart::RegisterInProcessServices(
+    content::ContentBrowserClient::StaticServiceMap* services) {
+  image_cursors_set_ = base::MakeUnique<ui::ImageCursorsSet>();
+  service_manager::EmbeddedServiceInfo info =
+      CreateEmbeddedUIServiceInfo(image_cursors_set_->GetWeakPtr());
+  services->insert(std::make_pair(ui::mojom::kServiceName, info));
+}

--- a/chrome/browser/browser_process_platform_part_ozone.h
+++ b/chrome/browser/browser_process_platform_part_ozone.h
@@ -1,0 +1,30 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CHROME_BROWSER_BROWSER_PROCESS_PLATFORM_PART_OZONE_H_
+#define CHROME_BROWSER_BROWSER_PROCESS_PLATFORM_PART_OZONE_H_
+
+#include "chrome/browser/browser_process_platform_part_base.h"
+
+namespace ui {
+class ImageCursorsSet;
+}
+
+class BrowserProcessPlatformPart : public BrowserProcessPlatformPartBase {
+ public:
+  BrowserProcessPlatformPart();
+  ~BrowserProcessPlatformPart() override;
+
+  // Overridden from BrowserProcessPlatformPartBase:
+  void RegisterInProcessServices(
+      content::ContentBrowserClient::StaticServiceMap* services) override;
+
+ private:
+  // Used by the UI Service.
+  std::unique_ptr<ui::ImageCursorsSet> image_cursors_set_;
+
+  DISALLOW_COPY_AND_ASSIGN(BrowserProcessPlatformPart);
+};
+
+#endif  // CHROME_BROWSER_BROWSER_PROCESS_PLATFORM_PART_OZONE_H_

--- a/chrome/browser/embedded_ui_service_info_factory.cc
+++ b/chrome/browser/embedded_ui_service_info_factory.cc
@@ -1,0 +1,36 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "chrome/browser/embedded_ui_service_info_factory.h"
+
+#include "content/public/browser/discardable_shared_memory_manager.h"
+#include "services/ui/public/interfaces/constants.mojom.h"
+#include "services/ui/service.h"
+
+namespace {
+
+std::unique_ptr<service_manager::Service> CreateEmbeddedUIService(
+    const scoped_refptr<base::SingleThreadTaskRunner>& task_runner,
+    base::WeakPtr<ui::ImageCursorsSet> image_cursors_set_weak_ptr,
+    discardable_memory::DiscardableSharedMemoryManager* memory_manager) {
+  ui::Service::InProcessConfig config;
+  config.resource_runner = task_runner;
+  config.image_cursors_set_weak_ptr = image_cursors_set_weak_ptr;
+  config.memory_manager = memory_manager;
+  return base::MakeUnique<ui::Service>(&config);
+}
+
+}  // namespace
+
+service_manager::EmbeddedServiceInfo CreateEmbeddedUIServiceInfo(
+    base::WeakPtr<ui::ImageCursorsSet> image_cursors_set_weak_ptr) {
+  service_manager::EmbeddedServiceInfo info;
+  info.factory = base::Bind(
+      &CreateEmbeddedUIService, base::ThreadTaskRunnerHandle::Get(),
+      image_cursors_set_weak_ptr, content::GetDiscardableSharedMemoryManager());
+  info.use_own_thread = true;
+  info.message_loop_type = base::MessageLoop::TYPE_UI;
+  info.thread_priority = base::ThreadPriority::DISPLAY;
+  return info;
+}

--- a/chrome/browser/embedded_ui_service_info_factory.h
+++ b/chrome/browser/embedded_ui_service_info_factory.h
@@ -1,0 +1,15 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CHROME_BROWSER_EMBEDDED_UI_SERVICE_INFO_FACTORY_H_
+#define CHROME_BROWSER_EMBEDDED_UI_SERVICE_INFO_FACTORY_H_
+
+#include "services/service_manager/embedder/embedded_service_info.h"
+#include "services/ui/common/image_cursors_set.h"
+
+// Returns an EmbeddedServiceInfo used to create the UI service.
+service_manager::EmbeddedServiceInfo CreateEmbeddedUIServiceInfo(
+    base::WeakPtr<ui::ImageCursorsSet> image_cursors_set_weak_ptr);
+
+#endif  // CHROME_BROWSER_EMBEDDED_UI_SERVICE_INFO_FACTORY_H_


### PR DESCRIPTION
Patch does two things:

1) Factor out Services related logic out of BrowserProcessPlatforPart{chromeos}
    
    CL introduces a BrowserProcessPlatforPartMus class, factors the MUS logic
    in ::RegisterInProcessServices out of BrowserProcessPlatforPart{chromeos}
    into it, and makes the later inherit from the former.
    
    For ChromeOS there is no behavior change (both --mash and --mus continue
    with the same process/service model), but it allow platforms other
    than ChromeOS run with Ozone and Mus, and benefit from in-process UI service.
    
    TEST=None
    BUG=722527

2)  fixup! Allow chrome launch with --mus parameter
    
Issue #157