### PR TITLE
fixup! [ozone/wayland] Fix Showing/Hiding, Placing and Events for Men…

### DIFF
--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -176,6 +176,10 @@ void WaylandWindow::Hide() {
   if (xdg_popup_) {
     parent_window_->set_child_window(nullptr);
     xdg_popup_.reset();
+    // Detach buffer from surface in order to completely shutdown popups and
+    // release resources.
+    wl_surface_attach(surface_.get(), NULL, 0, 0);
+    wl_surface_commit(surface_.get());
   }
 }
 


### PR DESCRIPTION
…u Windows

Release buffer as soon as the popups are destroyed. This fixes a problem, when a submenu window is opened second time and wayland complaints that the buffer has already been used.