### PR TITLE
Call SetWindowGeometry on Configure events respecting negotiated size.

### DIFF
--- a/ui/ozone/platform/wayland/fake_server.cc
+++ b/ui/ozone/platform/wayland/fake_server.cc
@@ -202,6 +202,16 @@ void AckConfigure(wl_client* client, wl_resource* resource, uint32_t serial) {
       ->AckConfigure(serial);
 }
 
+void SetWindowGeometry(wl_client* client,
+                       wl_resource* resource,
+                       int32_t x,
+                       int32_t y,
+                       int32_t width,
+                       int32_t height) {
+  static_cast<MockXdgSurface*>(wl_resource_get_user_data(resource))
+      ->SetWindowGeometry(x, y, width, height);
+}
+
 void SetMaximized(wl_client* client, wl_resource* resource) {
   static_cast<MockXdgSurface*>(wl_resource_get_user_data(resource))
       ->SetMaximized();
@@ -230,20 +240,20 @@ void SetMinimized(wl_client* client, wl_resource* resource) {
 }
 
 const struct xdg_surface_interface xdg_surface_impl = {
-    &DestroyResource,  // destroy
-    nullptr,           // set_parent
-    &SetTitle,         // set_title
-    &SetAppId,         // set_app_id
-    nullptr,           // show_window_menu
-    nullptr,           // move
-    nullptr,           // resize
-    &AckConfigure,     // ack_configure
-    nullptr,           // set_window_geometry
-    &SetMaximized,     // set_maximized
-    &UnsetMaximized,   // set_unmaximized
-    &SetFullScreen,    // set_fullscreen
-    &UnsetFullScreen,  // unset_fullscreen
-    &SetMinimized,     // set_minimized
+    &DestroyResource,    // destroy
+    nullptr,             // set_parent
+    &SetTitle,           // set_title
+    &SetAppId,           // set_app_id
+    nullptr,             // show_window_menu
+    nullptr,             // move
+    nullptr,             // resize
+    &AckConfigure,       // ack_configure
+    &SetWindowGeometry,  // set_window_geometry
+    &SetMaximized,       // set_maximized
+    &UnsetMaximized,     // set_unmaximized
+    &SetFullScreen,      // set_fullscreen
+    &UnsetFullScreen,    // unset_fullscreen
+    &SetMinimized,       // set_minimized
 };
 
 }  // namespace

--- a/ui/ozone/platform/wayland/fake_server.h
+++ b/ui/ozone/platform/wayland/fake_server.h
@@ -48,6 +48,8 @@ class MockXdgSurface : public ServerObject {
   MOCK_METHOD1(SetTitle, void(const char* title));
   MOCK_METHOD1(SetAppId, void(const char* app_id));
   MOCK_METHOD1(AckConfigure, void(uint32_t serial));
+  MOCK_METHOD4(SetWindowGeometry,
+               void(int32_t x, int32_t y, int32_t widht, int32_t height));
   MOCK_METHOD0(SetMaximized, void());
   MOCK_METHOD0(UnsetMaximized, void());
   MOCK_METHOD0(SetFullScreen, void());

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -140,6 +140,7 @@ void WaylandWindow::ApplyPendingBounds() {
 
   SetBounds(pending_bounds_);
   DCHECK(xdg_surface_);
+  xdg_surface_->SetWindowGeometry(bounds_);
   xdg_surface_->AckConfigure();
   pending_bounds_ = gfx::Rect();
   connection_->ScheduleFlush();

--- a/ui/ozone/platform/wayland/wayland_window_unittest.cc
+++ b/ui/ozone/platform/wayland/wayland_window_unittest.cc
@@ -166,7 +166,22 @@ TEST_F(WaylandWindowTest, ConfigureEvent) {
   // Make sure that the implementation does not call OnBoundsChanged for each
   // configure event if it receives multiple in a row.
   EXPECT_CALL(delegate, OnBoundsChanged(Eq(gfx::Rect(0, 0, 1500, 1000))));
+  // Responding to a configure event, the window geometry in here must respect
+  // the sizing negotiations specified by the configure event.
+  EXPECT_CALL(*xdg_surface, SetWindowGeometry(0, 0, 1500, 1000)).Times(1);
   EXPECT_CALL(*xdg_surface, AckConfigure(13));
+}
+
+TEST_F(WaylandWindowTest, ConfigureEventWithNulledSize) {
+  wl_array states;
+  wl_array_init(&states);
+
+  // If Wayland sends configure event with 0 width and 0 size, client should
+  // call back with desired sizes. In this case, that's the actual size of
+  // the window.
+  SendConfigureEvent(0, 0, 14, &states);
+  EXPECT_CALL(*xdg_surface, SetWindowGeometry(0, 0, 800, 600));
+  EXPECT_CALL(*xdg_surface, AckConfigure(14));
 }
 
 }  // namespace ui

--- a/ui/ozone/platform/wayland/xdg_surface_wrapper.h
+++ b/ui/ozone/platform/wayland/xdg_surface_wrapper.h
@@ -8,6 +8,10 @@
 #include "base/strings/string16.h"
 #include "ui/ozone/platform/wayland/wayland_object.h"
 
+namespace gfx {
+class Rect;
+}
+
 namespace ui {
 
 class WaylandConnection;
@@ -50,6 +54,9 @@ class XDGSurfaceWrapper {
 
   // Sends acknowledge configure event back to wayland.
   virtual void AckConfigure() = 0;
+
+  // Sets a desired window geometry once wayland requests client to do so.
+  virtual void SetWindowGeometry(const gfx::Rect& bounds) = 0;
 };
 
 }  // namespace ui

--- a/ui/ozone/platform/wayland/xdg_surface_wrapper_v5.cc
+++ b/ui/ozone/platform/wayland/xdg_surface_wrapper_v5.cc
@@ -115,6 +115,11 @@ void XDGSurfaceWrapperV5::AckConfigure() {
   xdg_surface_ack_configure(xdg_surface_.get(), pending_configure_serial_);
 }
 
+void XDGSurfaceWrapperV5::SetWindowGeometry(const gfx::Rect& bounds) {
+  xdg_surface_set_window_geometry(xdg_surface_.get(), bounds.x(), bounds.y(),
+                                  bounds.width(), bounds.height());
+}
+
 // static
 void XDGSurfaceWrapperV5::Configure(void* data,
                                     xdg_surface* obj,

--- a/ui/ozone/platform/wayland/xdg_surface_wrapper_v5.h
+++ b/ui/ozone/platform/wayland/xdg_surface_wrapper_v5.h
@@ -32,6 +32,7 @@ class XDGSurfaceWrapperV5 : public XDGSurfaceWrapper {
   void SurfaceResize(WaylandConnection* connection, uint32_t hittest) override;
   void SetTitle(const base::string16& title) override;
   void AckConfigure() override;
+  void SetWindowGeometry(const gfx::Rect& bounds) override;
 
   // xdg_surface_listener
   static void Configure(void* data,

--- a/ui/ozone/platform/wayland/xdg_surface_wrapper_v6.cc
+++ b/ui/ozone/platform/wayland/xdg_surface_wrapper_v6.cc
@@ -157,6 +157,13 @@ void XDGSurfaceWrapperV6::AckConfigure() {
                                 pending_configure_serial_);
 }
 
+void XDGSurfaceWrapperV6::SetWindowGeometry(const gfx::Rect& bounds) {
+  DCHECK(zxdg_surface_v6_);
+  zxdg_surface_v6_set_window_geometry(zxdg_surface_v6_.get(), bounds.x(),
+                                      bounds.y(), bounds.width(),
+                                      bounds.height());
+}
+
 // static
 void XDGSurfaceWrapperV6::Configure(void* data,
                                     struct zxdg_surface_v6* zxdg_surface_v6,

--- a/ui/ozone/platform/wayland/xdg_surface_wrapper_v6.h
+++ b/ui/ozone/platform/wayland/xdg_surface_wrapper_v6.h
@@ -9,6 +9,10 @@
 
 #include "base/macros.h"
 
+namespace gfx {
+class Rect;
+}
+
 namespace ui {
 
 class WaylandConnection;
@@ -31,6 +35,7 @@ class XDGSurfaceWrapperV6 : public XDGSurfaceWrapper {
   void SurfaceResize(WaylandConnection* connection, uint32_t hittest) override;
   void SetTitle(const base::string16& title) override;
   void AckConfigure() override;
+  void SetWindowGeometry(const gfx::Rect& bounds) override;
 
   // xdg_surface_listener
   static void Configure(void* data,


### PR DESCRIPTION
Wayland can ask to a client to set window geometry in certain cases
like before interactive drag/resize, unmaximize and etc.
If width and height are send as 0s, it means that a client
must answer Wayland with SetWindowGeometry command and acknowledge
that. If it is not done, certain compositors like Gnome with Wayland
can treat this not answered request as the client wants the window
to be with 0 widht and 0 height, which could result in a tiny window
during initial resize event.

What is more, width and height can be set to a certain value, which is negotiated value that 
client should respect by calling back SetWindowGeometry.

Issue: https://github.com/Igalia/chromium/issues/195