### PR TITLE
Extend WindowEventFilter to properly handle TouchEvents.

### DIFF
--- a/ui/views/widget/desktop_aura/window_event_filter.cc
+++ b/ui/views/widget/desktop_aura/window_event_filter.cc
@@ -21,6 +21,28 @@
 
 namespace views {
 
+namespace {
+
+bool CanPerformDragOrResize(int hittest) {
+  switch (hittest) {
+    case HTBOTTOM:
+    case HTBOTTOMLEFT:
+    case HTBOTTOMRIGHT:
+    case HTCAPTION:
+    case HTLEFT:
+    case HTRIGHT:
+    case HTTOP:
+    case HTTOPLEFT:
+    case HTTOPRIGHT:
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
+
+}  // namespace
+
 WindowEventFilter::WindowEventFilter(DesktopWindowTreeHost* window_tree_host)
     : window_tree_host_(window_tree_host), click_component_(HTNOWHERE) {}
 
@@ -29,22 +51,37 @@ WindowEventFilter::~WindowEventFilter() {}
 void WindowEventFilter::OnMouseEvent(ui::MouseEvent* event) {
   if (event->type() != ui::ET_MOUSE_PRESSED)
     return;
+  HandleEventInternal(event);
+}
+
+void WindowEventFilter::OnTouchEvent(ui::TouchEvent* event) {
+  if (event->type() != ui::ET_TOUCH_PRESSED)
+    return;
+  HandleEventInternal(event);
+}
+
+void WindowEventFilter::HandleEventInternal(ui::Event* event) {
+  DCHECK(event->IsMouseEvent() || event->IsTouchEvent());
 
   aura::Window* target = static_cast<aura::Window*>(event->target());
   if (!target->delegate())
     return;
 
+  DCHECK(event->IsLocatedEvent());
+
   int previous_click_component = HTNOWHERE;
-  int component = target->delegate()->GetNonClientComponent(event->location());
-  if (event->IsLeftMouseButton()) {
+  const gfx::Point& location = event->AsLocatedEvent()->location();
+  int component = target->delegate()->GetNonClientComponent(location);
+  if (event->type() == ui::ET_TOUCH_PRESSED ||
+      event->AsMouseEvent()->IsLeftMouseButton()) {
     previous_click_component = click_component_;
     click_component_ = component;
   }
 
   if (component == HTCAPTION) {
     OnClickedCaption(event, previous_click_component);
-  } else if (component == HTMAXBUTTON) {
-    OnClickedMaximizeButton(event);
+  } else if (component == HTMAXBUTTON && event->IsMouseEvent()) {
+    OnClickedMaximizeButton(event->AsMouseEvent());
   } else {
     if (target->GetProperty(aura::client::kResizeBehaviorKey) &
         ui::mojom::kResizeBehaviorCanResize) {
@@ -53,11 +90,11 @@ void WindowEventFilter::OnMouseEvent(ui::MouseEvent* event) {
   }
 }
 
-void WindowEventFilter::OnClickedCaption(ui::MouseEvent* event,
+void WindowEventFilter::OnClickedCaption(ui::Event* event,
                                          int previous_click_component) {
   aura::Window* target = static_cast<aura::Window*>(event->target());
 
-  if (event->IsMiddleMouseButton()) {
+  if (event->IsMouseEvent() && event->AsMouseEvent()->IsMiddleMouseButton()) {
     LinuxUI::NonClientMiddleClickAction action =
         LinuxUI::MIDDLE_CLICK_ACTION_LOWER;
     LinuxUI* linux_ui = LinuxUI::instance();
@@ -84,7 +121,8 @@ void WindowEventFilter::OnClickedCaption(ui::MouseEvent* event,
     return;
   }
 
-  if (event->IsLeftMouseButton() && event->flags() & ui::EF_IS_DOUBLE_CLICK) {
+  if ((event->IsMouseEvent() && event->AsMouseEvent()->IsLeftMouseButton() &&
+       event->flags() & ui::EF_IS_DOUBLE_CLICK)) {
     click_component_ = HTNOWHERE;
     if ((target->GetProperty(aura::client::kResizeBehaviorKey) &
          ui::mojom::kResizeBehaviorCanMaximize) &&
@@ -132,11 +170,14 @@ void WindowEventFilter::ToggleMaximizedState() {
 
 void WindowEventFilter::LowerWindow() {}
 
-void WindowEventFilter::MaybeDispatchHostWindowDragMovement(
-    int hittest,
-    ui::MouseEvent* event) {
-  if (event->IsLeftMouseButton())
+void WindowEventFilter::MaybeDispatchHostWindowDragMovement(int hittest,
+                                                            ui::Event* event) {
+  if ((event->type() == ui::ET_TOUCH_PRESSED ||
+       event->AsMouseEvent()->IsLeftMouseButton()) &&
+      CanPerformDragOrResize(hittest)) {
     window_tree_host_->PerformNativeWindowDragOrResize(hittest);
+    event->StopPropagation();
+  }
 }
 
 }  // namespace views

--- a/ui/views/widget/desktop_aura/window_event_filter.h
+++ b/ui/views/widget/desktop_aura/window_event_filter.h
@@ -24,10 +24,14 @@ class VIEWS_EXPORT WindowEventFilter : public ui::EventHandler {
 
   // Overridden from ui::EventHandler:
   void OnMouseEvent(ui::MouseEvent* event) override;
+  void OnTouchEvent(ui::TouchEvent* event) override;
 
  private:
+  // Handles touch and mouse events.
+  void HandleEventInternal(ui::Event* event);
+
   // Called when the user clicked the caption area.
-  void OnClickedCaption(ui::MouseEvent* event, int previous_click_component);
+  void OnClickedCaption(ui::Event* event, int previous_click_component);
 
   // Called when the user clicked the maximize button.
   void OnClickedMaximizeButton(ui::MouseEvent* event);
@@ -38,7 +42,7 @@ class VIEWS_EXPORT WindowEventFilter : public ui::EventHandler {
   // or titlebar drag occurred with left mouse click. In case of X11, a
   // _NET_WM_MOVERESIZE message is sent.
   virtual void MaybeDispatchHostWindowDragMovement(int hittest,
-                                                   ui::MouseEvent* event);
+                                                   ui::Event* event);
 
   // A signal to lower an attached to this filter window to the bottom of the
   // stack.

--- a/ui/views/widget/desktop_aura/x11_window_event_filter.cc
+++ b/ui/views/widget/desktop_aura/x11_window_event_filter.cc
@@ -56,8 +56,9 @@ X11WindowEventFilter::~X11WindowEventFilter() {
 
 void X11WindowEventFilter::MaybeDispatchHostWindowDragMovement(
     int hittest,
-    ui::MouseEvent* event) {
-  if (event->IsLeftMouseButton() && event->native_event()) {
+    ui::Event* event) {
+  if (event->native_event() && (event->type() == ui::ET_TOUCH_PRESSED ||
+                                (event->AsMouseEvent()->IsLeftMouseButton()))) {
     // Get the |x_root_window_| location out of the native event.
     const gfx::Point x_root_location =
         ui::EventSystemLocationFromNative(event->native_event());

--- a/ui/views/widget/desktop_aura/x11_window_event_filter.h
+++ b/ui/views/widget/desktop_aura/x11_window_event_filter.h
@@ -31,7 +31,7 @@ class VIEWS_EXPORT X11WindowEventFilter : public WindowEventFilter {
  private:
   // WindowEventFilter override:
   void MaybeDispatchHostWindowDragMovement(int hittest,
-                                           ui::MouseEvent* event) override;
+                                           ui::Event* event) override;
   void LowerWindow() override;
 
   bool DispatchHostWindowDragMovement(int hittest,


### PR DESCRIPTION
Extend WindowEventFilter to properly handle TouchEvents.
This fixes resizing and dragging issues with wayland touch support.

Issue: #100