### PR TITLE
Add nullcheck for child_window_

### DIFF
--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -311,7 +311,8 @@ bool WaylandWindow::CanDispatchEvent(const PlatformEvent& native_event) {
   Event* event = static_cast<Event*>(native_event);
   if (event->IsMouseEvent()) {
     if (g_current_capture_ == this) {
-      if (has_pointer_or_touch_focus() || child_window_->is_focused_popup())
+      if (has_pointer_or_touch_focus() ||
+          (child_window_ && child_window_->is_focused_popup()))
         return true;
       else
         return false;


### PR DESCRIPTION
Add nullcheck for child_window_. Fixes random crashes.