### PR TITLE
Fix scrolling after clicking the non client area.

### DIFF
--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -2373,6 +2373,10 @@ void WindowTree::PerformNativeWindowDragOrResize(Id window_id,
     return;
   }
   display_root->display()->PerformNativeWindowDragOrResize(hittest);
+
+  // Reset states so that the next events are processed without any
+  // left over state.
+  display_root->window_manager_state()->event_dispatcher()->Reset();
 }
 
 void WindowTree::CancelWindowMove(Id window_id) {

--- a/ui/aura/mus/window_tree_host_mus.cc
+++ b/ui/aura/mus/window_tree_host_mus.cc
@@ -112,6 +112,10 @@ void WindowTreeHostMus::SetBoundsFromServer(const gfx::Rect& bounds_in_pixels) {
   SetBoundsInPixels(bounds_in_pixels);
 }
 
+ui::EventDispatchDetails WindowTreeHostMus::SendEventToSink(ui::Event* event) {
+  return aura::WindowTreeHostPlatform::SendEventToSink(event);
+}
+
 void WindowTreeHostMus::SetClientArea(
     const gfx::Insets& insets,
     const std::vector<gfx::Rect>& additional_client_area) {

--- a/ui/aura/mus/window_tree_host_mus.h
+++ b/ui/aura/mus/window_tree_host_mus.h
@@ -42,9 +42,7 @@ class AURA_EXPORT WindowTreeHostMus : public aura::WindowTreeHostPlatform {
   // Sets the bounds in pixels.
   void SetBoundsFromServer(const gfx::Rect& bounds_in_pixels);
 
-  ui::EventDispatchDetails SendEventToSink(ui::Event* event) {
-    return aura::WindowTreeHostPlatform::SendEventToSink(event);
-  }
+  virtual ui::EventDispatchDetails SendEventToSink(ui::Event* event);
 
   InputMethodMus* input_method() { return input_method_.get(); }
 

--- a/ui/views/mus/desktop_window_tree_host_mus.h
+++ b/ui/views/mus/desktop_window_tree_host_mus.h
@@ -46,6 +46,8 @@ class VIEWS_MUS_EXPORT DesktopWindowTreeHostMus
     auto_update_client_area_ = value;
   }
 
+  ui::EventDispatchDetails SendEventToSink(ui::Event* event) override;
+
  private:
   void SendClientAreaToServer();
   void SendHitTestMaskToServer();


### PR DESCRIPTION
Patch fixes scrolling after clicking the non client area.
This is similar to upstream bug https://codereview.chromium.org/198093003.

Issue #189