### PR TITLE
Revert custom changes in WindowTreeClient::ConfigureWindowDataFromServer

### DIFF
--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -81,7 +81,7 @@ void Display::Init(const display::ViewportMetrics& metrics,
   binding_ = std::move(binding);
   display_manager()->AddDisplay(this);
 
-  CreateRootWindow(metrics.bounds_in_pixels.size());
+  CreateRootWindow(metrics.bounds_in_pixels);
 
   platform_display_ = PlatformDisplay::Create(
       root_.get(), metrics, window_server_->GetThreadedImageCursorsFactory());
@@ -311,7 +311,7 @@ void Display::CreateWindowManagerDisplayRootFromFactory(
       std::move(display_root_ptr));
 }
 
-void Display::CreateRootWindow(const gfx::Size& size) {
+void Display::CreateRootWindow(const gfx::Rect& bounds) {
   DCHECK(!root_);
 
   root_.reset(window_server_->CreateServerWindow(
@@ -319,7 +319,7 @@ void Display::CreateRootWindow(const gfx::Size& size) {
       ServerWindow::Properties()));
   root_->set_event_targeting_policy(
       mojom::EventTargetingPolicy::DESCENDANTS_ONLY);
-  root_->SetBounds(gfx::Rect(size), allocator_.GenerateId());
+  root_->SetBounds(bounds, allocator_.GenerateId());
   root_->SetVisible(true);
   focus_controller_ = base::MakeUnique<FocusController>(root_.get());
   focus_controller_->AddObserver(this);

--- a/services/ui/ws/display.h
+++ b/services/ui/ws/display.h
@@ -188,9 +188,9 @@ class Display : public PlatformDisplayDelegate,
   void CreateWindowManagerDisplayRootFromFactory(
       WindowManagerWindowTreeFactory* factory);
 
-  // Creates the root ServerWindow for this display, where |size| is in physical
+  // Creates the root ServerWindow for this display, where |rect| is in physical
   // pixels.
-  void CreateRootWindow(const gfx::Size& size);
+  void CreateRootWindow(const gfx::Rect& bounds);
 
   // Applyes the cursor scale and rotation to the PlatformDisplay.
   void UpdateCursorConfig();

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -1409,6 +1409,16 @@ mojom::WindowDataPtr WindowTree::WindowToWindowData(
       transient_parent ? ClientWindowIdForWindow(transient_parent).id
                        : ClientWindowId().id;
   window_data->bounds = window->bounds();
+  // In external window mode, we cap the bounds WindowManagerDisplayRoot's
+  // root window to 0,0. So send the bounds of Display's root, which has the
+  // same size but contains the proper window placement (x, y).
+  if (window_server_->IsInExternalWindowMode()) {
+    WindowManagerDisplayRoot* display_root =
+        GetWindowManagerDisplayRoot(window);
+    if (display_root && display_root->GetClientVisibleRoot() == window)
+      window_data->bounds = GetDisplay(window)->root_window()->bounds();
+  }
+
   window_data->properties = mojo::MapToUnorderedMap(window->properties());
   window_data->visible = window->visible();
   return window_data;

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -540,17 +540,9 @@ void WindowTreeClient::ConfigureWindowDataFromServer(
     SetWindowVisibleFromServer(WindowMus::Get(window_tree_host->window()),
                                true);
   }
-  gfx::Rect new_bounds = window_data.bounds;
-  // Disallow changing StubWindow's bounds in external window mode as long
-  // as the StubWindow's bounds are used as a origin reference of a real
-  // native window.
-  if (in_external_window_mode_ && new_bounds.origin() == gfx::Point()) {
-    gfx::Point old_origin = window_tree_host->GetBoundsInPixels().origin();
-    new_bounds.set_origin(old_origin);
-  }
   WindowMus* window = WindowMus::Get(window_tree_host->window());
 
-  SetWindowBoundsFromServer(window, new_bounds, local_surface_id);
+  SetWindowBoundsFromServer(window, window_data.bounds, local_surface_id);
   ui::Compositor* compositor =
       window_tree_host->window()->GetHost()->compositor();
   compositor->AddObserver(this);


### PR DESCRIPTION
This CL creates ws::Display::root_ with the proper bounds, and passes the
ws::Display bounds information for the client through WindowTree::DoOnEmbed.
Previously, we were passing WindowManagerDisplayRoot::root_'s bounds,
which we always cap to (0, 0).

This allows us to revert from custom changes in
WindowTreeClient::ConfigureWindowDataFromServer.

Issue #108