### PR TITLE
Propagate child-parent relationship from aura to mus.

### DIFF
--- a/services/ui/display/viewport_metrics.h
+++ b/services/ui/display/viewport_metrics.h
@@ -9,6 +9,7 @@
 
 #include "services/ui/public/interfaces/window_manager_constants.mojom.h"
 #include "ui/gfx/geometry/rect.h"
+#include "ui/gfx/native_widget_types.h"
 
 namespace display {
 
@@ -23,6 +24,10 @@ struct ViewportMetrics {
   // and for upstreaming, we should likely consider renaming ViewportMetrics
   // to DisplayProperties or so.
   ui::mojom::WindowType window_type = ui::mojom::WindowType::WINDOW;
+
+  // An id of a suggested parent window. Used by ozone platforms (currently by
+  // Wayland) to get a parent window and form parent-child relationship.
+  gfx::AcceleratedWidget parent_window_widget_id = gfx::kNullAcceleratedWidget;
 };
 
 inline bool operator==(const ViewportMetrics& lhs, const ViewportMetrics& rhs) {

--- a/services/ui/public/interfaces/window_manager.mojom
+++ b/services/ui/public/interfaces/window_manager.mojom
@@ -78,6 +78,10 @@ interface WindowManager {
   // created by the window manager at the request of a client.
   // Type: mojom::WindowType (int32_t).
   const string kWindowType_InitProperty = "init:window-type";
+  
+  // The id of the parent window, which ozone windows can use to make a proper
+  // parenting chain. Type: int32_t.
+  const string kParentWindowId_InitProperty = "init:parent-window-id";
 
   // End properties used only during creation time. ----------------------------
 

--- a/services/ui/ws/platform_display_default.cc
+++ b/services/ui/ws/platform_display_default.cc
@@ -382,5 +382,13 @@ void PlatformDisplayDefault::OnAcceleratedWidgetDestroyed() {
 
 void PlatformDisplayDefault::OnActivationChanged(bool active) {}
 
+void PlatformDisplayDefault::GetParentWindowAcceleratedWidget(
+    gfx::AcceleratedWidget* widget) {
+  if (metrics_.parent_window_widget_id == gfx::kNullAcceleratedWidget)
+    return;
+
+  *widget = metrics_.parent_window_widget_id;
+}
+
 }  // namespace ws
 }  // namespace ui

--- a/services/ui/ws/platform_display_default.h
+++ b/services/ui/ws/platform_display_default.h
@@ -74,6 +74,8 @@ class PlatformDisplayDefault : public PlatformDisplay,
                                     float device_scale_factor) override;
   void OnAcceleratedWidgetDestroyed() override;
   void OnActivationChanged(bool active) override;
+  void GetParentWindowAcceleratedWidget(
+      gfx::AcceleratedWidget* widget) override;
 
   ServerWindow* root_window_;
 

--- a/services/ui/ws/window_tree_host_factory.cc
+++ b/services/ui/ws/window_tree_host_factory.cc
@@ -9,6 +9,8 @@
 #include "services/ui/public/cpp/property_type_converters.h"
 #include "services/ui/ws/display.h"
 #include "services/ui/ws/display_binding.h"
+#include "services/ui/ws/display_manager.h"
+#include "services/ui/ws/window_manager_display_root.h"
 #include "services/ui/ws/window_server.h"
 #include "services/ui/ws/window_tree.h"
 
@@ -58,6 +60,18 @@ void WindowTreeHostFactory::CreatePlatformWindow(
         mojo::ConvertTo<int32_t>(iter->second));
   }
 
+  iter =
+      properties.find(ui::mojom::WindowManager::kParentWindowId_InitProperty);
+  metrics.parent_window_widget_id = gfx::kNullAcceleratedWidget;
+  if (iter != properties.end()) {
+    ClientWindowId client_window_id(mojo::ConvertTo<int32_t>(iter->second));
+    ServerWindow* server_window = tree->GetWindowByClientId(client_window_id);
+    DCHECK(server_window);
+    PlatformDisplay* platform_display = GetPlatformDisplay(server_window);
+    metrics.parent_window_widget_id = platform_display->GetAcceleratedWidget();
+    DCHECK_NE(gfx::kNullAcceleratedWidget, metrics.parent_window_widget_id);
+  }
+
   ws_display->Init(metrics, std::move(display_binding));
 
   // The call below used to be part of ws::Display::Init chain.
@@ -68,6 +82,17 @@ void WindowTreeHostFactory::CreatePlatformWindow(
   // ServerWindow::Add which can trigger a mouse update, which in turn
   // requires the platform/ozone window to be fully created by then.
   tree->AddRoot(ws_display->root_window()->children()[0]);
+}
+
+PlatformDisplay* WindowTreeHostFactory::GetPlatformDisplay(
+    ServerWindow* server_window) {
+  WindowManagerDisplayRoot* display_root =
+      window_server_->display_manager()->GetWindowManagerDisplayRoot(
+          server_window);
+  PlatformDisplay* platform_display =
+      display_root->display()->platform_display();
+  DCHECK(platform_display);
+  return platform_display;
 }
 
 }  // namespace ws

--- a/services/ui/ws/window_tree_host_factory.h
+++ b/services/ui/ws/window_tree_host_factory.h
@@ -15,6 +15,8 @@
 namespace ui {
 namespace ws {
 
+class PlatformDisplay;
+class ServerWindow;
 class WindowServer;
 
 class WindowTreeHostFactory : public mojom::WindowTreeHostFactory {
@@ -32,6 +34,8 @@ class WindowTreeHostFactory : public mojom::WindowTreeHostFactory {
       mojom::WindowTreeHostRequest tree_host_request,
       Id transport_window_id,
       const TransportProperties& transport_properties) override;
+
+  PlatformDisplay* GetPlatformDisplay(ServerWindow* server_window);
 
   WindowServer* window_server_;
   const UserId user_id_;

--- a/ui/ozone/platform/wayland/wayland_window.h
+++ b/ui/ozone/platform/wayland/wayland_window.h
@@ -115,6 +115,9 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
   // Resets the maximized and fullscreen window states.
   void ResetWindowStates();
 
+  // May get a parent window for this window.
+  void GetParentWindow();
+
   PlatformWindowDelegate* delegate_;
   WaylandConnection* connection_;
   WaylandWindow* parent_window_ = nullptr;

--- a/ui/platform_window/platform_window_delegate.h
+++ b/ui/platform_window/platform_window_delegate.h
@@ -14,6 +14,7 @@ class Rect;
 namespace ui {
 
 class Event;
+class PlatformWindow;
 
 enum PlatformWindowState {
   PLATFORM_WINDOW_STATE_UNKNOWN,
@@ -61,6 +62,9 @@ class PlatformWindowDelegate {
   // we can have a default implementation here and not need to add stubs to
   // all subclasses. To be discussed when upstraming.
   virtual void GetWindowType(PlatformWindowType* window_type) {}
+
+  virtual void GetParentWindowAcceleratedWidget(
+      gfx::AcceleratedWidget* widget) {}
 };
 
 }  // namespace ui

--- a/ui/views/mus/mus_client.cc
+++ b/ui/views/mus/mus_client.cc
@@ -19,6 +19,7 @@
 #include "ui/aura/mus/capture_synchronizer.h"
 #include "ui/aura/mus/mus_context_factory.h"
 #include "ui/aura/mus/property_converter.h"
+#include "ui/aura/mus/window_port_mus.h"
 #include "ui/aura/mus/window_tree_client.h"
 #include "ui/aura/mus/window_tree_host_mus.h"
 #include "ui/aura/mus/window_tree_host_mus_init_params.h"
@@ -210,6 +211,15 @@ MusClient::ConfigurePropertiesFromParams(
 
   properties[WindowManager::kRemoveStandardFrame_InitProperty] =
       mojo::ConvertTo<TransportType>(init_params.remove_standard_frame);
+
+  if (init_params.parent) {
+    aura::WindowPortMus* window_port_parent =
+        aura::WindowPortMus::Get(init_params.parent);
+    DCHECK(window_port_parent);
+    int window_id = window_port_parent->server_id();
+    properties[WindowManager::kParentWindowId_InitProperty] =
+        mojo::ConvertTo<std::vector<uint8_t>>(window_id);
+  }
 
   if (!Widget::RequiresNonClientView(init_params.type))
     return properties;


### PR DESCRIPTION
This commit simplifies the way how, for example, wayland
makes a child-parent relationship. Instead of doing a fancy
stuff with focuses (which involve races sometimes), it relies on
the information propagated from aura and then finds the right parent
for popup windows.