### PR TITLE
Yield the use of aura::Env::Mode::MUS over service_manager::ServiceManagerIsRemote in window_finder_mus.cc

### DIFF
--- a/chrome/browser/ui/views/tabs/window_finder_mus.cc
+++ b/chrome/browser/ui/views/tabs/window_finder_mus.cc
@@ -10,14 +10,24 @@
 #include "ui/aura/window.h"
 #include "ui/views/mus/mus_client.h"
 
+#if defined(USE_AURA)
+#include "ui/aura/env.h"
+#endif
+
+bool IsUsingMus() {
+#if defined(USE_AURA)
+  return aura::Env::GetInstance()->mode() == aura::Env::Mode::MUS;
+#else
+  return false;
+#endif
+}
+
 bool GetLocalProcessWindowAtPointMus(
     const gfx::Point& screen_point,
     const std::set<gfx::NativeWindow>& ignore,
     gfx::NativeWindow* mus_result) {
   *mus_result = nullptr;
-  content::ServiceManagerConnection* service_manager_connection =
-      content::ServiceManagerConnection::GetForProcess();
-  if (!service_manager_connection || !service_manager::ServiceManagerIsRemote())
+  if (!IsUsingMus())
     return false;
 
   std::set<aura::Window*> root_windows =


### PR DESCRIPTION
Since PR #188 chrome/mus on Linux adopted the same process model
of chromeos/mus (UI service as a thread of the Browser process).
Since then, service_manager::ServiceManagerIsRemote started resolving to 'false'.
This broke tab dragging for chrome/mus.

Patch changes window_finder_mus.cc to use aura::Env::Mode::Mus (like done
in [1]) instead of service_manager::ServiceManagerIsRemote.

Note that this continues to work the same way for chromeos/mash.

[1] https://chromium-review.googlesource.com/601257

Issue #210