### PR TITLE
[ozone/wayland] Implement cursor support

### DIFF
--- a/ui/base/cursor/ozone/bitmap_cursor_factory_ozone.h
+++ b/ui/base/cursor/ozone/bitmap_cursor_factory_ozone.h
@@ -17,9 +17,16 @@
 
 namespace ui {
 
+// ChromeOS does not seem to need the thread safe variant of RefCounted because
+// it uses "custom" cursors, and in PlatformDisplayDefault::SetCursor, it takes
+// the non-threaded path.
+//
+// TODO(tonikitoo,msisov): investigate how to share the same logic as ChromeOS
+// or upstream this change.
+
 // A cursor that is an SkBitmap combined with a gfx::Point hotspot.
 class UI_BASE_EXPORT BitmapCursorOzone
-    : public base::RefCounted<BitmapCursorOzone> {
+    : public base::RefCountedThreadSafe<BitmapCursorOzone> {
  public:
   BitmapCursorOzone(const SkBitmap& bitmap, const gfx::Point& hotspot);
   BitmapCursorOzone(const std::vector<SkBitmap>& bitmaps,
@@ -34,7 +41,7 @@ class UI_BASE_EXPORT BitmapCursorOzone
   int frame_delay_ms();
 
  private:
-  friend class base::RefCounted<BitmapCursorOzone>;
+  friend class base::RefCountedThreadSafe<BitmapCursorOzone>;
   ~BitmapCursorOzone();
 
   std::vector<SkBitmap> bitmaps_;

--- a/ui/ozone/platform/wayland/BUILD.gn
+++ b/ui/ozone/platform/wayland/BUILD.gn
@@ -20,6 +20,8 @@ source_set("wayland") {
     "ozone_platform_wayland.h",
     "wayland_connection.cc",
     "wayland_connection.h",
+    "wayland_cursor.cc",
+    "wayland_cursor.h",
     "wayland_keyboard.cc",
     "wayland_keyboard.h",
     "wayland_object.cc",

--- a/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+++ b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
@@ -5,6 +5,7 @@
 #include "ui/ozone/platform/wayland/ozone_platform_wayland.h"
 
 #include "base/memory/ptr_util.h"
+#include "ui/base/cursor/ozone/bitmap_cursor_factory_ozone.h"
 #include "ui/base/ui_features.h"
 #include "ui/display/fake_display_delegate.h"
 #include "ui/events/ozone/layout/keyboard_layout_engine_manager.h"
@@ -12,7 +13,6 @@
 #include "ui/ozone/platform/wayland/wayland_connection.h"
 #include "ui/ozone/platform/wayland/wayland_surface_factory.h"
 #include "ui/ozone/platform/wayland/wayland_window.h"
-#include "ui/ozone/public/cursor_factory_ozone.h"
 #include "ui/ozone/public/gpu_platform_support_host.h"
 #include "ui/ozone/public/input_controller.h"
 #include "ui/ozone/public/ozone_platform.h"
@@ -101,7 +101,7 @@ class OzonePlatformWayland : public OzonePlatform {
         base::MakeUnique<StubKeyboardLayoutEngine>());
 #endif
 
-    cursor_factory_.reset(new CursorFactoryOzone);
+    cursor_factory_.reset(new BitmapCursorFactoryOzone);
     overlay_manager_.reset(new StubOverlayManager);
     input_controller_ = CreateStubInputController();
     surface_factory_.reset(new WaylandSurfaceFactory(connection_.get()));
@@ -127,7 +127,7 @@ class OzonePlatformWayland : public OzonePlatform {
  private:
   std::unique_ptr<WaylandConnection> connection_;
   std::unique_ptr<WaylandSurfaceFactory> surface_factory_;
-  std::unique_ptr<CursorFactoryOzone> cursor_factory_;
+  std::unique_ptr<BitmapCursorFactoryOzone> cursor_factory_;
   std::unique_ptr<StubOverlayManager> overlay_manager_;
   std::unique_ptr<InputController> input_controller_;
   std::unique_ptr<GpuPlatformSupportHost> gpu_platform_support_host_;

--- a/ui/ozone/platform/wayland/wayland_connection.cc
+++ b/ui/ozone/platform/wayland/wayland_connection.cc
@@ -127,6 +127,11 @@ WaylandOutput* WaylandConnection::PrimaryOutput() const {
   return output_list_.front().get();
 }
 
+void WaylandConnection::SetCursorBitmap(const std::vector<SkBitmap>& bitmaps,
+                                        const gfx::Point& location) {
+  pointer_->cursor()->UpdateBitmap(bitmaps, location, serial_);
+}
+
 void WaylandConnection::OnDispatcherListChanged() {
   StartProcessingEvents();
 }

--- a/ui/ozone/platform/wayland/wayland_connection.h
+++ b/ui/ozone/platform/wayland/wayland_connection.h
@@ -50,6 +50,9 @@ class WaylandConnection : public PlatformEventSource,
   void set_serial(uint32_t serial) { serial_ = serial; }
   uint32_t serial() { return serial_; }
 
+  void SetCursorBitmap(const std::vector<SkBitmap>& bitmaps,
+                       const gfx::Point& location);
+
  private:
   void Flush();
   void DispatchUiEvent(Event* event);

--- a/ui/ozone/platform/wayland/wayland_cursor.cc
+++ b/ui/ozone/platform/wayland/wayland_cursor.cc
@@ -1,0 +1,127 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/ozone/platform/wayland/wayland_cursor.h"
+
+#include <sys/mman.h>
+#include <vector>
+
+#include "base/logging.h"
+#include "base/memory/shared_memory.h"
+#include "ui/ozone/platform/wayland/wayland_connection.h"
+#include "ui/ozone/platform/wayland/wayland_pointer.h"
+
+namespace ui {
+
+WaylandCursor::WaylandCursor()
+    : sh_memory_(new base::SharedMemory()) {}
+
+void WaylandCursor::Init(wl_pointer* pointer, WaylandConnection* connection) {
+  if (input_pointer_ == pointer)
+    return;
+
+  DCHECK(connection);
+  if (input_pointer_)
+    wl_pointer_destroy(input_pointer_);
+
+  input_pointer_ = pointer;
+
+  shm_ = connection->shm();
+  pointer_surface_ = wl_compositor_create_surface(connection->compositor());
+}
+
+WaylandCursor::~WaylandCursor() {
+  wl_surface_destroy(pointer_surface_);
+  if (buffer_)
+    wl_buffer_destroy(buffer_);
+
+  if (sh_memory_->handle().GetHandle()) {
+    sh_memory_->Unmap();
+    sh_memory_->Close();
+  }
+  delete sh_memory_;
+}
+
+void WaylandCursor::UpdateBitmap(const std::vector<SkBitmap>& cursor_image,
+                                 const gfx::Point& location,
+                                 uint32_t serial) {
+  if (!input_pointer_)
+    return;
+
+  if (!cursor_image.size()) {
+    HideCursor(serial);
+    return;
+  }
+
+  const SkBitmap& image = cursor_image[0];
+  int width = image.width();
+  int height = image.height();
+  if (!width || !height) {
+    HideCursor(serial);
+    return;
+  }
+
+  if (!CreateSHMBuffer(width, height)) {
+    LOG(ERROR) << "Failed to create SHM buffer for Cursor Bitmap.";
+    wl_pointer_set_cursor(input_pointer_, serial, nullptr, 0, 0);
+    return;
+  }
+
+  // The |bitmap| contains ARGB image, so just copy it.
+  memcpy(sh_memory_->memory(), image.getPixels(), width_ * height_ * 4);
+
+  wl_pointer_set_cursor(input_pointer_, serial, pointer_surface_, location.x(),
+                        location.y());
+  wl_surface_attach(pointer_surface_, buffer_, 0, 0);
+  wl_surface_damage(pointer_surface_, 0, 0, width_, height_);
+  wl_surface_commit(pointer_surface_);
+}
+
+bool WaylandCursor::CreateSHMBuffer(int width, int height) {
+  if (width == width_ && height == height_)
+    return true;
+
+  struct wl_shm_pool* pool;
+  int size, stride;
+
+  width_ = width;
+  height_ = height;
+  stride = width_ * 4;
+  SkImageInfo info = SkImageInfo::MakeN32Premul(width_, height_);
+  size = info.getSafeSize(stride);
+
+  if (sh_memory_->handle().GetHandle()) {
+    sh_memory_->Unmap();
+    sh_memory_->Close();
+  }
+
+  if (!sh_memory_->CreateAndMapAnonymous(size)) {
+    LOG(ERROR) << "Create and mmap failed.";
+    return false;
+  }
+
+  pool = wl_shm_create_pool(shm_, sh_memory_->handle().GetHandle(), size);
+  buffer_ = wl_shm_pool_create_buffer(pool, 0, width_, height_, stride,
+                                      WL_SHM_FORMAT_ARGB8888);
+  wl_shm_pool_destroy(pool);
+  return true;
+}
+
+void WaylandCursor::HideCursor(uint32_t serial) {
+  width_ = 0;
+  height_ = 0;
+  wl_pointer_set_cursor(input_pointer_, serial, nullptr, 0, 0);
+
+  if (buffer_) {
+    wl_buffer_destroy(buffer_);
+    buffer_ = nullptr;
+  }
+
+  if (sh_memory_->handle().GetHandle()) {
+    sh_memory_->Unmap();
+    sh_memory_->Close();
+  }
+}
+
+}  // namespace ui

--- a/ui/ozone/platform/wayland/wayland_cursor.h
+++ b/ui/ozone/platform/wayland/wayland_cursor.h
@@ -1,0 +1,58 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_CURSOR_H_
+#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_CURSOR_H_
+
+#include <wayland-client.h>
+#include <vector>
+
+#include "base/macros.h"
+#include "third_party/skia/include/core/SkBitmap.h"
+
+namespace base {
+class SharedMemory;
+}
+
+namespace gfx {
+class Point;
+}
+
+namespace ui {
+
+class WaylandConnection;
+
+class WaylandCursor {
+ public:
+  WaylandCursor();
+  ~WaylandCursor();
+
+  void Init(wl_pointer* pointer, WaylandConnection* connection);
+
+  void UpdateBitmap(const std::vector<SkBitmap>& bitmaps,
+                    const gfx::Point& location,
+                    uint32_t serial);
+
+  wl_pointer* GetInputPointer() const { return input_pointer_; }
+
+ private:
+  bool CreateSHMBuffer(int width, int height);
+  void HideCursor(uint32_t serial);
+
+  struct wl_pointer* input_pointer_ = nullptr;
+  struct wl_surface* pointer_surface_ = nullptr;
+  struct wl_buffer* buffer_ = nullptr;
+  struct wl_shm* shm_ = nullptr;
+
+  base::SharedMemory* sh_memory_ = nullptr;
+
+  int width_ = 0;
+  int height_ = 0;
+
+  DISALLOW_COPY_AND_ASSIGN(WaylandCursor);
+};
+
+}  // namespace ui
+
+#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_CURSOR_H_

--- a/ui/ozone/platform/wayland/wayland_pointer.cc
+++ b/ui/ozone/platform/wayland/wayland_pointer.cc
@@ -24,6 +24,8 @@ WaylandPointer::WaylandPointer(wl_pointer* pointer,
   };
 
   wl_pointer_add_listener(obj_.get(), &listener, this);
+
+  cursor_.reset(new WaylandCursor);
 }
 
 WaylandPointer::~WaylandPointer() {}

--- a/ui/ozone/platform/wayland/wayland_pointer.h
+++ b/ui/ozone/platform/wayland/wayland_pointer.h
@@ -7,6 +7,7 @@
 
 #include "ui/events/ozone/evdev/event_dispatch_callback.h"
 #include "ui/gfx/geometry/point_f.h"
+#include "ui/ozone/platform/wayland/wayland_cursor.h"
 #include "ui/ozone/platform/wayland/wayland_object.h"
 
 namespace ui {
@@ -20,7 +21,10 @@ class WaylandPointer {
 
   void set_connection(WaylandConnection* connection) {
     connection_ = connection;
+    cursor_->Init(obj_.get(), connection_);
   }
+
+  WaylandCursor* cursor() { return cursor_.get(); }
 
  private:
   // wl_pointer_listener
@@ -54,6 +58,7 @@ class WaylandPointer {
   void SetSerial(uint32_t serial);
 
   WaylandConnection* connection_ = nullptr;
+  std::unique_ptr<WaylandCursor> cursor_;
   wl::Object<wl_pointer> obj_;
   EventDispatchCallback callback_;
   gfx::PointF location_;

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -8,6 +8,7 @@
 
 #include "base/bind.h"
 #include "base/memory/ptr_util.h"
+#include "ui/base/cursor/ozone/bitmap_cursor_factory_ozone.h"
 #include "ui/base/hit_test.h"
 #include "ui/events/event.h"
 #include "ui/events/ozone/events_ozone.h"
@@ -297,7 +298,18 @@ void WaylandWindow::Restore() {
 }
 
 void WaylandWindow::SetCursor(PlatformCursor cursor) {
-  NOTIMPLEMENTED();
+  scoped_refptr<BitmapCursorOzone> bitmap =
+      BitmapCursorFactoryOzone::GetBitmapCursor(cursor);
+  if (bitmap_ == bitmap)
+    return;
+
+  bitmap_ = bitmap;
+
+  if (bitmap_) {
+    connection_->SetCursorBitmap(bitmap_->bitmaps(), bitmap_->hotspot());
+  } else {
+    connection_->SetCursorBitmap(std::vector<SkBitmap>(), gfx::Point());
+  }
 }
 
 void WaylandWindow::MoveCursorTo(const gfx::Point& location) {

--- a/ui/ozone/platform/wayland/wayland_window.h
+++ b/ui/ozone/platform/wayland/wayland_window.h
@@ -5,6 +5,7 @@
 #ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_WINDOW_H_
 #define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_WINDOW_H_
 
+#include "base/memory/ref_counted.h"
 #include "ui/events/platform/platform_event_dispatcher.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/native_widget_types.h"
@@ -13,6 +14,7 @@
 
 namespace ui {
 
+class BitmapCursorOzone;
 class PlatformWindowDelegate;
 class WaylandConnection;
 class XDGPopupWrapper;
@@ -137,6 +139,9 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
   // know anything about the version.
   std::unique_ptr<XDGSurfaceWrapper> xdg_surface_;
   std::unique_ptr<XDGPopupWrapper> xdg_popup_;
+
+  // The current cursor bitmap (immutable).
+  scoped_refptr<BitmapCursorOzone> bitmap_;
 
   gfx::Rect bounds_;
   gfx::Rect pending_bounds_;


### PR DESCRIPTION
Patch makes use of the existing BitmapCursorFactoryOzone implementation
to provide an initial cursor support in Ozone/Wayland.

There are some follow ups planned, including making sure RefCountedThreadSafe
is needed, and the use of "custom" cursors, like chromeos.

Note: wayland_cursor.cc/h are based on Intel's Ozone/Wayland implmentation.

Issue #194.