### PR TITLE
Fix maximize/restore glitch of OpaqueBrowserFrameView in Weston.

### DIFF
--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -395,12 +395,9 @@ void Display::OnWindowStateChanged(ui::mojom::ShowState new_state) {
   ServerWindow* server_window =
       display_root->window_manager_state()->GetWindowManagerRootForDisplayRoot(
           root_window());
-  ClientWindowId window_id;
-  // We are calling WindowTreeClient directly from here for the sake not
-  // changing WindowTree for such a simple call, adding less code as possible
-  // downstream.
-  if (window_tree && window_tree->IsWindowKnown(server_window, &window_id))
-    window_tree->client()->OnWindowStateChanged(window_id.id, new_state);
+
+  if (window_tree)
+    window_tree->OnWindowStateChanged(server_window, new_state);
 }
 
 OzonePlatform* Display::GetOzonePlatform() {

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -1200,6 +1200,15 @@ void WindowTree::OnRequestClose(ServerWindow* target_window) {
     client()->RequestClose(ClientWindowIdToTransportId(client_window_id));
 }
 
+void WindowTree::OnWindowStateChanged(ServerWindow* target_window,
+                                      ui::mojom::ShowState new_state) {
+  DCHECK(window_server_->IsInExternalWindowMode());
+  ClientWindowId client_window_id;
+  if (IsWindowKnown(target_window, &client_window_id))
+    client()->OnWindowStateChanged(
+        ClientWindowIdToTransportId(client_window_id), new_state);
+}
+
 bool WindowTree::ShouldRouteToWindowManager(const ServerWindow* window) const {
   if (window_manager_state_)
     return false;  // We are the window manager, don't route to ourself.

--- a/services/ui/ws/window_tree.h
+++ b/services/ui/ws/window_tree.h
@@ -322,6 +322,12 @@ class WindowTree : public mojom::WindowTree,
   // certain events.
   void OnRequestClose(ServerWindow* target_window);
 
+  // In external window mode, ozone backends can ask client to change states of
+  // windows. This call propagates the new state further to WindowTreeClient and
+  // aura windows.
+  void OnWindowStateChanged(ServerWindow* target_window,
+                            ui::mojom::ShowState new_state);
+
  private:
   friend class test::WindowTreeTestApi;
 

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -264,6 +264,7 @@ void WaylandWindow::Maximize() {
   if (IsFullScreen())
     ToggleFullscreen();
 
+  previous_bounds_in_pixels_ = bounds_;
   xdg_surface_->SetMaximized();
   connection_->ScheduleFlush();
 }
@@ -280,12 +281,12 @@ void WaylandWindow::Minimize() {
   xdg_surface_->SetMinimized();
   connection_->ScheduleFlush();
   is_minimized_ = true;
+  was_minimized_ = false;
 }
 
 void WaylandWindow::Restore() {
   if (xdg_popup_ || !xdg_surface_)
     return;
-
   // Unfullscreen the window if it is fullscreen.
   if (IsFullScreen())
     ToggleFullscreen();
@@ -294,6 +295,8 @@ void WaylandWindow::Restore() {
     xdg_surface_->UnSetMaximized();
     connection_->ScheduleFlush();
   }
+  if (is_minimized_)
+    was_minimized_ = is_minimized_;
   is_minimized_ = false;
 }
 
@@ -379,25 +382,60 @@ void WaylandWindow::ConvertEventLocationToCurrentWindowLocation(
 void WaylandWindow::HandleSurfaceConfigure(int32_t width,
                                            int32_t height,
                                            bool is_maximized,
-                                           bool is_fullscreen) {
+                                           bool is_fullscreen,
+                                           bool is_activated) {
+  // Handle restore state from wayland side: if the state was minimized and
+  // a user restore windows from panel tray, the only way to know that the
+  // window is restored is by checking if the window has been minimized and
+  // |is_activated| is set to true.
+  if (is_minimized_ && is_activated) {
+    is_minimized_ = false;
+    was_minimized_ = true;
+  }
+
+  bool was_maximized = is_maximized_;
+  ResetWindowStates();
+  is_maximized_ = is_maximized;
+  is_fullscreen_ = is_fullscreen;
+
   // Width or height set 0 means that we should decide on width and height by
   // ourselves, but we don't want to set to anything else. Use previous size.
   if (width == 0 || height == 0) {
     width = GetBounds().width();
     height = GetBounds().height();
+    if (was_maximized) {
+      // In weston, unmaximize asks client to decide on bounds. It's ok if
+      // the state has been changed from normal to maximize and back to normal.
+      // In that case, previous bounds are known. But if the browser has been
+      // started in maximized mode, unmaximize bounds are unknown or better to
+      // say those correspond to the maximized state bounds. A client must
+      // decide which bounds to use. At this point, use half of the maximized
+      // bounds.
+      width = previous_bounds_in_pixels_.width();
+      height = previous_bounds_in_pixels_.height();
+      if (previous_bounds_in_pixels_ == GetBounds()) {
+        // TODO(msisov, tonikitoo): fix this hack.
+        width = width / 2;
+        height = height / 2;
+      }
+    }
   }
-
-  ResetWindowStates();
-  is_maximized_ = is_maximized;
-  is_fullscreen_ = is_fullscreen;
 
   ui::PlatformWindowState state =
       ui::PlatformWindowState::PLATFORM_WINDOW_STATE_NORMAL;
-  if (IsMaximized())
-    state = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MAXIMIZED;
-  if (IsFullScreen())
-    state = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_FULLSCREEN;
-  delegate_->OnWindowStateChanged(state);
+  if (is_minimized_ != was_minimized_) {
+    if (is_minimized_) {
+      state = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MINIMIZED;
+    } else {
+      was_minimized_ = false;
+      // When the window is recovered from minimized state, set state to the
+      // previous state.
+      state = IsMaximized()
+                  ? ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MAXIMIZED
+                  : ui::PlatformWindowState::PLATFORM_WINDOW_STATE_NORMAL;
+    }
+    delegate_->OnWindowStateChanged(state);
+  }
 
   // Rather than call SetBounds here for every configure event, just save the
   // most recent bounds, and have WaylandConnection call ApplyPendingBounds

--- a/ui/ozone/platform/wayland/wayland_window.h
+++ b/ui/ozone/platform/wayland/wayland_window.h
@@ -94,7 +94,8 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
   void HandleSurfaceConfigure(int32_t widht,
                               int32_t height,
                               bool is_maximized,
-                              bool is_fullscreen);
+                              bool is_fullscreen,
+                              bool is_activated);
 
   void OnCloseRequest();
 
@@ -144,12 +145,14 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
   scoped_refptr<BitmapCursorOzone> bitmap_;
 
   gfx::Rect bounds_;
+  gfx::Rect previous_bounds_in_pixels_;
   gfx::Rect pending_bounds_;
   bool has_pointer_focus_ = false;
   bool has_keyboard_focus_ = false;
   bool has_touch_focus_ = false;
 
   bool is_minimized_ = false;
+  bool was_minimized_ = false;
   bool is_maximized_ = false;
   bool is_fullscreen_ = false;
 

--- a/ui/ozone/platform/wayland/xdg_surface_wrapper_v5.cc
+++ b/ui/ozone/platform/wayland/xdg_surface_wrapper_v5.cc
@@ -131,6 +131,7 @@ void XDGSurfaceWrapperV5::Configure(void* data,
 
   bool is_maximized = false;
   bool is_fullscreen = false;
+  bool is_activated = false;
 
   // wl_array_for_each has a bug in upstream. It tries to assign void* to
   // uint32_t *, which is not allowed in C++. Explicit cast should be
@@ -149,6 +150,9 @@ void XDGSurfaceWrapperV5::Configure(void* data,
       case (XDG_SURFACE_STATE_FULLSCREEN):
         is_fullscreen = true;
         break;
+      case (XDG_SURFACE_STATE_ACTIVATED):
+        is_activated = true;
+        break;
       default:
         break;
     }
@@ -156,7 +160,7 @@ void XDGSurfaceWrapperV5::Configure(void* data,
 
   surface->pending_configure_serial_ = serial;
   surface->wayland_window_->HandleSurfaceConfigure(width, height, is_maximized,
-                                                   is_fullscreen);
+                                                   is_fullscreen, is_activated);
 }
 
 // static

--- a/ui/ozone/platform/wayland/xdg_surface_wrapper_v6.cc
+++ b/ui/ozone/platform/wayland/xdg_surface_wrapper_v6.cc
@@ -186,6 +186,7 @@ void XDGSurfaceWrapperV6::ConfigureTopLevel(
 
   bool is_maximized = false;
   bool is_fullscreen = false;
+  bool is_activated = false;
 
   // wl_array_for_each has a bug in upstream. It tries to assign void* to
   // uint32_t *, which is not allowed in C++. Explicit cast should be
@@ -204,13 +205,16 @@ void XDGSurfaceWrapperV6::ConfigureTopLevel(
       case (ZXDG_TOPLEVEL_V6_STATE_FULLSCREEN):
         is_fullscreen = true;
         break;
+      case (ZXDG_TOPLEVEL_V6_STATE_ACTIVATED):
+        is_activated = true;
+        break;
       default:
         break;
     }
   }
 
   surface->wayland_window_->HandleSurfaceConfigure(width, height, is_maximized,
-                                                   is_fullscreen);
+                                                   is_fullscreen, is_activated);
 }
 
 // static


### PR DESCRIPTION
This patch avoids spamming aura with states unless previous state
has been "minimized" state and makes the wayland client to decide
what bounds to use and send these back to aura, which
calls relayout and updates OpaqueBrowserFrameView.