### PR TITLE
Crash when right-clicking on the window decoration area

### DIFF
--- a/chrome/browser/ui/browser_command_controller.cc
+++ b/chrome/browser/ui/browser_command_controller.cc
@@ -751,7 +751,7 @@ void BrowserCommandController::InitCommandState() {
   command_updater_.UpdateCommandEnabled(IDC_VISIT_DESKTOP_OF_LRU_USER_2, true);
   command_updater_.UpdateCommandEnabled(IDC_VISIT_DESKTOP_OF_LRU_USER_3, true);
 #endif
-#if defined(OS_LINUX) && !defined(OS_CHROMEOS)
+#if defined(OS_LINUX) && !defined(OS_CHROMEOS) && !defined(USE_OZONE)
   command_updater_.UpdateCommandEnabled(IDC_USE_SYSTEM_TITLE_BAR, true);
 #endif
 

--- a/chrome/browser/ui/browser_view_prefs.cc
+++ b/chrome/browser/ui/browser_view_prefs.cc
@@ -32,10 +32,14 @@ void RegisterBrowserViewLocalPrefs(PrefRegistrySimple* registry) {
 
 void RegisterBrowserViewProfilePrefs(
     user_prefs::PrefRegistrySyncable* registry) {
+#if defined(OS_LINUX) && !defined(OS_CHROMEOS)
+  bool custom_frame_pref_default = true;
 #if defined(USE_X11)
+  custom_frame_pref_default = ui::GetCustomFramePrefDefault();
+#endif  // USE_X11
   registry->RegisterBooleanPref(prefs::kUseCustomChromeFrame,
-                                ui::GetCustomFramePrefDefault());
-#endif
+                                custom_frame_pref_default);
+#endif  // OS_LINUX && !OS_CHROMEOS
 
   registry->RegisterIntegerPref(
       prefs::kBackShortcutBubbleShownCount, 0,


### PR DESCRIPTION
On chrome/x11, right-clicking on the window decoration bar toggles a
context menu whose one of the menu items allows switching between
builtin and system/native window decorations.

Today, chrome/mus crashes when building the menu because it tried to
read a preference only registered in use_x11: kUseCustomChromeFrame.

So this CL does two things:

- registers the preference [1] in case of [os_linux && use_ozone && !os_chromeos].

- since chrome/mus does not support using system's window decoration, forbids
this menu item [2] altogether, making it unclickable.

Alternatively, we could simply not add the menu item in case of chrome/mus,
(see SystemMenuModelBuilder::BuildSystemMenuForBrowserWindow)
but I feel it would diverge more from regular chrome/x11

[1] kUseCustomChromeFrame
[2] IDC_USE_SYSTEM_TITLE_BAR

TBR=msisov

Issue #225