### PR TITLE
[ozone/wayland] Use ui::EventTimeForNow for pointer and keyboard events

### DIFF
--- a/ui/ozone/platform/wayland/wayland_keyboard.cc
+++ b/ui/ozone/platform/wayland/wayland_keyboard.cc
@@ -9,6 +9,7 @@
 
 #include "base/files/scoped_file.h"
 #include "ui/base/ui_features.h"
+#include "ui/events/base_event_utils.h"
 #include "ui/events/event.h"
 #include "ui/events/keycodes/dom/dom_code.h"
 #include "ui/events/keycodes/dom/keycode_converter.h"
@@ -109,7 +110,7 @@ void WaylandKeyboard::Key(void* data,
   ui::KeyEvent event(
       down ? ET_KEY_PRESSED : ET_KEY_RELEASED, key_code, dom_code,
       keyboard->modifiers_, dom_key,
-      base::TimeTicks() + base::TimeDelta::FromMilliseconds(time));
+      EventTimeForNow());
   event.set_source_device_id(keyboard->obj_.id());
   keyboard->callback_.Run(&event);
 }

--- a/ui/ozone/platform/wayland/wayland_pointer.cc
+++ b/ui/ozone/platform/wayland/wayland_pointer.cc
@@ -7,6 +7,7 @@
 #include <linux/input.h>
 #include <wayland-client.h>
 
+#include "ui/events/base_event_utils.h"
 #include "ui/events/event.h"
 #include "ui/ozone/platform/wayland/wayland_connection.h"
 #include "ui/ozone/platform/wayland/wayland_window.h"
@@ -63,7 +64,7 @@ void WaylandPointer::Motion(void* data,
   pointer->location_.SetPoint(wl_fixed_to_double(surface_x),
                               wl_fixed_to_double(surface_y));
   MouseEvent event(ET_MOUSE_MOVED, gfx::Point(), gfx::Point(),
-                   base::TimeTicks() + base::TimeDelta::FromMilliseconds(time),
+                   EventTimeForNow(),
                    pointer->flags_, 0);
   event.set_location_f(pointer->location_);
   event.set_root_location_f(pointer->location_);
@@ -111,7 +112,7 @@ void WaylandPointer::Button(void* data,
     pointer->flags_ &= ~flag;
   }
   MouseEvent event(type, gfx::Point(), gfx::Point(),
-                   base::TimeTicks() + base::TimeDelta::FromMilliseconds(time),
+                   EventTimeForNow(),
                    flags, flag);
   event.set_location_f(pointer->location_);
   event.set_root_location_f(pointer->location_);
@@ -142,7 +143,7 @@ void WaylandPointer::Axis(void* data,
     return;
   MouseWheelEvent event(
       offset, gfx::Point(), gfx::Point(),
-      base::TimeTicks() + base::TimeDelta::FromMilliseconds(time),
+      EventTimeForNow(),
       pointer->flags_, 0);
   event.set_location_f(pointer->location_);
   event.set_root_location_f(pointer->location_);


### PR DESCRIPTION
This fixes the following wheel scroll event crash on Weston:

FATAL:latency_tracker.cc(196)] Check failed:
gpu_swap_begin_component.last_event_time >=
original_component.first_event_time (42321552294 bogo-microseconds vs.
3419125241000 bogo-microseconds)

It also pairs us up with Intel's Ozone/Wayland implementation.

TBR=msisov
Issue #179

PS: touch events are left off for now (so that msisov@ can followup) given that I do
not have a way to test them at the moment. 