### PR TITLE
Fix "Regression: menus are not hidden"

### DIFF
--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -381,9 +381,8 @@ void Display::OnCloseRequest() {
   ServerWindow* server_window =
       display_root->window_manager_state()->GetWindowManagerRootForDisplayRoot(
           root_window());
-  ClientWindowId window_id;
-  if (window_tree && window_tree->IsWindowKnown(server_window, &window_id))
-    window_tree->client()->RequestClose(window_id.id);
+  if (window_tree)
+    window_tree->OnRequestClose(server_window);
 }
 
 void Display::OnWindowStateChanged(ui::mojom::ShowState new_state) {

--- a/services/ui/ws/platform_display_default.cc
+++ b/services/ui/ws/platform_display_default.cc
@@ -318,11 +318,11 @@ void PlatformDisplayDefault::DispatchEvent(ui::Event* event) {
 }
 
 void PlatformDisplayDefault::OnCloseRequest() {
-#if !defined(USE_OZONE) || defined(CHROMEOS)
+#if defined(USE_OZONE) && defined(OS_LINUX) && !defined(OS_CHROMEOS)
+  delegate_->OnCloseRequest();
+#else
   const int64_t display_id = delegate_->GetDisplay().id();
   display::ScreenManager::GetInstance()->RequestCloseDisplay(display_id);
-#else
-  delegate_->OnCloseRequest();
 #endif
 }
 

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -1193,6 +1193,13 @@ void WindowTree::AddExternalModeWindowManagerState(
   external_mode_wm_states_.insert(std::move(window_manager_state));
 }
 
+void WindowTree::OnRequestClose(ServerWindow* target_window) {
+  DCHECK(window_server_->IsInExternalWindowMode());
+  ClientWindowId client_window_id;
+  if (IsWindowKnown(target_window, &client_window_id))
+    client()->RequestClose(ClientWindowIdToTransportId(client_window_id));
+}
+
 bool WindowTree::ShouldRouteToWindowManager(const ServerWindow* window) const {
   if (window_manager_state_)
     return false;  // We are the window manager, don't route to ourself.

--- a/services/ui/ws/window_tree.h
+++ b/services/ui/ws/window_tree.h
@@ -318,6 +318,10 @@ class WindowTree : public mojom::WindowTree,
   void AddExternalModeWindowManagerState(
       std::unique_ptr<WindowManagerState> window_manager_state);
 
+  // In external window mode, ozone backends can ask client to close a window on
+  // certain events.
+  void OnRequestClose(ServerWindow* target_window);
+
  private:
   friend class test::WindowTreeTestApi;
 

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -336,6 +336,10 @@ bool WaylandWindow::CanDispatchEvent(const PlatformEvent& native_event) {
   if (HasCapture())
     return true;
 
+  // If another window has capture, return early before checking focus.
+  if (g_current_capture_)
+    return false;
+
   Event* event = static_cast<Event*>(native_event);
   if (event->IsMouseEvent())
     return has_pointer_focus_;


### PR DESCRIPTION
This PR consists of two patches: fixing WaylandWindow::CanDispatchEvent and
fixing Display::OnCloseRequest