### PR TITLE
Propagate Activation State to Aura.

### DIFF
--- a/content/renderer/mus/renderer_window_tree_client.cc
+++ b/content/renderer/mus/renderer_window_tree_client.cc
@@ -271,6 +271,9 @@ void RendererWindowTreeClient::OnWindowStateChanged(
     uint32_t window_id,
     ui::mojom::ShowState state) {}
 
+void RendererWindowTreeClient::OnActivationChanged(uint32_t window_id,
+                                                   bool is_active) {}
+
 void RendererWindowTreeClient::RequestClose(uint32_t window_id) {}
 
 void RendererWindowTreeClient::GetWindowManager(

--- a/content/renderer/mus/renderer_window_tree_client.h
+++ b/content/renderer/mus/renderer_window_tree_client.h
@@ -157,6 +157,7 @@ class RendererWindowTreeClient : public ui::mojom::WindowTreeClient {
   void OnChangeCompleted(uint32_t change_id, bool success) override;
   void OnWindowStateChanged(uint32_t window_id,
                             ui::mojom::ShowState state) override;
+  void OnActivationChanged(uint32_t window_id, bool is_active) override;
   void RequestClose(uint32_t window_id) override;
   void GetWindowManager(
       mojo::AssociatedInterfaceRequest<ui::mojom::WindowManager> internal)

--- a/services/ui/public/interfaces/window_tree.mojom
+++ b/services/ui/public/interfaces/window_tree.mojom
@@ -549,6 +549,10 @@ interface WindowTreeClient {
   // The WindowManager calls back after the client set proprties to minimize, maximize or restore
   // the window or after the window is restored back from minimized state by clicking on a tray.
   OnWindowStateChanged(uint32 window_id, ShowState state);
+  
+  // The WindowManager is requesting the specified window to change activation
+  // state.
+  OnActivationChanged(uint32 window_id, bool is_active);
 
   // The WindowManager is requesting the specified window to close. If the
   // client allows the change it should delete the window.

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -400,6 +400,20 @@ void Display::OnWindowStateChanged(ui::mojom::ShowState new_state) {
     window_tree->OnWindowStateChanged(server_window, new_state);
 }
 
+void Display::OnActivationChanged(bool is_active) {
+  if (!window_server_->IsInExternalWindowMode())
+    return;
+
+  WindowTree* window_tree = window_server_->GetTreeForExternalWindowMode();
+  if (!window_tree)
+    return;
+
+  WindowManagerDisplayRoot* display_root =
+      window_manager_display_root_map_.begin()->second;
+  ServerWindow* server_window = display_root->GetClientVisibleRoot();
+  window_tree->OnActivationChanged(server_window, is_active);
+}
+
 OzonePlatform* Display::GetOzonePlatform() {
 #if defined(USE_OZONE)
   return OzonePlatform::GetInstance();

--- a/services/ui/ws/display.h
+++ b/services/ui/ws/display.h
@@ -201,6 +201,7 @@ class Display : public PlatformDisplayDelegate,
   void OnBoundsChanged(const gfx::Rect& new_bounds) override;
   void OnCloseRequest() override;
   void OnWindowStateChanged(ui::mojom::ShowState new_state) override;
+  void OnActivationChanged(bool is_active) override;
 
   OzonePlatform* GetOzonePlatform() override;
 

--- a/services/ui/ws/platform_display_default.cc
+++ b/services/ui/ws/platform_display_default.cc
@@ -394,7 +394,9 @@ void PlatformDisplayDefault::OnAcceleratedWidgetDestroyed() {
   NOTREACHED();
 }
 
-void PlatformDisplayDefault::OnActivationChanged(bool active) {}
+void PlatformDisplayDefault::OnActivationChanged(bool active) {
+  delegate_->OnActivationChanged(active);
+}
 
 void PlatformDisplayDefault::GetParentWindowAcceleratedWidget(
     gfx::AcceleratedWidget* widget) {

--- a/services/ui/ws/platform_display_delegate.h
+++ b/services/ui/ws/platform_display_delegate.h
@@ -52,6 +52,10 @@ class PlatformDisplayDelegate {
   // for non-Ozone platforms.
   virtual OzonePlatform* GetOzonePlatform() = 0;
 
+  // Called when the activation state of the window has been changed. For
+  // example, click on a different window or between windows.
+  virtual void OnActivationChanged(bool is_active) = 0;
+
  protected:
   virtual ~PlatformDisplayDelegate() {}
 };

--- a/services/ui/ws/test_utils.cc
+++ b/services/ui/ws/test_utils.cc
@@ -466,6 +466,9 @@ void TestWindowTreeClient::OnChangeCompleted(uint32_t change_id, bool success) {
 void TestWindowTreeClient::OnWindowStateChanged(uint32_t window_id,
                                                 ::ui::mojom::ShowState state) {}
 
+void TestWindowTreeClient::OnActivationChanged(uint32_t window_id,
+                                               bool is_active) {}
+
 void TestWindowTreeClient::RequestClose(uint32_t window_id) {}
 
 void TestWindowTreeClient::GetWindowManager(

--- a/services/ui/ws/test_utils.h
+++ b/services/ui/ws/test_utils.h
@@ -561,6 +561,7 @@ class TestWindowTreeClient : public ui::mojom::WindowTreeClient {
   void OnChangeCompleted(uint32_t change_id, bool success) override;
   void OnWindowStateChanged(uint32_t window_id,
                             ::ui::mojom::ShowState state) override;
+  void OnActivationChanged(uint32_t window_id, bool is_active) override;
   void RequestClose(uint32_t window_id) override;
   void GetWindowManager(
       mojo::AssociatedInterfaceRequest<mojom::WindowManager> internal) override;

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -1218,6 +1218,15 @@ void WindowTree::OnWindowStateChanged(ServerWindow* target_window,
         ClientWindowIdToTransportId(client_window_id), new_state);
 }
 
+void WindowTree::OnActivationChanged(ServerWindow* target_window,
+                                     bool is_active) {
+  DCHECK(window_server_->IsInExternalWindowMode());
+  ClientWindowId client_window_id;
+  if (IsWindowKnown(target_window, &client_window_id))
+    client()->OnActivationChanged(ClientWindowIdToTransportId(client_window_id),
+                                  is_active);
+}
+
 bool WindowTree::ShouldRouteToWindowManager(const ServerWindow* window) const {
   if (window_manager_state_)
     return false;  // We are the window manager, don't route to ourself.

--- a/services/ui/ws/window_tree.h
+++ b/services/ui/ws/window_tree.h
@@ -333,6 +333,11 @@ class WindowTree : public mojom::WindowTree,
   void OnWindowStateChanged(ServerWindow* target_window,
                             ui::mojom::ShowState new_state);
 
+  // In external window mode, ozone backends can ask client to change the
+  // activation state of the windows, which results in changing focus in focus
+  // controller.
+  void OnActivationChanged(ServerWindow* target_window, bool is_active);
+
  private:
   friend class test::WindowTreeTestApi;
 

--- a/services/ui/ws/window_tree_client_unittest.cc
+++ b/services/ui/ws/window_tree_client_unittest.cc
@@ -275,6 +275,8 @@ class TestWindowTreeClient : public mojom::WindowTreeClient,
   void OnWindowStateChanged(uint32_t window_id,
                             ::ui::mojom::ShowState state) override {}
 
+  void OnActivationChanged(uint32_t window_id, bool is_active) override {}
+
   // WindowTreeClient:
   void OnEmbed(
       WindowDataPtr root,

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -29,6 +29,7 @@
 #include "services/ui/public/interfaces/window_manager_window_tree_factory.mojom.h"
 #include "ui/aura/client/aura_constants.h"
 #include "ui/aura/client/drag_drop_client.h"
+#include "ui/aura/client/focus_client.h"
 #include "ui/aura/client/transient_window_client.h"
 #include "ui/aura/env.h"
 #include "ui/aura/env_input_state_controller.h"
@@ -1710,6 +1711,25 @@ void WindowTreeClient::OnWindowStateChanged(uint32_t window_id,
   }
 
   aura_window->SetProperty(aura::client::kShowStateKey, show_state);
+}
+
+void WindowTreeClient::OnActivationChanged(uint32_t window_id, bool is_active) {
+  DCHECK(in_external_window_mode_);
+  WindowMus* window = GetWindowByServerId(window_id);
+  // This call goes from the host window manager once a window gains or looses
+  // focus and is being activated or deactivated. Thus, it must be a root
+  // window, but not other children.
+  if (!window || !IsRoot(window))
+    return;
+
+  client::FocusClient* focus_client = nullptr;
+  aura::Window* client_window = nullptr;
+  if (is_active) {
+    client_window = window->GetWindow();
+    focus_client = aura::client::GetFocusClient(client_window);
+  }
+
+  focus_synchronizer_->SetActiveFocusClient(focus_client, client_window);
 }
 
 void WindowTreeClient::GetWindowManager(

--- a/ui/aura/mus/window_tree_client.h
+++ b/ui/aura/mus/window_tree_client.h
@@ -448,6 +448,7 @@ class AURA_EXPORT WindowTreeClient
   void OnChangeCompleted(uint32_t change_id, bool success) override;
   void OnWindowStateChanged(uint32_t window_id,
                             ui::mojom::ShowState state) override;
+  void OnActivationChanged(uint32_t window_id, bool is_active) override;
   void RequestClose(uint32_t window_id) override;
   void SetBlockingContainers(
       const std::vector<BlockingContainers>& all_blocking_containers) override;

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -439,6 +439,11 @@ void WaylandWindow::HandleSurfaceConfigure(int32_t width,
     delegate_->OnWindowStateChanged(state);
   }
 
+  was_active_ = is_active_;
+  is_active_ = is_activated;
+  if (was_active_ != is_active_)
+    delegate_->OnActivationChanged(is_active_);
+
   // Rather than call SetBounds here for every configure event, just save the
   // most recent bounds, and have WaylandConnection call ApplyPendingBounds
   // when it has finished processing events. We may get many configure events

--- a/ui/ozone/platform/wayland/wayland_window.h
+++ b/ui/ozone/platform/wayland/wayland_window.h
@@ -156,6 +156,9 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
   bool is_maximized_ = false;
   bool is_fullscreen_ = false;
 
+  bool was_active_ = false;
+  bool is_active_ = false;
+
   DISALLOW_COPY_AND_ASSIGN(WaylandWindow);
 };
 

--- a/ui/platform_window/platform_window_delegate.h
+++ b/ui/platform_window/platform_window_delegate.h
@@ -59,6 +59,8 @@ class PlatformWindowDelegate {
   // a new widget is made available through OnAcceleratedWidgetAvailable().
   virtual void OnAcceleratedWidgetDestroyed() = 0;
 
+  // Notifies the delegate that the activation state of the window has been
+  // changed.
   virtual void OnActivationChanged(bool active) = 0;
 
   // TODO(tonikitoo,msisov): Adding this method with an out parameter so that

--- a/ui/platform_window/x11/x11_window_base.cc
+++ b/ui/platform_window/x11/x11_window_base.cc
@@ -25,6 +25,9 @@
 #include "ui/gfx/x/x11_atom_cache.h"
 #include "ui/platform_window/platform_window_delegate.h"
 
+#include "ui/base/x/x11_pointer_grab.h"
+#include "ui/events/devices/x11/touch_factory_x11.h"
+
 namespace ui {
 
 namespace {
@@ -228,6 +231,8 @@ void X11WindowBase::Create() {
   ui::SetUseOSWindowFrame(xwindow_, false);
 #endif
 
+  has_window_focus_ = true;
+  window_mapped_in_server_ = true;
   // TODO(sky): provide real scale factor.
   delegate_->OnAcceleratedWidgetAvailable(xwindow_, 1.f);
 }
@@ -315,9 +320,14 @@ void X11WindowBase::SetTitle(const base::string16& title) {
   }
 }
 
-void X11WindowBase::SetCapture() {}
+void X11WindowBase::SetCapture() {
+  has_pointer_grab_ |= !ui::GrabPointer(xwindow_, true, None);
+}
 
-void X11WindowBase::ReleaseCapture() {}
+void X11WindowBase::ReleaseCapture() {
+  ui::UngrabPointer();
+  has_pointer_grab_ = false;
+}
 
 void X11WindowBase::ToggleFullscreen() {
   SetWMSpecState(!is_fullscreen_, gfx::GetAtom("_NET_WM_STATE_FULLSCREEN"),
@@ -400,6 +410,13 @@ bool X11WindowBase::IsEventForXWindow(const XEvent& xev) const {
 
 void X11WindowBase::ProcessXWindowEvent(XEvent* xev) {
   switch (xev->type) {
+    case EnterNotify:
+    case LeaveNotify: {
+      OnCrossingEvent(xev->type == EnterNotify, xev->xcrossing.focus,
+                      xev->xcrossing.mode, xev->xcrossing.detail);
+      break;
+    }
+
     case Expose: {
       gfx::Rect damage_rect(xev->xexpose.x, xev->xexpose.y, xev->xexpose.width,
                             xev->xexpose.height);
@@ -407,10 +424,11 @@ void X11WindowBase::ProcessXWindowEvent(XEvent* xev) {
       break;
     }
 
-    case FocusOut:
-      if (xev->xfocus.mode != NotifyGrab)
-        delegate_->OnLostCapture();
+    case FocusIn:
+    case FocusOut: {
+      OnFocusEvent(xev->type == FocusIn, xev->xfocus.mode, xev->xfocus.detail);
       break;
+    }
 
     case ConfigureNotify: {
       DCHECK_EQ(xwindow_, xev->xconfigure.event);
@@ -432,6 +450,20 @@ void X11WindowBase::ProcessXWindowEvent(XEvent* xev) {
         bounds_ = bounds;
         delegate_->OnBoundsChanged(bounds_);
       }
+      break;
+    }
+
+    case MapNotify: {
+      window_mapped_in_server_ = true;
+      break;
+    }
+
+    case UnmapNotify: {
+      window_mapped_in_server_ = false;
+      has_pointer_ = false;
+      has_pointer_grab_ = false;
+      has_pointer_focus_ = false;
+      has_window_focus_ = false;
       break;
     }
 
@@ -504,6 +536,154 @@ void X11WindowBase::OnWMStateUpdated() {
     }
     delegate_->OnWindowStateChanged(state);
   }
+}
+
+void X11WindowBase::BeforeActivationStateChanged() {
+  was_active_ = IsActive();
+  had_pointer_ = has_pointer_;
+  had_pointer_grab_ = has_pointer_grab_;
+  had_window_focus_ = has_window_focus_;
+}
+
+void X11WindowBase::AfterActivationStateChanged() {
+  if (had_pointer_grab_ && !has_pointer_grab_) {
+    // TODO(msisov, tonikitoo): think how to make a call to
+    // dispatcher()->OnHostLostMouseGrab(). That's done in
+    // DesktopWindowTreeHostX11::AfterActivationStateChanged also.
+  }
+
+  bool had_pointer_capture = had_pointer_ || had_pointer_grab_;
+  bool has_pointer_capture = has_pointer_ || has_pointer_grab_;
+  if (had_pointer_capture && !has_pointer_capture)
+    delegate_->OnLostCapture();
+
+  if (was_active_ != IsActive())
+    delegate_->OnActivationChanged(IsActive());
+}
+
+bool X11WindowBase::IsActive() const {
+  // Focus and stacking order are independent in X11.  Since we cannot guarantee
+  // a window is topmost if it has focus, just use the focus state to determine
+  // if a window is active.
+  bool is_active = has_window_focus_ || has_pointer_focus_;
+
+  // is_active => window_mapped_in_server_
+  // !window_mapped_in_server_ => !is_active
+  DCHECK(!is_active || window_mapped_in_server_);
+
+  // |has_window_focus_| and |has_pointer_focus_| are mutually exclusive.
+  DCHECK(!has_window_focus_ || !has_pointer_focus_);
+
+  return is_active;
+}
+
+void X11WindowBase::OnCrossingEvent(bool enter,
+                                    bool focus_in_window_or_ancestor,
+                                    int mode,
+                                    int detail) {
+  // NotifyInferior on a crossing event means the pointer moved into or out of a
+  // child window, but the pointer is still within |xwindow_|.
+  if (detail == NotifyInferior)
+    return;
+
+  BeforeActivationStateChanged();
+
+  if (mode == NotifyGrab)
+    has_pointer_grab_ = enter;
+  else if (mode == NotifyUngrab)
+    has_pointer_grab_ = false;
+
+  has_pointer_ = enter;
+  if (focus_in_window_or_ancestor && !has_window_focus_) {
+    // If we reach this point, we know the focus is in an ancestor or the
+    // pointer root.  The definition of |has_pointer_focus_| is (An ancestor
+    // window or the PointerRoot is focused) && |has_pointer_|.  Therefore, we
+    // can just use |has_pointer_| in the assignment.  The transitions for when
+    // the focus changes are handled in OnFocusEvent().
+    has_pointer_focus_ = has_pointer_;
+  }
+
+  AfterActivationStateChanged();
+}
+
+void X11WindowBase::OnFocusEvent(bool focus_in, int mode, int detail) {
+  // NotifyInferior on a focus event means the focus moved into or out of a
+  // child window, but the focus is still within |xwindow_|.
+  if (detail == NotifyInferior)
+    return;
+
+  bool notify_grab = mode == NotifyGrab || mode == NotifyUngrab;
+
+  BeforeActivationStateChanged();
+
+  // For every focus change, the X server sends normal focus events which are
+  // useful for tracking |has_window_focus_|, but supplements these events with
+  // NotifyPointer events which are only useful for tracking pointer focus.
+
+  // For |has_pointer_focus_| and |has_window_focus_|, we continue tracking
+  // state during a grab, but ignore grab/ungrab events themselves.
+  if (!notify_grab && detail != NotifyPointer)
+    has_window_focus_ = focus_in;
+
+  if (!notify_grab && has_pointer_) {
+    switch (detail) {
+      case NotifyAncestor:
+      case NotifyVirtual:
+        // If we reach this point, we know |has_pointer_| was true before and
+        // after this event.  Since the definition of |has_pointer_focus_| is
+        // (An ancestor window or the PointerRoot is focused) && |has_pointer_|,
+        // we only need to worry about transitions on the first conjunct.
+        // Therefore, |has_pointer_focus_| will become true when:
+        // 1. Focus moves from |xwindow_| to an ancestor
+        //    (FocusOut with NotifyAncestor)
+        // 2. Focus moves from a decendant of |xwindow_| to an ancestor
+        //    (FocusOut with NotifyVirtual)
+        // |has_pointer_focus_| will become false when:
+        // 1. Focus moves from an ancestor to |xwindow_|
+        //    (FocusIn with NotifyAncestor)
+        // 2. Focus moves from an ancestor to a child of |xwindow_|
+        //    (FocusIn with NotifyVirtual)
+        has_pointer_focus_ = !focus_in;
+        break;
+      case NotifyPointer:
+        // The remaining cases for |has_pointer_focus_| becoming true are:
+        // 3. Focus moves from |xwindow_| to the PointerRoot
+        // 4. Focus moves from a decendant of |xwindow_| to the PointerRoot
+        // 5. Focus moves from None to the PointerRoot
+        // 6. Focus moves from Other to the PointerRoot
+        // 7. Focus moves from None to an ancestor of |xwindow_|
+        // 8. Focus moves from Other to an ancestor fo |xwindow_|
+        // In each case, we will get a FocusIn with a detail of NotifyPointer.
+        // The remaining cases for |has_pointer_focus_| becoming false are:
+        // 3. Focus moves from the PointerRoot to |xwindow_|
+        // 4. Focus moves from the PointerRoot to a decendant of |xwindow|
+        // 5. Focus moves from the PointerRoot to None
+        // 6. Focus moves from an ancestor of |xwindow_| to None
+        // 7. Focus moves from the PointerRoot to Other
+        // 8. Focus moves from an ancestor of |xwindow_| to Other
+        // In each case, we will get a FocusOut with a detail of NotifyPointer.
+        has_pointer_focus_ = focus_in;
+        break;
+      case NotifyNonlinear:
+      case NotifyNonlinearVirtual:
+        // We get Nonlinear(Virtual) events when
+        // 1. Focus moves from Other to |xwindow_|
+        //    (FocusIn with NotifyNonlinear)
+        // 2. Focus moves from Other to a decendant of |xwindow_|
+        //    (FocusIn with NotifyNonlinearVirtual)
+        // 3. Focus moves from |xwindow_| to Other
+        //    (FocusOut with NotifyNonlinear)
+        // 4. Focus moves from a decendant of |xwindow_| to Other
+        //    (FocusOut with NotifyNonlinearVirtual)
+        // |has_pointer_focus_| should be false before and after this event.
+        has_pointer_focus_ = false;
+        break;
+      default:
+        break;
+    }
+  }
+
+  AfterActivationStateChanged();
 }
 
 bool X11WindowBase::HasWMSpecProperty(const char* property) const {

--- a/ui/platform_window/x11/x11_window_base.h
+++ b/ui/platform_window/x11/x11_window_base.h
@@ -78,14 +78,56 @@ class X11_WINDOW_EXPORT X11WindowBase : public PlatformWindow {
   // Called when WM_STATE property is changed.
   void OnWMStateUpdated();
 
+  void OnCrossingEvent(bool enter,
+                       bool focus_in_window_or_ancestor,
+                       int mode,
+                       int detail);
+
+  // Called on an XFocusInEvent, XFocusOutEvent, XIFocusInEvent, or an
+  // XIFocusOutEvent.
+  // TODO(msisov, tonikitoo): share this with DesktopWindowTreeHostX11.
+  void OnFocusEvent(bool focus_in, int mode, int detail);
+
   // Checks if the window manager has set a specific state.
   // TODO(msisov, tonikitoo): share this with DesktopWindowTreeHostX11.
   bool HasWMSpecProperty(const char* property) const;
+
+  // Record the activation state.
+  // TODO(msisov, tonikitoo): share this with DesktopWindowTreeHostX11.
+  void BeforeActivationStateChanged();
+
+  // Handle the state change since BeforeActivationStateChanged().
+  // TODO(msisov, tonikitoo): share this with DesktopWindowTreeHostX11.
+  void AfterActivationStateChanged();
 
   // TODO(msisov, tonikitoo): share this with DesktopWindowTreeHostX11.
   bool IsMinimized() const;
   bool IsMaximized() const;
   bool IsFullScreen() const;
+
+  bool IsActive() const;
+
+  bool window_mapped_in_server_ = false;
+  // Does |xwindow_| have the pointer grab (XI2 or normal)?
+  bool has_pointer_grab_ = false;
+
+  // Is the pointer in |xwindow_| or one of its children?
+  bool has_pointer_ = false;
+
+  // Is |xwindow_| or one of its children focused?
+  bool has_window_focus_ = false;
+
+  // (An ancestor window or the PointerRoot is focused) && |has_pointer_|.
+  // |has_pointer_focus_| == true is the odd case where we will receive keyboard
+  // input when |has_window_focus_| == false.  |has_window_focus_| and
+  // |has_pointer_focus_| are mutually exclusive.
+  bool has_pointer_focus_ = false;
+
+  // Used for tracking activation state in {Before|After}ActivationStateChanged.
+  bool was_active_ = false;
+  bool had_pointer_ = false;
+  bool had_pointer_grab_ = false;
+  bool had_window_focus_ = false;
 
   PlatformWindowDelegate* delegate_;
 

--- a/ui/platform_window/x11/x11_window_manager_ozone.cc
+++ b/ui/platform_window/x11/x11_window_manager_ozone.cc
@@ -25,7 +25,6 @@ void X11WindowManagerOzone::GrabEvents(X11WindowOzone* window) {
     old_grabber->OnLostCapture();
 
   event_grabber_ = window;
-  ui::GrabPointer(window->xwindow(), true, None);
 }
 
 void X11WindowManagerOzone::UngrabEvents(X11WindowOzone* window) {
@@ -33,7 +32,6 @@ void X11WindowManagerOzone::UngrabEvents(X11WindowOzone* window) {
     return;
   event_grabber_->OnLostCapture();
   event_grabber_ = nullptr;
-  ui::UngrabPointer();
 }
 
 void X11WindowManagerOzone::AddX11Window(X11WindowOzone* window) {

--- a/ui/platform_window/x11/x11_window_ozone.cc
+++ b/ui/platform_window/x11/x11_window_ozone.cc
@@ -60,10 +60,13 @@ void X11WindowOzone::PrepareForShutdown() {
 
 void X11WindowOzone::SetCapture() {
   window_manager_->GrabEvents(this);
+  X11WindowBase::SetCapture();
 }
 
 void X11WindowOzone::ReleaseCapture() {
   window_manager_->UngrabEvents(this);
+  if (window_manager_->event_grabber() == this)
+    X11WindowBase::ReleaseCapture();
 }
 
 void X11WindowOzone::SetCursor(PlatformCursor cursor) {


### PR DESCRIPTION
This patch makes it possible to propagate activation state from
ozone backends to aura by add additional method OnActivationChanged
to WindowTree/WindowTreeClient.
    
The patch works the following way:
There are two cases:
1) There is only one browser window.
2) There are two or more browser windows. Basically, this doesn't
differ that much from the first case.
    
In first case, when the browser window looses focus (client clicks
outside the browser area or clicks other (browser) window) or gains focus
(client clicks on the browser window. It can be non-client or client area),
ozone backends call their delegate that they lost or gained focus,
which results in a call to WindowTreeClient::OnActivationChanged.
    
The WindowTreeClient calls aura::FocusSynchronizer with or without
active focus client, which sets or resets an activation client resulting
in a call to FocusSynchronizer::OnActiveFocusClientChanged and
FocusSynchronizerObserver::OnActiveFocusClientChanged. The first one
instantiates a FlightChange for focus and calls to WindowTree::SetFocus,
the second one results in DesktopWindowTreeHostX11::OnActiveFocusClientChanged,
which results in a call to DesktopNativeWidgetAura::HandleActivationChanged.
    
The last one updates the views then and other things related to lost or
gained focus.

X11WindowBase contains the same logic as DesktopWindowTreeHostX11 now. It helps to identify
gained or lost activation state.
