### PR TITLE
First attempt to reduce Gpu service startup failure.

### DIFF
--- a/ui/aura/mus/window_tree_host_mus.cc
+++ b/ui/aura/mus/window_tree_host_mus.cc
@@ -174,9 +174,14 @@ void WindowTreeHostMus::ConfineCursorToBounds(
                                                    display_id_);
 }
 
-display::Display WindowTreeHostMus::GetDisplay() const {
+display::Display WindowTreeHostMus::GetDisplay() {
   display::Display display;
-  display::Screen::GetScreen()->GetDisplayWithDisplayId(display_id_, &display);
+  auto* screen = display::Screen::GetScreen();
+  if (screen->GetDisplayWithDisplayId(display_id_, &display))
+    return display;
+  // Fallback: return the primary display.
+  display = screen->GetPrimaryDisplay();
+  display_id_ = display.id();
   return display;
 }
 

--- a/ui/aura/mus/window_tree_host_mus.h
+++ b/ui/aura/mus/window_tree_host_mus.h
@@ -92,7 +92,7 @@ class AURA_EXPORT WindowTreeHostMus : public aura::WindowTreeHostPlatform {
   // Intended only for WindowTreeClient to call.
   void set_display_id(int64_t id) { display_id_ = id; }
   int64_t display_id() const { return display_id_; }
-  display::Display GetDisplay() const;
+  display::Display GetDisplay();
 
   // aura::WindowTreeHostPlatform:
   void HideImpl() override;

--- a/ui/views/mus/screen_mus.cc
+++ b/ui/views/mus/screen_mus.cc
@@ -58,6 +58,12 @@ void ScreenMus::Init(service_manager::Connector* connector) {
   display_manager_observer_binding_.Bind(mojo::MakeRequest(&observer));
   display_manager_->AddObserver(std::move(observer));
 
+#if defined(USE_OZONE) && defined(OS_LINUX) && !defined(OS_CHROMEOS)
+  // Install a default display and assume WS will update that the real value
+  // as soon as Ozone starts.
+  display_list().AddDisplay(
+      display::Display(0xFFFFFFFF, gfx::Rect(0, 0, 801, 802)), Type::PRIMARY);
+#else
   // We need the set of displays before we can continue. Wait for it.
   //
   // TODO(rockot): Do something better here. This should not have to block tasks
@@ -74,6 +80,7 @@ void ScreenMus::Init(service_manager::Connector* connector) {
     display_list().AddDisplay(
         display::Display(0xFFFFFFFF, gfx::Rect(0, 0, 801, 802)), Type::PRIMARY);
   }
+#endif
 }
 
 display::Display ScreenMus::GetDisplayNearestWindow(


### PR DESCRIPTION
It happens occasionally that the gpu service (GpuServiceImpl) fails to
notify the gpu host (GpuHost) that it has been initialized
(in practice, GpuServiceImpl::InitializeWithHost calls out to
GpuHost::DidInitialize, via mojo, but it never reaches the end).

The natural flow when the call succeeds is:

- GpuHost notifies the WindowServer that Gpu services is initialized,
and then ui::Service.
- ui::Service would initialized ScreenManager (ScreenManagerOzoneExternal::Init),
which would call out to Ozone to query "host display info".
- Ozone would then call back to ScreenManagerOzoneExternal, then DisplayManager
and UserDisplayManager.
- The last would call out to ScreenMus, which awaiting in a sync call.

However, all this does not happen because the GpuService when does not
initialize well at the beginning, ending up in a dead wait.

The CL tries to avoid the sync wait at ScreenMus side, installing a
default display::Display, that would be replaced when Ozone sends the
proper display down the road.

Issue #212