### PR TITLE
fixup! Show and hide menu windows once visibility is changed

### DIFF
--- a/services/ui/public/interfaces/window_tree.mojom
+++ b/services/ui/public/interfaces/window_tree.mojom
@@ -149,9 +149,6 @@ interface WindowTree {
                     string name,
                     array<uint8>? value);
                     
-  // Sets native window to be hidden once client sends a request for it.
-  SetNativeWindowHidden(uint32 window_id);
-
   // Sets the opacity of the specified window to |opacity|.
   SetWindowOpacity(uint32 change_id, uint32 window_id, float opacity);
 

--- a/services/ui/ws/server_window.cc
+++ b/services/ui/ws/server_window.cc
@@ -334,13 +334,6 @@ void ServerWindow::SetVisible(bool value) {
     observer.OnWindowVisibilityChanged(this);
 }
 
-void ServerWindow::SetNativeWindowHidden() {
-  if (visible_)
-    return;
-  for (auto& observer : observers_)
-    observer.OnSetNativeWindowHidden(this);
-}
-
 void ServerWindow::SetOpacity(float value) {
   if (value == opacity_)
     return;

--- a/services/ui/ws/server_window.h
+++ b/services/ui/ws/server_window.h
@@ -164,9 +164,6 @@ class ServerWindow : public viz::HostFrameSinkClient {
   bool visible() const { return visible_; }
   void SetVisible(bool value);
 
-  // Tells WindowServer to hide native window.
-  void SetNativeWindowHidden();
-
   float opacity() const { return opacity_; }
   void SetOpacity(float value);
 

--- a/services/ui/ws/server_window_observer.h
+++ b/services/ui/ws/server_window_observer.h
@@ -66,7 +66,6 @@ class ServerWindowObserver {
 
   virtual void OnWillChangeWindowVisibility(ServerWindow* window) {}
   virtual void OnWindowVisibilityChanged(ServerWindow* window) {}
-  virtual void OnSetNativeWindowHidden(ServerWindow* window) {}
   virtual void OnWindowOpacityChanged(ServerWindow* window,
                                       float old_opacity,
                                       float new_opacity) {}

--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -907,24 +907,9 @@ void WindowServer::OnWindowVisibilityChanged(ServerWindow* window) {
   if (display_root) {
     display_root->window_manager_state()
         ->ReleaseCaptureBlockedByAnyModalWindow();
-    bool visible = window->visible();
-    if (visible)
-      SetNativeWindowVisibility(display_root, visible);
+    if (display_root->GetClientVisibleRoot() == window)
+      SetNativeWindowVisibility(display_root, window->visible());
   }
-}
-
-void WindowServer::OnSetNativeWindowHidden(ServerWindow* window) {
-  if (in_destructor_)
-    return;
-
-  WindowManagerDisplayRoot* display_root =
-      display_manager_->GetWindowManagerDisplayRoot(window);
-  if (!display_root)
-    return;
-
-  bool visible = window->visible();
-  DCHECK(!visible);
-  SetNativeWindowVisibility(display_root, visible);
 }
 
 void WindowServer::OnWindowCursorChanged(ServerWindow* window,

--- a/services/ui/ws/window_server.h
+++ b/services/ui/ws/window_server.h
@@ -354,7 +354,6 @@ class WindowServer : public ServerWindowDelegate,
                          mojom::OrderDirection direction) override;
   void OnWillChangeWindowVisibility(ServerWindow* window) override;
   void OnWindowVisibilityChanged(ServerWindow* window) override;
-  void OnSetNativeWindowHidden(ServerWindow* window) override;
   void OnWindowOpacityChanged(ServerWindow* window,
                               float old_opacity,
                               float new_opacity) override;

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -1910,13 +1910,6 @@ void WindowTree::SetWindowProperty(
   client()->OnChangeCompleted(change_id, success);
 }
 
-void WindowTree::SetNativeWindowHidden(Id window_id) {
-  ClientWindowId client_window_id(MakeClientWindowId(window_id));
-  ServerWindow* window = GetWindowByClientId(client_window_id);
-  DCHECK(window);
-  window->SetNativeWindowHidden();
-}
-
 void WindowTree::SetWindowOpacity(uint32_t change_id,
                                   Id window_id,
                                   float opacity) {

--- a/services/ui/ws/window_tree.h
+++ b/services/ui/ws/window_tree.h
@@ -517,7 +517,6 @@ class WindowTree : public mojom::WindowTree,
       Id transport_window_id,
       const std::string& name,
       const base::Optional<std::vector<uint8_t>>& value) override;
-  void SetNativeWindowHidden(Id window_id) override;
   void SetWindowOpacity(uint32_t change_id,
                         Id window_id,
                         float opacity) override;

--- a/ui/aura/local/window_port_local.cc
+++ b/ui/aura/local/window_port_local.cc
@@ -187,6 +187,4 @@ bool WindowPortLocal::ShouldRestackTransientChildren() {
   return true;
 }
 
-void WindowPortLocal::OnWillHideNativeWindow() {}
-
 }  // namespace aura

--- a/ui/aura/local/window_port_local.h
+++ b/ui/aura/local/window_port_local.h
@@ -55,8 +55,6 @@ class AURA_EXPORT WindowPortLocal : public WindowPort {
   void OnEventTargetingPolicyChanged() override;
   bool ShouldRestackTransientChildren() override;
 
-  void OnWillHideNativeWindow() override;
-
  private:
   void OnSurfaceChanged(const viz::SurfaceInfo& surface_info);
 

--- a/ui/aura/mus/window_port_mus.cc
+++ b/ui/aura/mus/window_port_mus.cc
@@ -557,10 +557,6 @@ void WindowPortMus::OnWindowAddedToRootWindow() {}
 
 void WindowPortMus::OnWillRemoveWindowFromRootWindow() {}
 
-void WindowPortMus::OnWillHideNativeWindow() {
-  window_tree_client_->OnWindowMusHideNativeWindow(this);
-}
-
 void WindowPortMus::OnEventTargetingPolicyChanged() {
   SetEventTargetingPolicy(window_->event_targeting_policy());
 }

--- a/ui/aura/mus/window_port_mus.h
+++ b/ui/aura/mus/window_port_mus.h
@@ -274,7 +274,6 @@ class AURA_EXPORT WindowPortMus : public WindowPort, public WindowMus {
   const viz::LocalSurfaceId& GetLocalSurfaceId() override;
   void OnWindowAddedToRootWindow() override;
   void OnWillRemoveWindowFromRootWindow() override;
-  void OnWillHideNativeWindow() override;
   void OnEventTargetingPolicyChanged() override;
   bool ShouldRestackTransientChildren() override;
 

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -1024,11 +1024,6 @@ void WindowTreeClient::OnWindowMusPropertyChanged(
                            transport_value_mojo);
 }
 
-void WindowTreeClient::OnWindowMusHideNativeWindow(WindowMus* window) {
-  DCHECK(tree_);
-  tree_->SetNativeWindowHidden(window->server_id());
-}
-
 void WindowTreeClient::OnWindowMusDeviceScaleFactorChanged(
     WindowMus* window,
     float old_scale_factor,

--- a/ui/aura/mus/window_tree_client.h
+++ b/ui/aura/mus/window_tree_client.h
@@ -349,7 +349,6 @@ class AURA_EXPORT WindowTreeClient
                                   const void* key,
                                   int64_t old_value,
                                   std::unique_ptr<ui::PropertyData> data);
-  void OnWindowMusHideNativeWindow(WindowMus* window);
   void OnWindowMusDeviceScaleFactorChanged(WindowMus* window,
                                            float old_scale_factor,
                                            float new_scale_factor);

--- a/ui/aura/mus/window_tree_host_mus.cc
+++ b/ui/aura/mus/window_tree_host_mus.cc
@@ -188,10 +188,6 @@ WindowTreeHostMus::ReleaseDisplayInitParams() {
 void WindowTreeHostMus::HideImpl() {
   WindowTreeHostPlatform::HideImpl();
   window()->Hide();
-
-  WindowPortMus* window_port = WindowPortMus::Get(window());
-  if (window_port)
-    window_port->OnWillHideNativeWindow();
 }
 
 void WindowTreeHostMus::SetBoundsInPixels(const gfx::Rect& bounds) {

--- a/ui/aura/test/mus/test_window_tree.cc
+++ b/ui/aura/test/mus/test_window_tree.cc
@@ -180,8 +180,6 @@ void TestWindowTree::SetWindowProperty(
   OnChangeReceived(change_id, WindowTreeChangeType::PROPERTY);
 }
 
-void TestWindowTree::SetNativeWindowHidden(Id window_id) {}
-
 void TestWindowTree::SetWindowOpacity(uint32_t change_id,
                                       uint32_t window_id,
                                       float opacity) {

--- a/ui/aura/test/mus/test_window_tree.h
+++ b/ui/aura/test/mus/test_window_tree.h
@@ -149,7 +149,6 @@ class TestWindowTree : public ui::mojom::WindowTree {
       uint32_t window_id,
       const std::string& name,
       const base::Optional<std::vector<uint8_t>>& value) override;
-  void SetNativeWindowHidden(Id window_id) override;
   void SetWindowOpacity(uint32_t change_id,
                         uint32_t window_id,
                         float opacity) override;

--- a/ui/aura/window_port.h
+++ b/ui/aura/window_port.h
@@ -104,8 +104,6 @@ class AURA_EXPORT WindowPort {
   virtual void OnWindowAddedToRootWindow() = 0;
   virtual void OnWillRemoveWindowFromRootWindow() = 0;
 
-  virtual void OnWillHideNativeWindow() = 0;
-
   virtual void OnEventTargetingPolicyChanged() = 0;
 
   // See description of function with same name in transient_window_client.

--- a/ui/aura/window_port_for_shutdown.cc
+++ b/ui/aura/window_port_for_shutdown.cc
@@ -47,8 +47,6 @@ std::unique_ptr<ui::PropertyData> WindowPortForShutdown::OnWillChangeProperty(
   return nullptr;
 }
 
-void WindowPortForShutdown::OnWillHideNativeWindow() {}
-
 void WindowPortForShutdown::OnPropertyChanged(
     const void* key,
     int64_t old_value,

--- a/ui/aura/window_port_for_shutdown.h
+++ b/ui/aura/window_port_for_shutdown.h
@@ -35,7 +35,6 @@ class WindowPortForShutdown : public WindowPort {
                             const gfx::Transform& new_transform) override;
   std::unique_ptr<ui::PropertyData> OnWillChangeProperty(
       const void* key) override;
-  void OnWillHideNativeWindow() override;
   void OnPropertyChanged(const void* key,
                          int64_t old_value,
                          std::unique_ptr<ui::PropertyData> data) override;


### PR DESCRIPTION
Instead of using additional redundant hooks to hide windows,
just check if the visibility of a root window has been changed.
Based on that knowledge, hide or show ozone windows.

I realized I was wrong at the beginning of this project due to lack of knowledge about aura/mus code.

The patch should be as simple as such:

if (display_root->GetClientVisibleRoot() == window)
  SetNativeWindowVisibility(display_root, window->visible());