### PR TITLE
fixup! Make ozone backends to propage activation state to aura

### DIFF
--- a/services/ui/ws/platform_display_default_unittest.cc
+++ b/services/ui/ws/platform_display_default_unittest.cc
@@ -60,6 +60,7 @@ class TestPlatformDisplayDelegate : public PlatformDisplayDelegate {
   void OnCloseRequest() override {}
   void OnNativeCaptureLost() override {}
   void OnWindowStateChanged(ui::mojom::ShowState new_state) override {}
+  void OnActivationChanged(bool is_active) override {}
   OzonePlatform* GetOzonePlatform() override { return ozone_platform_; }
 
  private:

--- a/ui/platform_window/x11/x11_window_base.cc
+++ b/ui/platform_window/x11/x11_window_base.cc
@@ -123,6 +123,17 @@ void X11WindowBase::Destroy() {
   XDestroyWindow(xdisplay, xwindow);
 }
 
+void X11WindowBase::SetPointerGrab() {
+  if (has_pointer_grab_)
+    return;
+  has_pointer_grab_ |= !ui::GrabPointer(xwindow_, true, None);
+}
+
+void X11WindowBase::ReleasePointerGrab() {
+  ui::UngrabPointer();
+  has_pointer_grab_ = false;
+}
+
 void X11WindowBase::Create() {
   DCHECK(!bounds_.size().IsEmpty());
 

--- a/ui/platform_window/x11/x11_window_base.h
+++ b/ui/platform_window/x11/x11_window_base.h
@@ -54,6 +54,9 @@ class X11_WINDOW_EXPORT X11WindowBase : public PlatformWindow {
  protected:
   void Destroy();
 
+  void SetPointerGrab();
+  void ReleasePointerGrab();
+
   PlatformWindowDelegate* delegate() { return delegate_; }
   XDisplay* xdisplay() { return xdisplay_; }
   XID xwindow() const { return xwindow_; }

--- a/ui/platform_window/x11/x11_window_ozone.cc
+++ b/ui/platform_window/x11/x11_window_ozone.cc
@@ -60,13 +60,13 @@ void X11WindowOzone::PrepareForShutdown() {
 
 void X11WindowOzone::SetCapture() {
   window_manager_->GrabEvents(this);
-  X11WindowBase::SetCapture();
+  // Sets pointer grab if events are grabbed.
+  if (window_manager_->event_grabber() == this)
+    SetPointerGrab();
 }
 
 void X11WindowOzone::ReleaseCapture() {
   window_manager_->UngrabEvents(this);
-  if (window_manager_->event_grabber() == this)
-    X11WindowBase::ReleaseCapture();
 }
 
 void X11WindowOzone::SetCursor(PlatformCursor cursor) {
@@ -134,6 +134,7 @@ uint32_t X11WindowOzone::DispatchEvent(const PlatformEvent& platform_event) {
 }
 
 void X11WindowOzone::OnLostCapture() {
+  ReleasePointerGrab();
   delegate()->OnLostCapture();
 }
 


### PR DESCRIPTION
Handle pointer grab properly and add missing implementation. I messed up a bit and broke it.

What's broken:

When user opens a browser window and presses inside it, he/she is not able to click anywhere else after that as long as pointer grab is not unset. 