### PR TITLE
fixup! Handle window minimize/maximize/restore in external window mode.

### DIFF
--- a/content/renderer/mus/renderer_window_tree_client.cc
+++ b/content/renderer/mus/renderer_window_tree_client.cc
@@ -267,10 +267,6 @@ void RendererWindowTreeClient::OnDragDropDone() {}
 void RendererWindowTreeClient::OnChangeCompleted(uint32_t change_id,
                                                  bool success) {}
 
-void RendererWindowTreeClient::OnWindowStateChanged(
-    uint32_t window_id,
-    ui::mojom::ShowState state) {}
-
 void RendererWindowTreeClient::OnActivationChanged(uint32_t window_id,
                                                    bool is_active) {}
 

--- a/content/renderer/mus/renderer_window_tree_client.h
+++ b/content/renderer/mus/renderer_window_tree_client.h
@@ -155,8 +155,6 @@ class RendererWindowTreeClient : public ui::mojom::WindowTreeClient {
                                   uint32_t action_taken) override;
   void OnDragDropDone() override;
   void OnChangeCompleted(uint32_t change_id, bool success) override;
-  void OnWindowStateChanged(uint32_t window_id,
-                            ui::mojom::ShowState state) override;
   void OnActivationChanged(uint32_t window_id, bool is_active) override;
   void RequestClose(uint32_t window_id) override;
   void GetWindowManager(

--- a/services/ui/public/interfaces/window_tree.mojom
+++ b/services/ui/public/interfaces/window_tree.mojom
@@ -546,10 +546,6 @@ interface WindowTreeClient {
   // change ids for details.
   OnChangeCompleted(uint32 change_id, bool success);
 
-  // The WindowManager calls back after the client set proprties to minimize, maximize or restore
-  // the window or after the window is restored back from minimized state by clicking on a tray.
-  OnWindowStateChanged(uint32 window_id, ShowState state);
-  
   // The WindowManager is requesting the specified window to change activation
   // state.
   OnActivationChanged(uint32 window_id, bool is_active);

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -13,6 +13,7 @@
 #include "services/service_manager/public/interfaces/connector.mojom.h"
 #include "services/ui/common/types.h"
 #include "services/ui/display/viewport_metrics.h"
+#include "services/ui/public/cpp/property_type_converters.h"
 #include "services/ui/public/interfaces/cursor/cursor.mojom.h"
 #include "services/ui/ws/debug_utils.h"
 #include "services/ui/ws/display_binding.h"
@@ -389,15 +390,14 @@ void Display::OnWindowStateChanged(ui::mojom::ShowState new_state) {
   if (!window_server_->IsInExternalWindowMode())
     return;
 
-  WindowTree* window_tree = window_server_->GetTreeForExternalWindowMode();
+  std::vector<uint8_t> transport_value =
+      mojo::ConvertTo<std::vector<uint8_t>>(static_cast<int64_t>(new_state));
+
   WindowManagerDisplayRoot* display_root =
       window_manager_display_root_map_.begin()->second;
-  ServerWindow* server_window =
-      display_root->window_manager_state()->GetWindowManagerRootForDisplayRoot(
-          root_window());
-
-  if (window_tree)
-    window_tree->OnWindowStateChanged(server_window, new_state);
+  ServerWindow* server_window = display_root->GetClientVisibleRoot();
+  server_window->SetProperty(mojom::WindowManager::kShowState_Property,
+                             &transport_value);
 }
 
 void Display::OnActivationChanged(bool is_active) {

--- a/services/ui/ws/test_utils.cc
+++ b/services/ui/ws/test_utils.cc
@@ -463,9 +463,6 @@ void TestWindowTreeClient::OnChangeCompleted(uint32_t change_id, bool success) {
     tracker_.OnChangeCompleted(change_id, success);
 }
 
-void TestWindowTreeClient::OnWindowStateChanged(uint32_t window_id,
-                                                ::ui::mojom::ShowState state) {}
-
 void TestWindowTreeClient::OnActivationChanged(uint32_t window_id,
                                                bool is_active) {}
 

--- a/services/ui/ws/test_utils.h
+++ b/services/ui/ws/test_utils.h
@@ -559,8 +559,6 @@ class TestWindowTreeClient : public ui::mojom::WindowTreeClient {
                                   uint32_t action_taken) override;
   void OnDragDropDone() override;
   void OnChangeCompleted(uint32_t change_id, bool success) override;
-  void OnWindowStateChanged(uint32_t window_id,
-                            ::ui::mojom::ShowState state) override;
   void OnActivationChanged(uint32_t window_id, bool is_active) override;
   void RequestClose(uint32_t window_id) override;
   void GetWindowManager(

--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -764,7 +764,7 @@ void WindowServer::SetNativeWindowState(ServerWindow* window,
                                         ui::mojom::ShowState state) {
   WindowManagerDisplayRoot* display_root =
       display_manager_->GetWindowManagerDisplayRoot(window);
-  if (!display_root)
+  if (!display_root || display_root->GetClientVisibleRoot() != window)
     return;
   PlatformDisplay* display = display_root->display()->platform_display();
   DCHECK(display);

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -1209,15 +1209,6 @@ void WindowTree::OnRequestClose(ServerWindow* target_window) {
     client()->RequestClose(ClientWindowIdToTransportId(client_window_id));
 }
 
-void WindowTree::OnWindowStateChanged(ServerWindow* target_window,
-                                      ui::mojom::ShowState new_state) {
-  DCHECK(window_server_->IsInExternalWindowMode());
-  ClientWindowId client_window_id;
-  if (IsWindowKnown(target_window, &client_window_id))
-    client()->OnWindowStateChanged(
-        ClientWindowIdToTransportId(client_window_id), new_state);
-}
-
 void WindowTree::OnActivationChanged(ServerWindow* target_window,
                                      bool is_active) {
   DCHECK(window_server_->IsInExternalWindowMode());

--- a/services/ui/ws/window_tree.h
+++ b/services/ui/ws/window_tree.h
@@ -327,12 +327,6 @@ class WindowTree : public mojom::WindowTree,
   // certain events.
   void OnRequestClose(ServerWindow* target_window);
 
-  // In external window mode, ozone backends can ask client to change states of
-  // windows. This call propagates the new state further to WindowTreeClient and
-  // aura windows.
-  void OnWindowStateChanged(ServerWindow* target_window,
-                            ui::mojom::ShowState new_state);
-
   // In external window mode, ozone backends can ask client to change the
   // activation state of the windows, which results in changing focus in focus
   // controller.

--- a/services/ui/ws/window_tree_client_unittest.cc
+++ b/services/ui/ws/window_tree_client_unittest.cc
@@ -272,9 +272,6 @@ class TestWindowTreeClient : public mojom::WindowTreeClient,
     }
   }
 
-  void OnWindowStateChanged(uint32_t window_id,
-                            ::ui::mojom::ShowState state) override {}
-
   void OnActivationChanged(uint32_t window_id, bool is_active) override {}
 
   // WindowTreeClient:

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -1683,36 +1683,6 @@ void WindowTreeClient::SetBlockingContainers(
       base::Bind(&OnAckMustSucceed));
 }
 
-void WindowTreeClient::OnWindowStateChanged(uint32_t window_id,
-                                            ui::mojom::ShowState state) {
-  DCHECK(in_external_window_mode_);
-  WindowMus* window = GetWindowByServerId(window_id);
-  if (!window || !IsRoot(window))
-    return;
-
-  aura::Window* aura_window = window->GetWindow();
-  WindowTreeHostMus* host = GetWindowTreeHostMus(aura_window);
-  ui::WindowShowState show_state;
-  switch (state) {
-    case (ui::mojom::ShowState::MINIMIZED):
-      show_state = ui::SHOW_STATE_MINIMIZED;
-      host->Hide();
-      break;
-    case (ui::mojom::ShowState::MAXIMIZED):
-      show_state = ui::SHOW_STATE_MAXIMIZED;
-      host->Show();
-      break;
-    case (ui::mojom::ShowState::NORMAL):
-      show_state = ui::SHOW_STATE_NORMAL;
-      host->Show();
-      break;
-    default:
-      return;
-  }
-
-  aura_window->SetProperty(aura::client::kShowStateKey, show_state);
-}
-
 void WindowTreeClient::OnActivationChanged(uint32_t window_id, bool is_active) {
   DCHECK(in_external_window_mode_);
   WindowMus* window = GetWindowByServerId(window_id);

--- a/ui/aura/mus/window_tree_client.h
+++ b/ui/aura/mus/window_tree_client.h
@@ -446,8 +446,6 @@ class AURA_EXPORT WindowTreeClient
                                   uint32_t action_taken) override;
   void OnDragDropDone() override;
   void OnChangeCompleted(uint32_t change_id, bool success) override;
-  void OnWindowStateChanged(uint32_t window_id,
-                            ui::mojom::ShowState state) override;
   void OnActivationChanged(uint32_t window_id, bool is_active) override;
   void RequestClose(uint32_t window_id) override;
   void SetBlockingContainers(


### PR DESCRIPTION
Remove the APIs that we've added and use ServerWindow::SetProperty instead
which results in a call to WindowTreeClient::OnWindowSharedPropertyChanged
and Window::SetPropertyFromServer. The further should synchronize the
aura states without explicit interactions from the host window manager.