### PR TITLE
fixup! Make ozone backends to propage activation state to aura

### DIFF
--- a/ui/platform_window/x11/x11_window_base.cc
+++ b/ui/platform_window/x11/x11_window_base.cc
@@ -242,8 +242,6 @@ void X11WindowBase::Create() {
   ui::SetUseOSWindowFrame(xwindow_, false);
 #endif
 
-  has_window_focus_ = true;
-  window_mapped_in_server_ = true;
   // TODO(sky): provide real scale factor.
   delegate_->OnAcceleratedWidgetAvailable(xwindow_, 1.f);
 }


### PR DESCRIPTION
Don't put window mapped or focused on initialization as long as
those will be set on configure event. This fixes focusing in X11, when
a new window is created.