### PR TITLE
Crash at shutdown 

### DIFF
--- a/services/ui/display/screen_manager_ozone_external.cc
+++ b/services/ui/display/screen_manager_ozone_external.cc
@@ -20,10 +20,8 @@ std::unique_ptr<ScreenManager> ScreenManager::Create() {
 }
 
 ScreenManagerOzoneExternal::ScreenManagerOzoneExternal()
-    : screen_owned_(base::MakeUnique<ScreenBase>()),
-      screen_(screen_owned_.get()),
+    : screen_(base::MakeUnique<ScreenBase>()),
       weak_ptr_factory_(this) {
-  Screen::SetScreenInstance(screen_owned_.get());
 }
 
 ScreenManagerOzoneExternal::~ScreenManagerOzoneExternal() {}
@@ -44,7 +42,7 @@ void ScreenManagerOzoneExternal::OnHostDisplaysReady(
 
   screen_->display_list().AddDisplay(display, DisplayList::Type::PRIMARY);
 
-  // TODO(tonikitoo): Before calling out to ScreenManagerDelegate check if
+  // TODO(tonikitoo, msisov): Before calling out to ScreenManagerDelegate check if
   // more than one host display is available.
   delegate_->OnHostDisplaysReady(service_manager::mojom::kRootUserID);
 }
@@ -64,7 +62,7 @@ void ScreenManagerOzoneExternal::Init(ScreenManagerDelegate* delegate) {
 void ScreenManagerOzoneExternal::RequestCloseDisplay(int64_t display_id) {}
 
 display::ScreenBase* ScreenManagerOzoneExternal::GetScreen() {
-  return screen_;
+  return screen_.get();
 }
 
 }  // namespace display

--- a/services/ui/display/screen_manager_ozone_external.h
+++ b/services/ui/display/screen_manager_ozone_external.h
@@ -37,13 +37,9 @@ class ScreenManagerOzoneExternal : public ScreenManager {
   void RequestCloseDisplay(int64_t display_id) override;
   display::ScreenBase* GetScreen() override;
 
-  // A Screen instance is created in the constructor because it might be
-  // accessed early. The ownership of this object will be transfered to
-  // |display_manager_| when that gets initialized.
-  std::unique_ptr<ScreenBase> screen_owned_;
-
-  // Used to add/remove/modify displays.
-  ScreenBase* screen_;
+  // Internal control for displays added/removed/modified.
+  // THIS IS NOT INSTALLED IN Screen::SetScreenInstancce.
+  std::unique_ptr<ScreenBase> screen_;
 
   ScreenManagerDelegate* delegate_ = nullptr;
   int next_display_id_ = 0;


### PR DESCRIPTION
Since we switched to mushrome process model, we have Mus and Browser threads in the same process.

We thus cant install an Screen instance from Mus anymore, and use Browser's.

Patch fixes this.

Issue #250 .