### PR TITLE
[ozone/wayland] occasional never ending wait at start up

### DIFF
--- a/ui/ozone/platform/wayland/wayland_connection.cc
+++ b/ui/ozone/platform/wayland/wayland_connection.cc
@@ -230,10 +230,6 @@ void WaylandConnection::Global(void* data,
 
     connection->output_list_.push_back(
         base::WrapUnique(new WaylandOutput(output.release())));
-
-    // By the time the Wayland output is instantiated, it must be able
-    // to receive and process events from the Wayland server.
-    connection->StartProcessingEvents();
   }
 
   connection->ScheduleFlush();


### PR DESCRIPTION
fixup! Allow ws to pass display::Display data to Aura/client

Stop early listen to events, when wl_output is installed.

This call isnt needed anymore, and was causing us to enter
the event loop earlier than we should, and occasional hangs
at start up.

Issue #212