### PR TITLE
[ozone/wayland] occasional never ending wait at start up

### DIFF
--- a/ui/ozone/platform/wayland/wayland_connection.cc
+++ b/ui/ozone/platform/wayland/wayland_connection.cc
@@ -50,7 +50,9 @@ bool WaylandConnection::Initialize() {
   }
 
   wl_registry_add_listener(registry_.get(), &registry_listener, this);
-  wl_display_roundtrip(display_.get());
+
+  while (!PrimaryOutput() || PrimaryOutput()->Geometry().IsEmpty())
+    wl_display_roundtrip(display_.get());
 
   if (!compositor_) {
     LOG(ERROR) << "No wl_compositor object";
@@ -230,10 +232,6 @@ void WaylandConnection::Global(void* data,
 
     connection->output_list_.push_back(
         base::WrapUnique(new WaylandOutput(output.release())));
-
-    // By the time the Wayland output is instantiated, it must be able
-    // to receive and process events from the Wayland server.
-    connection->StartProcessingEvents();
   }
 
   connection->ScheduleFlush();


### PR DESCRIPTION
fixup! Allow ws to pass display::Display data to Aura/client

Stop early listen to events, when wl_output is installed.
This call was causing us to enter the event loop earlier than we should,
and occasional hangs at start up.

Instead, when display/screen data is queried, we "ask" the server
to close all pending requests associated with a given wl_display.
Screen dimensions then can be queried.

Issue #212