### PR TITLE
fixup! Allow ws to pass display::Display data to Aura/client

### DIFF
--- a/ui/ozone/platform/wayland/fake_server.cc
+++ b/ui/ozone/platform/wayland/fake_server.cc
@@ -473,7 +473,8 @@ void MockCompositor::AddSurface(std::unique_ptr<MockSurface> surface) {
 }
 
 MockOutput::MockOutput()
-    : Global(&wl_output_interface, nullptr, kOutputVersion) {}
+    : Global(&wl_output_interface, nullptr, kOutputVersion),
+	  rect_(0, 0, 1024, 768) {}
 
 MockOutput::~MockOutput() {}
 

--- a/ui/ozone/platform/wayland/wayland_connection_unittest.cc
+++ b/ui/ozone/platform/wayland/wayland_connection_unittest.cc
@@ -73,10 +73,16 @@ TEST(WaylandConnectionTest, Output) {
   ASSERT_TRUE(connection.Initialize());
   connection.StartProcessingEvents();
 
-  base::RunLoop run_loop;
-  OutputObserver observer(run_loop.QuitClosure());
-  connection.PrimaryOutput()->SetObserver(&observer);
-  run_loop.Run();
+  /* Before adding a waiting loop to WaylandConnection::Initilize,
+   * this setting of the observer worked. But as long as we now wait
+   * until all the events are processed and the output handle mode is set,
+   * it's too late to add an observer at this point.
+   *
+   * base::RunLoop run_loop;
+   * OutputObserver observer(run_loop.QuitClosure());
+   * connection.PrimaryOutput()->SetObserver(&observer);
+   * run_loop.Run();
+   */
 
   ASSERT_TRUE(connection.GetOutputList().size() == 1);
   WaylandOutput* output = connection.PrimaryOutput();


### PR DESCRIPTION
Fix unittests: after the change to WaylandConnection::Initialize, the
unittests started to hang on startup, because the WaylandOutput::Geometry
had always been empty.

The fix is to modify a ctor of MockOutput, which will set a default gfx::Rect geometry a
to it. MockOutput is a global wl object on the server side, with non-empty geometry,
which will be set during initialization step.

The second part of the fix is to modify WaylandConnectionTest::Output in such a way that
it would not wait in a blocking run loop. At the moment, we have
a wl_display_roundtrip run until WaylandOutput::Geometry is set instead.