### PR TITLE
Leverage the use of ExternalWindowTreeFactory

### DIFF
--- a/services/ui/demo/mus_demo_external.cc
+++ b/services/ui/demo/mus_demo_external.cc
@@ -73,7 +73,7 @@ void MusDemoExternal::OnStartImpl() {
     }
   }
 
-  window_tree_client()->ConnectViaWindowTreeHostFactory();
+  window_tree_client()->ConnectViaExternalWindowTreeFactory();
 
   // TODO(tonikitoo,fwang): Implement management of displays in external mode.
   // For now, a fake display is created in order to work around an assertion in

--- a/services/ui/ws/window_tree.h
+++ b/services/ui/ws/window_tree.h
@@ -164,7 +164,12 @@ class WindowTree : public mojom::WindowTree,
   WindowServer* window_server() { return window_server_; }
   const WindowServer* window_server() const { return window_server_; }
 
-  void WillCreateRootDisplay(Id transport_window_id) {
+  // Called from WindowTreeHostFactory when creating a new ws::Display.
+  // The Id is stored, and set to the WindowManagerDisplayRoot::root_,
+  // which hosts the content embedded by the client.
+  //
+  // Used in external window mode.
+  void prepare_to_create_root_display(Id transport_window_id) {
     pending_client_window_id_ = transport_window_id;
   }
 
@@ -772,7 +777,8 @@ class WindowTree : public mojom::WindowTree,
       base::flat_map<base::UnguessableToken, mojom::WindowTreeClientPtr>;
   ScheduledEmbeds scheduled_embeds_;
 
-  // TODO(tonikitoo,msisov): Add a comment.
+  // Temporarily stores the Id to be set to the WindowManagerDisplayRoot::root_,
+  // which hosts the content embedded by the client.
   Id pending_client_window_id_ = kInvalidClientId;
 
   // A weak ptr factory for callbacks from the window manager for when we send

--- a/services/ui/ws/window_tree_host_factory.cc
+++ b/services/ui/ws/window_tree_host_factory.cc
@@ -33,7 +33,7 @@ void WindowTreeHostFactory::CreatePlatformWindow(
     Id transport_window_id,
     const TransportProperties& transport_properties) {
   WindowTree* tree = window_server_->GetTreeForExternalWindowMode();
-  tree->WillCreateRootDisplay(transport_window_id);
+  tree->prepare_to_create_root_display(transport_window_id);
 
   Display* ws_display = new Display(window_server_);
 

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -275,7 +275,7 @@ WindowTreeClient::~WindowTreeClient() {
   CHECK(windows_.empty());
 }
 
-void WindowTreeClient::ConnectViaWindowTreeHostFactory() {
+void WindowTreeClient::ConnectViaExternalWindowTreeFactory() {
   ui::mojom::ExternalWindowTreeFactoryPtr factory;
   connector_->BindInterface(ui::mojom::kServiceName, &factory);
 
@@ -1143,8 +1143,8 @@ void WindowTreeClient::OnEmbed(
     bool drawn,
     const base::Optional<viz::LocalSurfaceId>& local_surface_id) {
   if (in_external_window_mode_) {
-    // No need to set 'tree_ptr_' whether it was already set during
-    // ConnectViaWindowTreeHostFactory.
+    // No need to set 'tree_ptr_' since it was already set during
+    // ConnectViaExternalWindowTreeFactory.
     DCHECK(tree_ptr_);
     DCHECK(!tree);
 

--- a/ui/aura/mus/window_tree_client.h
+++ b/ui/aura/mus/window_tree_client.h
@@ -119,8 +119,8 @@ class AURA_EXPORT WindowTreeClient
   // Establishes the connection by way of the WindowTreeFactory.
   void ConnectViaWindowTreeFactory();
 
-  // Establishes the connection by way of the WindowTreeFactoryHost.
-  void ConnectViaWindowTreeHostFactory();
+  // Establishes the connection by way of the ExternalWindowTreeFactory.
+  void ConnectViaExternalWindowTreeFactory();
 
   // Establishes the connection by way of WindowManagerWindowTreeFactory.
   // See mojom for details on |automatically_create_display_roots|.

--- a/ui/views/mus/mus_client.cc
+++ b/ui/views/mus/mus_client.cc
@@ -119,7 +119,7 @@ MusClient::MusClient(service_manager::Connector* connector,
       nullptr /* window_tree_client_request */, std::move(io_task_runner),
       create_discardable_memory);
   aura::Env::GetInstance()->SetWindowTreeClient(window_tree_client_.get());
-  window_tree_client_->ConnectViaWindowTreeHostFactory();
+  window_tree_client_->ConnectViaExternalWindowTreeFactory();
 #else
   window_tree_client_ = base::MakeUnique<aura::WindowTreeClient>(
       connector, this, nullptr /* window_manager_delegate */,


### PR DESCRIPTION
fixup! c++ / mojo changes for 'external window mode'

Driven by tweaks in some class variable comments and method names including

- ConnectViaWindowTreeHostFactory -> ConnectViaExternalWindowTreeFactory
- WillCreateRootDisplay-> prepare_to_create_root_display