### PR TITLE
Share more code between ExternalWindowTreeFactory and WindowServer

### DIFF
--- a/services/ui/ws/external_window_tree_factory.cc
+++ b/services/ui/ws/external_window_tree_factory.cc
@@ -4,9 +4,7 @@
 
 #include "services/ui/ws/external_window_tree_factory.h"
 
-#include "services/ui/ws/external_window_access_policy.h"
 #include "services/ui/ws/window_server.h"
-#include "services/ui/ws/window_server_delegate.h"
 #include "services/ui/ws/window_tree.h"
 
 namespace ui {
@@ -22,39 +20,12 @@ ExternalWindowTreeFactory::~ExternalWindowTreeFactory() {}
 void ExternalWindowTreeFactory::Register(
     mojom::WindowTreeRequest tree_request,
     mojom::WindowTreeClientPtr tree_client) {
-  // NOTE: The code below is analogous to WS::CreateTreeForWindowManager,
-  // but for the sake of an easier rebase, we are concentrating additions
-  // like this here.
-
+  // TODO(tonikitoo,msisov): Propose removing the bulk of "window manager"
+  // suffix in methods and class names.
   bool automatically_create_display_roots = true;
-
-  // TODO(tonikitoo,msisov): Maybe remove the "window manager" suffix
-  // if the method name?
-  window_server_->delegate()->OnWillCreateTreeForWindowManager(
+  window_server_->CreateTreeForWindowManager(
+      user_id_, std::move(tree_request), std::move(tree_client),
       automatically_create_display_roots);
-
-  std::unique_ptr<ws::WindowTree> tree(
-      new ws::WindowTree(window_server_, user_id_, nullptr /*ServerWindow*/,
-                         base::WrapUnique(new ExternalWindowAccessPolicy)));
-
-  std::unique_ptr<ws::DefaultWindowTreeBinding> tree_binding(
-      new ws::DefaultWindowTreeBinding(tree.get(), window_server_,
-                                       std::move(tree_request),
-                                       std::move(tree_client)));
-
-  // Pass nullptr as mojom::WindowTreePtr (3rd parameter), because in external
-  // window mode, the WindowTreePtr is created on the aura/WindowTreeClient
-  // side.
-  //
-  // NOTE: WindowServer::AddTree calls WindowTree::Init, which can trigger a
-  // WindowTreeClient::OnEmbed call. In the particular flow though, WTC::OnEmbed
-  // will not get called because the WindowTree instance was created above
-  // taking 'nullptr' as the ServerWindow parameter, hence the WindowTree has no
-  // 'root' yet.
-  WindowTree* tree_ptr = tree.get();
-  window_server_->AddTree(std::move(tree), std::move(tree_binding),
-                          nullptr /*mojom::WindowTreePtr*/);
-  tree_ptr->ConfigureRootWindowTreeClient(automatically_create_display_roots);
 }
 
 }  // namespace ws

--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -14,6 +14,7 @@
 #include "services/ui/ws/display.h"
 #include "services/ui/ws/display_creation_config.h"
 #include "services/ui/ws/display_manager.h"
+#include "services/ui/ws/external_window_access_policy.h"
 #include "services/ui/ws/frame_generator.h"
 #include "services/ui/ws/gpu_host.h"
 #include "services/ui/ws/operation.h"
@@ -172,8 +173,12 @@ WindowTree* WindowServer::CreateTreeForWindowManager(
   delegate_->OnWillCreateTreeForWindowManager(
       automatically_create_display_roots);
 
+  std::unique_ptr<AccessPolicy> access_policy = in_external_window_mode_
+      ? base::WrapUnique(new ExternalWindowAccessPolicy)
+      : base::WrapUnique(new WindowManagerAccessPolicy);
+
   std::unique_ptr<WindowTree> window_tree(new WindowTree(
-      this, user_id, nullptr, base::WrapUnique(new WindowManagerAccessPolicy)));
+      this, user_id, nullptr, std::move(access_policy)));
   std::unique_ptr<WindowTreeBinding> window_tree_binding =
       delegate_->CreateWindowTreeBinding(
           WindowServerDelegate::BindingType::WINDOW_MANAGER, this,

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -225,6 +225,12 @@ void WindowTree::ConfigureWindowManager(
   automatically_create_display_roots_ = automatically_create_display_roots;
   window_manager_internal_ = binding_->GetWindowManager();
   window_manager_internal_->OnConnect();
+
+  if (window_server_->IsInExternalWindowMode()) {
+    window_tree_host_factory_.reset(
+        new WindowTreeHostFactory(window_server_, user_id_));
+    return;
+  }
   window_manager_state_ = base::MakeUnique<WindowManagerState>(this);
 }
 


### PR DESCRIPTION
Once upon a time, ExternalWindowTreeFactory::Register forked WindowServer::CreateTreeForWindowManager, in order to customize some bits.

Today both can share the same core logic, with minor if's. Patch does it.

Also, it moves the ExternalAccessPolicy initialization to WS::CreateTreeForWindowManager.
Issue #266 