### PR TITLE
fixup! Handle events for interactive drag and resize of native windows.

### DIFF
--- a/services/ui/ws/platform_display_default.cc
+++ b/services/ui/ws/platform_display_default.cc
@@ -170,6 +170,10 @@ void PlatformDisplayDefault::GetWindowType(
 
 void PlatformDisplayDefault::PerformNativeWindowDragOrResize(uint32_t hittest) {
   platform_window_->PerformNativeWindowDragOrResize(hittest);
+
+  // Release capture explicitly set by EventDispatcher to ensure events are
+  // passed properly after resizing/dragging is done.
+  platform_window_->ReleaseCapture();
 }
 
 void PlatformDisplayDefault::SetCursor(const ui::CursorData& cursor_data) {


### PR DESCRIPTION
Reset capture explicitely once a call for dragging/moving a window
comes. This capture is set by EventDispatcher only, not by aura.
In stock X11, capture is not set, when user clicks on opaque view
area, but buttons and tabs.

Issue #262 