### PR TITLE
fixup! Fix maximize/restore glitch of OpaqueBrowserFrameView in Weston.

### DIFF
--- a/ui/platform_window/x11/x11_window_base.cc
+++ b/ui/platform_window/x11/x11_window_base.cc
@@ -369,6 +369,7 @@ void X11WindowBase::Restore() {
     ToggleFullscreen();
 
   if (IsMaximized()) {
+    restored_bounds_in_pixels_ = bounds_;
     SetWMSpecState(false, gfx::GetAtom("_NET_WM_STATE_MAXIMIZED_VERT"),
                    gfx::GetAtom("_NET_WM_STATE_MAXIMIZED_HORZ"));
   }
@@ -526,6 +527,7 @@ void X11WindowBase::OnWMStateUpdated() {
   ui::GetAtomArrayProperty(xwindow_, "_NET_WM_STATE", &atom_list);
 
   bool was_minimized = IsMinimized();
+  bool was_maximized = IsMaximized();
 
   window_properties_.clear();
   std::copy(atom_list.begin(), atom_list.end(),
@@ -534,17 +536,23 @@ void X11WindowBase::OnWMStateUpdated() {
   // Propagate the window minimization information to the client.
   ui::PlatformWindowState state =
       ui::PlatformWindowState::PLATFORM_WINDOW_STATE_NORMAL;
-  if (IsMinimized() != was_minimized) {
-    if (IsMinimized()) {
-      state = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MINIMIZED;
-    } else if (IsMaximized()) {
-      // When the window is recovered from minimized state, set state to the
-      // previous maximized state if it was like that. Otherwise, NORMAL state
-      // will be set.
-      state = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MAXIMIZED;
-    }
+  if (IsMaximized())
+    state = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MAXIMIZED;
+  else if (IsMinimized())
+    state = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MINIMIZED;
+
+  // |restored_bounds_in_pixels_| can tell if the maximize/restore has been
+  // triggered by client or not. Typically, if it was the client who triggered
+  // that, |restored_bounds_in_pixels_| had values stored. Thus, we can be
+  // sure the client is not flooded with window states when the sources of a
+  // change has been the client itself.
+  if ((restored_bounds_in_pixels_.IsEmpty() &&
+       IsMaximized() != was_maximized) ||
+      IsMinimized() != was_minimized) {
     delegate_->OnWindowStateChanged(state);
   }
+
+  restored_bounds_in_pixels_ = gfx::Rect();
 }
 
 void X11WindowBase::BeforeActivationStateChanged() {

--- a/ui/views/mus/desktop_window_tree_host_mus.cc
+++ b/ui/views/mus/desktop_window_tree_host_mus.cc
@@ -219,6 +219,11 @@ DesktopWindowTreeHostMus::DesktopWindowTreeHostMus(
   // Widget. This call enables that.
   NativeWidgetAura::RegisterNativeWidgetForWindow(desktop_native_widget_aura,
                                                   window());
+
+#if defined(OS_LINUX) && defined(USE_OZONE) && !(OS_CHROMEOS)
+  window()->AddObserver(this);
+#endif
+
   // TODO: use display id and bounds if available, likely need to pass in
   // InitParams for that.
 }
@@ -316,6 +321,17 @@ bool DesktopWindowTreeHostMus::ShouldSendClientAreaToServer() const {
   using WIP = views::Widget::InitParams;
   const WIP::Type type = desktop_native_widget_aura_->widget_type();
   return type == WIP::TYPE_WINDOW || type == WIP::TYPE_PANEL;
+}
+
+void DesktopWindowTreeHostMus::Relayout() {
+  Widget* widget = native_widget_delegate_->AsWidget();
+  NonClientView* non_client_view = widget->non_client_view();
+  // non_client_view may be NULL, especially during creation.
+  if (non_client_view) {
+    non_client_view->client_view()->InvalidateLayout();
+    non_client_view->InvalidateLayout();
+  }
+  widget->GetRootView()->Layout();
 }
 
 void DesktopWindowTreeHostMus::Init(aura::Window* content_window,
@@ -842,10 +858,30 @@ void DesktopWindowTreeHostMus::OnActiveFocusClientChanged(
 void DesktopWindowTreeHostMus::OnWindowPropertyChanged(aura::Window* window,
                                                        const void* key,
                                                        intptr_t old) {
-  DCHECK_EQ(window, desktop_native_widget_aura_->content_window());
+  // Note that DesktopWindowTreeHostMus is subscribed for two aura::Windows:
+  // the root window, which is interested because of show state changes, and
+  // content window, which is a child of a root window and belongs to
+  // DesktopNativeWidgetAura.
+
   DCHECK(!window->GetRootWindow() || this->window() == window->GetRootWindow());
   if (!this->window())
     return;
+
+#if defined(OS_LINUX) && defined(USE_OZONE) && !(OS_CHROMEOS)
+  // In ozone, the widget's client and non-client views must be updated once the
+  // root window has its window state updated. Otherwise, once the host window
+  // manager updates the window state, the views are out-dated and do not
+  // correspond to actual state. So, update them here on every window state
+  // change happened with the root window. The behaviour of
+  // DesktopWindowTreeHostX11::OnWmStateChanged is actually copied here.
+  if (window->IsRootWindow() && window == this->window()) {
+    if (key == aura::client::kShowStateKey)
+      Relayout();
+    return;
+  }
+#endif
+
+  DCHECK_EQ(window, desktop_native_widget_aura_->content_window());
 
   // Allow mus clients to mirror widget window properties to their root windows.
   MusPropertyMirror* property_mirror = MusClient::Get()->mus_property_mirror();

--- a/ui/views/mus/desktop_window_tree_host_mus.h
+++ b/ui/views/mus/desktop_window_tree_host_mus.h
@@ -62,6 +62,12 @@ class VIEWS_MUS_EXPORT DesktopWindowTreeHostMus
   // Returns true if the client area should be set on this.
   bool ShouldSendClientAreaToServer() const;
 
+  // Relayout the widget's client and non-client views.
+  // TODO(msisov, tonikitoo): think how to share this with
+  // DesktopWindowTreeHostX11. These two have pointers to
+  // |native_widget_delegate_|.
+  void Relayout();
+
   // DesktopWindowTreeHost:
   void Init(aura::Window* content_window,
             const Widget::InitParams& params) override;


### PR DESCRIPTION
Make the opaque view layout to be updated once window states are
updated upon the host window manager events like if a user moves a window
in such a way so that it becomes automatically maximized or restored.
And then make DesktopWindowTreeHostMus to relayout the wdiget's 
client and non-client views so that those are updated.
    
In order to continue to avoid flooding aura, |restored_bounds_in_pixels_|
or |previous_bounds_in_pixels_| are tracked. If those are empty, then
it must be server, which triggered the change. Otherwise, it has been
the client and there is no need to flood it with states it already knows.


Issue #270