### PR TITLE
[ozone/linux] Default to built-in window decoration drawing

### DIFF
--- a/ui/views/mus/desktop_window_tree_host_mus.h
+++ b/ui/views/mus/desktop_window_tree_host_mus.h
@@ -167,7 +167,14 @@ class VIEWS_MUS_EXPORT DesktopWindowTreeHostMus
 
   std::unique_ptr<ui::EventHandler> non_client_window_event_filter_;
 
+  // In Ozone/Linux, it is not Ash who fills in window decoration
+  // (like in ChromeOS). Hence, we forcily disable 'auto_update_client_area_'
+  // in order to built-in window decorations to be provided.
+#if defined(OS_LINUX) && defined(USE_OZONE) && !defined(OS_CHROMEOS)
+  bool auto_update_client_area_ = false;
+#else
   bool auto_update_client_area_ = true;
+#endif
 
   // Used so that Close() isn't immediate.
   base::WeakPtrFactory<DesktopWindowTreeHostMus> close_widget_factory_;


### PR DESCRIPTION
In Ozone/Chrome, DesktopWindowTreeHostMus installs a basic
NonClientFrameView instance (ClientSideNonClientFrameView), and relies
on Ash to fill in its content. This is not the case of Ozone/Linux builds.

For Chrome window decoration we are fine, since BrowserFrame
reimplements ::CreateNonClientFrameView [1], but for other Widgets
(including TaskManager), we end up without a proper window decoration.

Patch defaults DesktopWindowTreeHostMus::auto_update_client_area_ to 'false'
in Ozone/Linux builds, so that built-in window decorations are provided.

Issue #260

[1] //chrome/browser/ui/views/frame/browser_frame.cc