### PR TITLE
[ozone/mus] Add support to create a new window by dragging a tab.

### DIFF
--- a/services/ui/public/interfaces/window_tree.mojom
+++ b/services/ui/public/interfaces/window_tree.mojom
@@ -320,12 +320,14 @@ interface WindowTree {
   // where the location is (x << 16) | y.
   GetCursorLocationMemory() => (handle<shared_buffer> cursor_buffer);
 
-  // Tells the window manager to start moving the window. OnChangeCompleted is
+  // Tells the (host) window manager to start moving the window. OnChangeCompleted is
   // called on whether the move was canceled. Because there's a delay between
   // when a client sends this message and when the window manager starts acting
-  // on it, pass the cursor location at the start of the move.
+  // on it, pass the cursor location at the start of the move. In external
+  // window move, |drag_offset| is passed to ozone backend for proper handling
+  // of the move loop.
   PerformWindowMove(uint32 change_id, uint32 window_id, MoveLoopSource source,
-                    gfx.mojom.Point cursor);
+                    gfx.mojom.Point cursor, gfx.mojom.Vector2d drag_offset);
                     
   // Tells the native window manager to start interactive move or resize of the
   // window. Once window's bounds are changed during the move or resize, those

--- a/services/ui/ws/external_window_access_policy.cc
+++ b/services/ui/ws/external_window_access_policy.cc
@@ -26,5 +26,10 @@ bool ExternalWindowAccessPolicy::CanSetWindowProperties(
          delegate_->HasRootForAccessPolicy(window);
 }
 
+bool ExternalWindowAccessPolicy::CanInitiateMoveLoop(
+    const ServerWindow* window) const {
+  return delegate_->HasRootForAccessPolicy(window);
+}
+
 }  // namespace ws
 }  // namespace ui

--- a/services/ui/ws/external_window_access_policy.h
+++ b/services/ui/ws/external_window_access_policy.h
@@ -25,6 +25,7 @@ class ExternalWindowAccessPolicy : public WindowManagerAccessPolicy {
   // WindowManagerAccessPolicy:
   bool CanSetWindowBounds(const ServerWindow* window) const override;
   bool CanSetWindowProperties(const ServerWindow* window) const override;
+  bool CanInitiateMoveLoop(const ServerWindow* window) const override;
 
   DISALLOW_COPY_AND_ASSIGN(ExternalWindowAccessPolicy);
 };

--- a/services/ui/ws/platform_display.cc
+++ b/services/ui/ws/platform_display.cc
@@ -34,5 +34,11 @@ std::unique_ptr<PlatformDisplay> PlatformDisplay::Create(
 #endif
 }
 
+bool PlatformDisplay::RunMoveLoop(const gfx::Vector2d& drag_offset) {
+  return false;
+}
+
+void PlatformDisplay::StopMoveLoop() {}
+
 }  // namespace ws
 }  // namespace ui

--- a/services/ui/ws/platform_display.h
+++ b/services/ui/ws/platform_display.h
@@ -96,6 +96,11 @@ class PlatformDisplay : public ui::EventSource {
   // the |hittest|.
   virtual void PerformNativeWindowDragOrResize(uint32_t hittest) {}
 
+  // Instantiates a move loop of a platform window.
+  virtual bool RunMoveLoop(const gfx::Vector2d& drag_offset);
+
+  virtual void StopMoveLoop();
+
  private:
   // Static factory instance (always NULL for non-test).
   static PlatformDisplayFactory* factory_;

--- a/services/ui/ws/platform_display_default.cc
+++ b/services/ui/ws/platform_display_default.cc
@@ -176,6 +176,14 @@ void PlatformDisplayDefault::PerformNativeWindowDragOrResize(uint32_t hittest) {
   platform_window_->ReleaseCapture();
 }
 
+bool PlatformDisplayDefault::RunMoveLoop(const gfx::Vector2d& drag_offset) {
+  return platform_window_->RunMoveLoop(drag_offset);
+}
+
+void PlatformDisplayDefault::StopMoveLoop() {
+  platform_window_->StopMoveLoop();
+}
+
 void PlatformDisplayDefault::SetCursor(const ui::CursorData& cursor_data) {
   if (!image_cursors_)
     return;

--- a/services/ui/ws/platform_display_default.h
+++ b/services/ui/ws/platform_display_default.h
@@ -61,6 +61,8 @@ class PlatformDisplayDefault : public PlatformDisplay,
   void SetNativeWindowState(ui::mojom::ShowState state) override;
   void GetWindowType(PlatformWindowType* window_type) override;
   void PerformNativeWindowDragOrResize(uint32_t hittest) override;
+  bool RunMoveLoop(const gfx::Vector2d& drag_offset) override;
+  void StopMoveLoop() override;
 
  private:
   // ui::PlatformWindowDelegate:

--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -28,6 +28,7 @@
 #include "services/ui/ws/window_tree.h"
 #include "services/ui/ws/window_tree_binding.h"
 #include "ui/gfx/geometry/size_conversions.h"
+#include "services/ui/ws/platform_display_default.h"
 
 namespace ui {
 namespace ws {
@@ -507,16 +508,42 @@ void WindowServer::SetPaintCallback(
   window_paint_callback_ = callback;
 }
 
-void WindowServer::StartMoveLoop(uint32_t change_id,
+bool WindowServer::StartMoveLoop(uint32_t change_id,
                                  ServerWindow* window,
                                  WindowTree* initiator,
-                                 const gfx::Rect& revert_bounds) {
+                                 const gfx::Rect& revert_bounds,
+                                 const gfx::Vector2d& drag_offset) {
   current_move_loop_.reset(
       new CurrentMoveLoopState{change_id, window, initiator, revert_bounds});
+
+  bool result = false;
+  if (IsInExternalWindowMode()) {
+    PlatformDisplay* display =
+        GetPlatformDisplayOfVisibleRoot(current_move_loop_->window);
+    if (display)
+      result = display->RunMoveLoop(drag_offset);
+  }
+  return result;
 }
 
 void WindowServer::EndMoveLoop() {
+  if (IsInExternalWindowMode() && current_move_loop_) {
+    PlatformDisplay* display =
+        GetPlatformDisplayOfVisibleRoot(current_move_loop_->window);
+    if (display)
+      display->StopMoveLoop();
+  }
   current_move_loop_.reset();
+}
+
+PlatformDisplay* WindowServer::GetPlatformDisplayOfVisibleRoot(
+    const ServerWindow* window) {
+  WindowManagerDisplayRoot* display_root =
+      display_manager_->GetWindowManagerDisplayRoot(window);
+  PlatformDisplay* display = nullptr;
+  if (display_root && display_root->GetClientVisibleRoot() == window)
+    display = display_root->display()->platform_display();
+  return display;
 }
 
 uint32_t WindowServer::GetCurrentMoveLoopChangeId() {

--- a/services/ui/ws/window_server.h
+++ b/services/ui/ws/window_server.h
@@ -37,6 +37,7 @@ class AccessPolicy;
 class Display;
 class DisplayManager;
 class GpuHost;
+class PlatformDisplay;
 class ServerWindow;
 class ThreadedImageCursorsFactory;
 class UserActivityMonitor;
@@ -227,10 +228,11 @@ class WindowServer : public ServerWindowDelegate,
   // a [re]paint. This should only be called in a test configuration.
   void SetPaintCallback(const base::Callback<void(ServerWindow*)>& callback);
 
-  void StartMoveLoop(uint32_t change_id,
+  bool StartMoveLoop(uint32_t change_id,
                      ServerWindow* window,
                      WindowTree* initiator,
-                     const gfx::Rect& revert_bounds);
+                     const gfx::Rect& revert_bounds,
+                     const gfx::Vector2d& drag_offset);
   void EndMoveLoop();
   uint32_t GetCurrentMoveLoopChangeId();
   ServerWindow* GetCurrentMoveLoopWindow();
@@ -383,6 +385,8 @@ class WindowServer : public ServerWindowDelegate,
                              const UserId& active_id) override;
   void OnUserIdAdded(const UserId& id) override;
   void OnUserIdRemoved(const UserId& id) override;
+
+  PlatformDisplay* GetPlatformDisplayOfVisibleRoot(const ServerWindow* window);
 
   UserIdTracker user_id_tracker_;
 

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -2442,13 +2442,13 @@ void WindowTree::CancelDragDrop(Id window_id) {
   wms->CancelDragDrop();
 }
 
-void WindowTree::PerformWindowMove(uint32_t change_id,
-                                   Id window_id,
-                                   ui::mojom::MoveLoopSource source,
-                                   const gfx::Point& cursor) {
+void WindowTree::PerformWindowMove(uint32_t change_id, Id window_id,
+    ui::mojom::MoveLoopSource source, const gfx::Point& cursor,
+    const gfx::Vector2d& drag_offset) {
   ServerWindow* window = GetWindowByClientId(MakeClientWindowId(window_id));
   bool success = window && access_policy_->CanInitiateMoveLoop(window);
-  if (!success || !ShouldRouteToWindowManager(window)) {
+  if (!success || (!ShouldRouteToWindowManager(window) &&
+                   !window_server_->IsInExternalWindowMode())) {
     // We need to fail this move loop change, otherwise the client will just be
     // waiting for |change_id|.
     DVLOG(1) << "PerformWindowMove failed (access denied)";
@@ -2472,6 +2472,19 @@ void WindowTree::PerformWindowMove(uint32_t change_id,
     return;
   }
 
+  const uint32_t wm_change_id =
+      window_server_->IsInExternalWindowMode()
+          ? change_id
+          : window_server_->GenerateWindowManagerChangeId(this, change_id);
+  bool result = window_server_->StartMoveLoop(wm_change_id, window, this,
+                                              window->bounds(), drag_offset);
+
+  if (window_server_->IsInExternalWindowMode()) {
+    window_server_->EndMoveLoop();
+    OnChangeCompleted(change_id, result);
+    return;
+  }
+
   // When we perform a window move loop, we give the window manager non client
   // capture. Because of how the capture public interface currently works,
   // SetCapture() will check whether the mouse cursor is currently in the
@@ -2479,10 +2492,6 @@ void WindowTree::PerformWindowMove(uint32_t change_id,
   // manager. (And normal window movement relies on this behaviour.)
   WindowManagerState* wms = display_root->window_manager_state();
   wms->SetCapture(window, wms->window_tree()->id());
-
-  const uint32_t wm_change_id =
-      window_server_->GenerateWindowManagerChangeId(this, change_id);
-  window_server_->StartMoveLoop(wm_change_id, window, this, window->bounds());
   wms->window_tree()->window_manager_internal_->WmPerformMoveLoop(
       wm_change_id, wms->window_tree()->TransportIdForWindow(window), source,
       cursor);
@@ -2532,6 +2541,11 @@ void WindowTree::CancelWindowMove(Id window_id) {
   WindowManagerDisplayRoot* display_root = GetWindowManagerDisplayRoot(window);
   if (!display_root) {
     DVLOG(1) << "CancelWindowMove failed (no such window manager display root)";
+    return;
+  }
+
+  if (window_server_->IsInExternalWindowMode()) {
+    window_server()->EndMoveLoop();
     return;
   }
 

--- a/services/ui/ws/window_tree.h
+++ b/services/ui/ws/window_tree.h
@@ -597,7 +597,8 @@ class WindowTree : public mojom::WindowTree,
   void PerformWindowMove(uint32_t change_id,
                          Id window_id,
                          ui::mojom::MoveLoopSource source,
-                         const gfx::Point& cursor) override;
+                         const gfx::Point& cursor,
+                         const gfx::Vector2d& drag_offset) override;
   void PerformNativeWindowDragOrResize(Id window_id, uint32_t hittest) override;
   void CancelWindowMove(Id window_id) override;
 

--- a/services/ui/ws/window_tree_unittest.cc
+++ b/services/ui/ws/window_tree_unittest.cc
@@ -1273,7 +1273,7 @@ TEST_F(WindowTreeTest, ValidMoveLoopWithWM) {
       ->PerformWindowMove(
           change_id,
           child_tree->ClientWindowIdToTransportId(embed_window_id2_in_child),
-          mojom::MoveLoopSource::MOUSE, gfx::Point(0, 0));
+          mojom::MoveLoopSource::MOUSE, gfx::Point(0, 0), gfx::Vector2d());
 
   EXPECT_TRUE(wm_internal.on_perform_move_loop_called());
 }
@@ -1325,7 +1325,7 @@ TEST_F(WindowTreeTest, MoveLoopAckOKByWM) {
       ->PerformWindowMove(
           change_id,
           child_tree->ClientWindowIdToTransportId(embed_window_id2_in_child),
-          mojom::MoveLoopSource::MOUSE, gfx::Point(0, 0));
+          mojom::MoveLoopSource::MOUSE, gfx::Point(0, 0), gfx::Vector2d());
 
   // There should be three changes, the first two relating to capture changing,
   // the last for the completion.
@@ -1383,7 +1383,7 @@ TEST_F(WindowTreeTest, WindowManagerCantMoveLoop) {
   const uint32_t change_id = 7;
   static_cast<mojom::WindowTree*>(wm_tree())->PerformWindowMove(
       change_id, wm_tree()->ClientWindowIdToTransportId(embed_window_id2),
-      mojom::MoveLoopSource::MOUSE, gfx::Point(0, 0));
+      mojom::MoveLoopSource::MOUSE, gfx::Point(0, 0), gfx::Vector2d());
 
   EXPECT_FALSE(wm_internal.on_perform_move_loop_called());
 }
@@ -1434,7 +1434,7 @@ TEST_F(WindowTreeTest, RevertWindowBoundsOnMoveLoopFailure) {
       ->PerformWindowMove(
           change_id,
           child_tree->ClientWindowIdToTransportId(embed_window_id2_in_child),
-          mojom::MoveLoopSource::MOUSE, gfx::Point(0, 0));
+          mojom::MoveLoopSource::MOUSE, gfx::Point(0, 0), gfx::Vector2d());
 
   ServerWindow* server_window =
       wm_tree()->GetWindowByClientId(embed_window_id2);
@@ -1464,7 +1464,7 @@ TEST_F(WindowTreeTest, InvalidMoveLoopStillAcksAttempt) {
   const Id kInvalidWindowId = 1234567890;
   static_cast<mojom::WindowTree*>(tree)->PerformWindowMove(
       kChangeId, kInvalidWindowId, mojom::MoveLoopSource::MOUSE,
-      gfx::Point(0, 0));
+      gfx::Point(0, 0), gfx::Vector2d());
 
   EXPECT_EQ("ChangeCompleted id=8 sucess=false",
             SingleChangeToDescription(*embed_client->tracker()->changes()));

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -2295,6 +2295,7 @@ void WindowTreeClient::OnWindowTreeHostPerformWindowMove(
     WindowTreeHostMus* window_tree_host,
     ui::mojom::MoveLoopSource source,
     const gfx::Point& cursor_location,
+    const gfx::Vector2d& drag_offset,
     const base::Callback<void(bool)>& callback) {
   DCHECK(on_current_move_finished_.is_null());
   on_current_move_finished_ = callback;
@@ -2304,7 +2305,7 @@ void WindowTreeClient::OnWindowTreeHostPerformWindowMove(
       std::make_unique<InFlightDragChange>(window_mus, ChangeType::MOVE_LOOP));
   // Tell the window manager to take over moving us.
   tree_->PerformWindowMove(current_move_loop_change_, window_mus->server_id(),
-                           source, cursor_location);
+                           source, cursor_location, drag_offset);
 }
 
 void WindowTreeClient::OnWindowTreeHostPerformNativeWindowDragOrResize(

--- a/ui/aura/mus/window_tree_client.h
+++ b/ui/aura/mus/window_tree_client.h
@@ -561,6 +561,7 @@ class AURA_EXPORT WindowTreeClient
       WindowTreeHostMus* window_tree_host,
       ui::mojom::MoveLoopSource mus_source,
       const gfx::Point& cursor_location,
+      const gfx::Vector2d& drag_offset,
       const base::Callback<void(bool)>& callback) override;
   void OnWindowTreeHostPerformNativeWindowDragOrResize(
       WindowTreeHostMus* window_tree_host,

--- a/ui/aura/mus/window_tree_host_mus.cc
+++ b/ui/aura/mus/window_tree_host_mus.cc
@@ -155,9 +155,10 @@ void WindowTreeHostMus::StackAtTop() {
 void WindowTreeHostMus::PerformWindowMove(
     ui::mojom::MoveLoopSource mus_source,
     const gfx::Point& cursor_location,
+    const gfx::Vector2d& drag_offset,
     const base::Callback<void(bool)>& callback) {
   delegate_->OnWindowTreeHostPerformWindowMove(
-      this, mus_source, cursor_location, callback);
+      this, mus_source, cursor_location, drag_offset, callback);
 }
 
 void WindowTreeHostMus::PerformNativeWindowDragOrResize(int hittest) {

--- a/ui/aura/mus/window_tree_host_mus.h
+++ b/ui/aura/mus/window_tree_host_mus.h
@@ -72,6 +72,7 @@ class AURA_EXPORT WindowTreeHostMus : public aura::WindowTreeHostPlatform {
   // true if the move wasn't canceled.
   void PerformWindowMove(ui::mojom::MoveLoopSource mus_source,
                          const gfx::Point& cursor_location,
+                         const gfx::Vector2d& drag_offset,
                          const base::Callback<void(bool)>& callback);
 
   // Tells the native window manager to start interactive drag or resize of a

--- a/ui/aura/mus/window_tree_host_mus_delegate.h
+++ b/ui/aura/mus/window_tree_host_mus_delegate.h
@@ -65,6 +65,7 @@ class AURA_EXPORT WindowTreeHostMusDelegate {
       WindowTreeHostMus* window_tree_host,
       ui::mojom::MoveLoopSource mus_source,
       const gfx::Point& cursor_location,
+      const gfx::Vector2d& drag_offset,
       const base::Callback<void(bool)>& callback) = 0;
 
   // Called to tell the native window manager to start interactive drag or

--- a/ui/aura/test/mus/test_window_tree.cc
+++ b/ui/aura/test/mus/test_window_tree.cc
@@ -327,10 +327,10 @@ void TestWindowTree::PerformDragDrop(
 
 void TestWindowTree::CancelDragDrop(uint32_t window_id) {}
 
-void TestWindowTree::PerformWindowMove(uint32_t change_id,
-                                       uint32_t window_id,
+void TestWindowTree::PerformWindowMove(uint32_t change_id, uint32_t window_id,
                                        ui::mojom::MoveLoopSource source,
-                                       const gfx::Point& cursor_location) {
+                                       const gfx::Point& cursor_location,
+                                       const gfx::Vector2d& drag_offset) {
   OnChangeReceived(change_id);
 }
 

--- a/ui/aura/test/mus/test_window_tree.h
+++ b/ui/aura/test/mus/test_window_tree.h
@@ -228,7 +228,8 @@ class TestWindowTree : public ui::mojom::WindowTree {
   void PerformWindowMove(uint32_t change_id,
                          uint32_t window_id,
                          ui::mojom::MoveLoopSource source,
-                         const gfx::Point& cursor_location) override;
+                         const gfx::Point& cursor_location,
+                         const gfx::Vector2d& drag_offset) override;
   void PerformNativeWindowDragOrResize(Id window_id, uint32_t hittest) override;
   void CancelWindowMove(uint32_t window_id) override;
 

--- a/ui/ozone/platform/headless/headless_window.cc
+++ b/ui/ozone/platform/headless/headless_window.cc
@@ -78,4 +78,10 @@ PlatformImeController* HeadlessWindow::GetPlatformImeController() {
 
 void HeadlessWindow::PerformNativeWindowDragOrResize(uint32_t hittest) {}
 
+bool HeadlessWindow::RunMoveLoop(const gfx::Vector2d& drag_offset) {
+  return false;
+}
+
+void HeadlessWindow::StopMoveLoop() {}
+
 }  // namespace ui

--- a/ui/ozone/platform/headless/headless_window.h
+++ b/ui/ozone/platform/headless/headless_window.h
@@ -45,6 +45,8 @@ class HeadlessWindow : public PlatformWindow {
   void ConfineCursorToBounds(const gfx::Rect& bounds) override;
   PlatformImeController* GetPlatformImeController() override;
   void PerformNativeWindowDragOrResize(uint32_t hittest) override;
+  bool RunMoveLoop(const gfx::Vector2d& drag_offset) override;
+  void StopMoveLoop() override;
 
  private:
   PlatformWindowDelegate* delegate_;

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -338,6 +338,12 @@ void WaylandWindow::PerformNativeWindowDragOrResize(uint32_t hittest) {
     xdg_surface_->SurfaceResize(connection_, hittest);
 }
 
+bool WaylandWindow::RunMoveLoop(const gfx::Vector2d& drag_offset) {
+  return true;
+}
+
+void WaylandWindow::StopMoveLoop() {}
+
 bool WaylandWindow::CanDispatchEvent(const PlatformEvent& native_event) {
   if (HasCapture())
     return true;

--- a/ui/ozone/platform/wayland/wayland_window.h
+++ b/ui/ozone/platform/wayland/wayland_window.h
@@ -86,6 +86,8 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
   void ConfineCursorToBounds(const gfx::Rect& bounds) override;
   PlatformImeController* GetPlatformImeController() override;
   void PerformNativeWindowDragOrResize(uint32_t hittest) override;
+  bool RunMoveLoop(const gfx::Vector2d& drag_offset) override;
+  void StopMoveLoop() override;
 
   // PlatformEventDispatcher
   bool CanDispatchEvent(const PlatformEvent& event) override;

--- a/ui/platform_window/BUILD.gn
+++ b/ui/platform_window/BUILD.gn
@@ -19,6 +19,15 @@ source_set("platform_window") {
     "//ui/base/ime:text_input_types",
     "//ui/gfx",
   ]
+
+  if (use_ozone && !is_chromeos) {
+    sources += [
+      "whole_screen_move_loop.cc",
+      "whole_screen_move_loop.h",
+      "window_move_loop_client.cc",
+      "window_move_loop_client.h",
+    ]
+  }
 }
 
 group("platform_impls") {

--- a/ui/platform_window/platform_window.h
+++ b/ui/platform_window/platform_window.h
@@ -66,6 +66,11 @@ class PlatformWindow {
   // The window manager starts interactive drag or resize of a window based on
   // the |hittest|.
   virtual void PerformNativeWindowDragOrResize(uint32_t hittest) = 0;
+
+  // Asks to window move client to start move loop.
+  virtual bool RunMoveLoop(const gfx::Vector2d& drag_offset) = 0;
+
+  virtual void StopMoveLoop() = 0;
 };
 
 }  // namespace ui

--- a/ui/platform_window/stub/stub_window.cc
+++ b/ui/platform_window/stub/stub_window.cc
@@ -80,4 +80,10 @@ PlatformImeController* StubWindow::GetPlatformImeController() {
 
 void StubWindow::PerformNativeWindowDragOrResize(uint32_t hittest) {}
 
+bool StubWindow::RunMoveLoop(const gfx::Vector2d& drag_offset) {
+  return false;
+}
+
+void StubWindow::StopMoveLoop() {}
+
 }  // namespace ui

--- a/ui/platform_window/stub/stub_window.h
+++ b/ui/platform_window/stub/stub_window.h
@@ -45,6 +45,8 @@ class STUB_WINDOW_EXPORT StubWindow : public PlatformWindow {
   void ConfineCursorToBounds(const gfx::Rect& bounds) override;
   PlatformImeController* GetPlatformImeController() override;
   void PerformNativeWindowDragOrResize(uint32_t hittest) override;
+  bool RunMoveLoop(const gfx::Vector2d& drag_offset) override;
+  void StopMoveLoop() override;
 
   PlatformWindowDelegate* delegate_;
   gfx::Rect bounds_;

--- a/ui/platform_window/whole_screen_move_loop.cc
+++ b/ui/platform_window/whole_screen_move_loop.cc
@@ -1,0 +1,236 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/platform_window/whole_screen_move_loop.h"
+
+#include "ui/platform_window/window_move_loop_client.h"
+
+#include <stddef.h>
+#include <X11/keysym.h>
+#include <X11/Xlib.h>
+#include <utility>
+
+#include "base/bind.h"
+#include "base/logging.h"
+#include "base/macros.h"
+#include "base/message_loop/message_loop.h"
+#include "base/run_loop.h"
+#include "base/single_thread_task_runner.h"
+#include "base/threading/thread_task_runner_handle.h"
+#include "ui/aura/client/capture_client.h"
+#include "ui/aura/env.h"
+#include "ui/aura/window.h"
+#include "ui/aura/window_event_dispatcher.h"
+#include "ui/aura/window_tree_host.h"
+#include "ui/base/x/x11_pointer_grab.h"
+#include "ui/base/x/x11_util.h"
+#include "ui/base/x/x11_window_event_manager.h"
+#include "ui/events/event.h"
+#include "ui/events/event_utils.h"
+#include "ui/events/keycodes/keyboard_code_conversion_x.h"
+#include "ui/events/ozone/events_ozone.h"
+#include "ui/events/platform/platform_event_source.h"
+#include "ui/events/platform/scoped_event_dispatcher.h"
+#include "ui/events/platform/x11/x11_event_source.h"
+#include "ui/events/platform/x11/x11_event_source_libevent.h"
+#include "ui/platform_window/platform_window_delegate.h"
+
+namespace ui {
+
+// XGrabKey requires the modifier mask to explicitly be specified.
+const unsigned int kModifiersMasks[] = {
+  0,                                // No additional modifier.
+  Mod2Mask,                         // Num lock
+  LockMask,                         // Caps lock
+  Mod5Mask,                         // Scroll lock
+  Mod2Mask | LockMask,
+  Mod2Mask | Mod5Mask,
+  LockMask | Mod5Mask,
+  Mod2Mask | LockMask | Mod5Mask
+};
+
+WholeScreenMoveLoop::WholeScreenMoveLoop(views::X11MoveLoopDelegate* delegate)
+    : delegate_(delegate),
+      in_move_loop_(false),
+      grab_input_window_(None),
+      grabbed_pointer_(false),
+      canceled_(false),
+      weak_factory_(this) {}
+
+WholeScreenMoveLoop::~WholeScreenMoveLoop() {}
+
+void WholeScreenMoveLoop::DispatchMouseMovement() {
+  if (!last_motion_in_screen_ && !last_motion_in_screen_->IsLocatedEvent())
+    return;
+  delegate_->OnMouseMovement(last_motion_in_screen_->AsLocatedEvent()->location(),
+                             last_motion_in_screen_->flags(),
+                             last_motion_in_screen_->time_stamp());
+  last_motion_in_screen_.reset();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// DesktopWindowTreeHostLinux, ui::PlatformEventDispatcher implementation:
+
+bool WholeScreenMoveLoop::CanDispatchEvent(const ui::PlatformEvent& event) {
+  return in_move_loop_;
+}
+
+uint32_t WholeScreenMoveLoop::DispatchEvent(
+    const ui::PlatformEvent& platform_event) {
+  DCHECK(base::MessageLoopForUI::IsCurrent());
+
+  // This method processes all events while the move loop is active.
+  if (!in_move_loop_)
+    return ui::POST_DISPATCH_PERFORM_DEFAULT;
+
+  auto* ewpe = static_cast<EventWithPlatformEvent*>(platform_event);
+  auto* event = static_cast<ui::Event*>(ewpe->event);
+  switch (event->type()) {
+    case ui::ET_MOUSE_MOVED:
+    case ui::ET_MOUSE_DRAGGED: {
+      bool can_send = !last_motion_in_screen_.get();
+
+      ui::MouseEvent* mouse_event = event->AsMouseEvent();
+      gfx::Point root_location = mouse_event->root_location();
+      mouse_event->set_location(root_location);
+
+      last_motion_in_screen_ = ui::Event::Clone(*event);
+      DCHECK(last_motion_in_screen_->IsMouseEvent());
+
+      if (can_send)
+        DispatchMouseMovement();
+      return ui::POST_DISPATCH_PERFORM_DEFAULT;
+    }
+    case ui::ET_MOUSE_RELEASED: {
+      ui::MouseEvent* mouse_event = event->AsMouseEvent();
+      gfx::Point root_location = mouse_event->root_location();
+      mouse_event->set_location(root_location);
+
+      last_motion_in_screen_ = ui::Event::Clone(*event);
+      DCHECK(last_motion_in_screen_->IsMouseEvent());
+
+      EndMoveLoop();
+      return ui::POST_DISPATCH_PERFORM_DEFAULT;
+    }
+    case ui::ET_KEY_PRESSED:
+      canceled_ = true;
+      EndMoveLoop();
+      return ui::POST_DISPATCH_NONE;
+    default:
+      break;
+  }
+  return ui::POST_DISPATCH_PERFORM_DEFAULT;
+}
+
+bool WholeScreenMoveLoop::RunMoveLoop() {
+  DCHECK(!in_move_loop_);  // Can only handle one nested loop at a time.
+
+  CreateDragInputWindow(gfx::GetXDisplay());
+
+  if (!GrabPointer()) {
+    XDestroyWindow(gfx::GetXDisplay(), grab_input_window_);
+    CHECK(false) << "failed to grab pointer";
+    return false;
+  }
+
+  GrabEscKey();
+
+  std::unique_ptr<ui::ScopedEventDispatcher> old_dispatcher =
+      std::move(nested_dispatcher_);
+  nested_dispatcher_ =
+      ui::PlatformEventSource::GetInstance()->OverrideDispatcher(this);
+
+  base::WeakPtr<WholeScreenMoveLoop> alive(weak_factory_.GetWeakPtr());
+
+  in_move_loop_ = true;
+  canceled_ = false;
+  base::MessageLoopForUI* loop = base::MessageLoopForUI::current();
+  base::MessageLoop::ScopedNestableTaskAllower allow_nested(loop);
+  base::RunLoop run_loop;
+  quit_closure_ = run_loop.QuitClosure();
+  run_loop.Run();
+
+  if (!alive)
+    return false;
+
+  nested_dispatcher_ = std::move(old_dispatcher);
+  return !canceled_;
+}
+
+void WholeScreenMoveLoop::UpdateCursor() {}
+
+void WholeScreenMoveLoop::EndMoveLoop() {
+  if (!in_move_loop_)
+    return;
+
+  // Prevent DispatchMouseMovement from dispatching any posted motion event.
+  last_motion_in_screen_.reset();
+
+  // TODO(erg): Is this ungrab the cause of having to click to give input focus
+  // on drawn out windows? Not ungrabbing here screws the X server until I kill
+  // the chrome process.
+
+  // Ungrab before we let go of the window.
+  if (grabbed_pointer_)
+    ui::UngrabPointer();
+  else
+    UpdateCursor();
+
+  XDisplay* display = gfx::GetXDisplay();
+  unsigned int esc_keycode = XKeysymToKeycode(display, XK_Escape);
+  for (size_t i = 0; i < arraysize(kModifiersMasks); ++i) {
+    XUngrabKey(display, esc_keycode, kModifiersMasks[i], grab_input_window_);
+  }
+
+  // Restore the previous dispatcher.
+  nested_dispatcher_.reset();
+  grab_input_window_events_.reset();
+  XDestroyWindow(display, grab_input_window_);
+  grab_input_window_ = None;
+  in_move_loop_ = false;
+  quit_closure_.Run();
+}
+
+bool WholeScreenMoveLoop::GrabPointer() {
+  XDisplay* display = gfx::GetXDisplay();
+
+  // Pass "owner_events" as false so that X sends all mouse events to
+  // |grab_input_window_|.
+  int ret = ui::GrabPointer(grab_input_window_, false, None);
+  if (ret != GrabSuccess) {
+    DLOG(ERROR) << "Grabbing pointer for dragging failed: "
+                << ui::GetX11ErrorString(display, ret);
+  }
+  XFlush(display);
+  return ret == GrabSuccess;
+}
+
+void WholeScreenMoveLoop::GrabEscKey() {
+  XDisplay* display = gfx::GetXDisplay();
+  unsigned int esc_keycode = XKeysymToKeycode(display, XK_Escape);
+  for (size_t i = 0; i < arraysize(kModifiersMasks); ++i) {
+    XGrabKey(display, esc_keycode, kModifiersMasks[i], grab_input_window_,
+             False, GrabModeAsync, GrabModeAsync);
+  }
+}
+
+void WholeScreenMoveLoop::CreateDragInputWindow(XDisplay* display) {
+  unsigned long attribute_mask = CWEventMask | CWOverrideRedirect;
+  XSetWindowAttributes swa;
+  memset(&swa, 0, sizeof(swa));
+  swa.override_redirect = True;
+  grab_input_window_ = XCreateWindow(display, DefaultRootWindow(display), -100,
+                                     -100, 10, 10, 0, CopyFromParent, InputOnly,
+                                     CopyFromParent, attribute_mask, &swa);
+  uint32_t event_mask = ButtonPressMask | ButtonReleaseMask |
+                        PointerMotionMask | KeyPressMask | KeyReleaseMask |
+                        StructureNotifyMask;
+  grab_input_window_events_.reset(
+      new ui::XScopedEventSelector(grab_input_window_, event_mask));
+
+  XMapRaised(display, grab_input_window_);
+  ui::X11EventSource::GetInstance()->BlockUntilWindowMapped(grab_input_window_);
+}
+
+}  // namespace ui

--- a/ui/platform_window/whole_screen_move_loop.h
+++ b/ui/platform_window/whole_screen_move_loop.h
@@ -1,0 +1,90 @@
+// Copyright (c) 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_PLATFORM_WINDOW_WHOLE_SCREEN_MOVE_LOOP_H_
+#define UI_PLATFORM_WINDOW_WHOLE_SCREEN_MOVE_LOOP_H_
+
+#include <stdint.h>
+
+#include "base/callback.h"
+#include "base/compiler_specific.h"
+#include "base/macros.h"
+#include "base/memory/weak_ptr.h"
+#include "ui/base/cursor/cursor.h"
+#include "ui/events/platform/platform_event_dispatcher.h"
+#include "ui/gfx/geometry/vector2d_f.h"
+#include "ui/gfx/image/image_skia.h"
+#include "ui/gfx/native_widget_types.h"
+#include "ui/gfx/x/x11_types.h"
+#include "ui/views/widget/desktop_aura/x11_move_loop.h"
+#include "ui/views/widget/desktop_aura/x11_move_loop_delegate.h"
+
+
+
+namespace ui {
+class MouseEvent;
+class ScopedEventDispatcher;
+class XScopedEventSelector;
+class PlatformWindowDelegate;
+
+// Runs a nested run loop and grabs the mouse. This is used to implement
+// dragging.
+class WholeScreenMoveLoop : public ui::PlatformEventDispatcher {
+ public:
+  explicit WholeScreenMoveLoop(views::X11MoveLoopDelegate* delegate);
+  ~WholeScreenMoveLoop() override;
+
+  // ui:::PlatformEventDispatcher:
+  bool CanDispatchEvent(const ui::PlatformEvent& event) override;
+  uint32_t DispatchEvent(const ui::PlatformEvent& platform_event) override;
+
+  // X11MoveLoop:
+  bool RunMoveLoop();
+  void UpdateCursor();
+  void EndMoveLoop();
+
+ private:
+  // Grabs the pointer, setting the mouse cursor to |cursor|. Returns true if
+  // successful.
+  bool GrabPointer();
+
+  void GrabEscKey();
+
+  // Creates an input-only window to be used during the drag.
+  void CreateDragInputWindow(XDisplay* display);
+
+  // Dispatch mouse movement event to |delegate_| in a posted task.
+  void DispatchMouseMovement();
+
+  views::X11MoveLoopDelegate* delegate_;
+
+  // Are we running a nested run loop from RunMoveLoop()?
+  bool in_move_loop_;
+  std::unique_ptr<ui::ScopedEventDispatcher> nested_dispatcher_;
+
+  // An invisible InputOnly window. Keyboard grab and sometimes mouse grab
+  // are set on this window.
+  XID grab_input_window_;
+
+  // Events selected on |grab_input_window_|.
+  std::unique_ptr<ui::XScopedEventSelector> grab_input_window_events_;
+
+  // Whether the pointer was grabbed on |grab_input_window_|.
+  bool grabbed_pointer_;
+
+  base::Closure quit_closure_;
+
+  // Keeps track of whether the move-loop is cancled by the user (e.g. by
+  // pressing escape).
+  bool canceled_;
+
+  std::unique_ptr<ui::Event> last_motion_in_screen_;
+  base::WeakPtrFactory<WholeScreenMoveLoop> weak_factory_;
+
+  DISALLOW_COPY_AND_ASSIGN(WholeScreenMoveLoop);
+};
+
+}  // namespace ui
+
+#endif  // UI_PLATFORM_WINDOW_WHOLE_SCREEN_MOVE_LOOP_H_

--- a/ui/platform_window/window_move_loop_client.cc
+++ b/ui/platform_window/window_move_loop_client.cc
@@ -1,0 +1,59 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/platform_window/window_move_loop_client.h"
+
+#include <X11/Xlib.h>
+
+#include "base/debug/stack_trace.h"
+#include "base/message_loop/message_loop.h"
+#include "base/run_loop.h"
+#include "ui/aura/env.h"
+#include "ui/aura/window.h"
+#include "ui/aura/window_tree_host.h"
+#include "ui/base/x/x11_util.h"
+#include "ui/events/event.h"
+
+#include "ui/platform_window/platform_window.h"
+
+namespace ui {
+
+WindowMoveLoopClient::WindowMoveLoopClient()
+    : move_loop_(this), window_(nullptr) {
+}
+
+WindowMoveLoopClient::~WindowMoveLoopClient() {}
+
+void WindowMoveLoopClient::OnMouseMovement(const gfx::Point& screen_point,
+                                           int flags,
+                                           base::TimeTicks event_time) {
+  gfx::Point system_loc = screen_point - window_offset_;
+  window_->SetBounds(gfx::Rect(system_loc, gfx::Size()));
+}
+
+void WindowMoveLoopClient::OnMouseReleased() {
+  EndMoveLoop();
+}
+
+void WindowMoveLoopClient::OnMoveLoopEnded() {
+  window_ = nullptr;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// DesktopWindowTreeHostLinux, wm::WindowMoveClient implementation:
+
+bool WindowMoveLoopClient::RunMoveLoop(PlatformWindow* window,
+                                       const gfx::Vector2d& drag_offset) {
+  window_offset_ = drag_offset;
+  window_ = window;
+  window_->SetCapture();
+  return move_loop_.RunMoveLoop();
+}
+
+void WindowMoveLoopClient::EndMoveLoop() {
+  window_->ReleaseCapture();
+  move_loop_.EndMoveLoop();
+}
+
+}  // namespace ui

--- a/ui/platform_window/window_move_loop_client.h
+++ b/ui/platform_window/window_move_loop_client.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_PLATFORM_WINDOW_WINDOW_MOVE_LOOP_CLIENT_H_
+#define UI_PLATFORM_WINDOW_WINDOW_MOVE_LOOP_CLIENT_H_
+
+#include <X11/Xlib.h>
+
+#include "base/callback.h"
+#include "base/compiler_specific.h"
+#include "base/message_loop/message_loop.h"
+#include "ui/gfx/geometry/point.h"
+#include "ui/views/views_export.h"
+#include "ui/platform_window/whole_screen_move_loop.h"
+#include "ui/wm/public/window_move_client.h"
+
+namespace ui {
+
+class PlatformWindow;
+
+// When we're dragging tabs, we need to manually position our window.
+class WindowMoveLoopClient : public views::X11MoveLoopDelegate {
+ public:
+  WindowMoveLoopClient();
+  ~WindowMoveLoopClient() override;
+
+  // Overridden from X11MoveLoopDelegate:
+  void OnMouseMovement(const gfx::Point& screen_point,
+                       int flags,
+                       base::TimeTicks event_time) override;
+  void OnMouseReleased() override;
+  void OnMoveLoopEnded() override;
+
+  bool RunMoveLoop(PlatformWindow* window, const gfx::Vector2d& drag_offset);  
+  void EndMoveLoop();
+
+ private:
+  WholeScreenMoveLoop move_loop_;
+
+  // We need to keep track of this so we can actually move it when reacting to
+  // mouse events.
+  PlatformWindow* window_;
+
+  // Our cursor offset from the top left window origin when the drag
+  // started. Used to calculate the window's new bounds relative to the current
+  // location of the cursor.
+  gfx::Vector2d window_offset_;
+};
+
+}  // namespace ui
+
+#endif  // UI_PLATFORM_WINDOW_WINDOW_MOVE_LOOP_CLIENT_H_

--- a/ui/platform_window/x11/x11_window_base.cc
+++ b/ui/platform_window/x11/x11_window_base.cc
@@ -278,7 +278,7 @@ void X11WindowBase::SetBounds(const gfx::Rect& bounds) {
     XWindowChanges changes = {0};
     unsigned value_mask = 0;
 
-    if (bounds_.size() != bounds.size()) {
+    if (!bounds.size().IsEmpty() && bounds_.size() != bounds.size()) {
       changes.width = bounds.width();
       changes.height = bounds.height();
       value_mask |= CWHeight | CWWidth;
@@ -298,8 +298,13 @@ void X11WindowBase::SetBounds(const gfx::Rect& bounds) {
   // case if we're running without a window manager.  If there's a window
   // manager, it can modify or ignore the request, but (per ICCCM) we'll get a
   // (possibly synthetic) ConfigureNotify about the actual size and correct
-  // |bounds_| later.
+  // |bounds_| later. If |bounds| came with zero size, use the previous size
+  // of |bounds_|.
+  gfx::Size size = bounds_.size();
+  if (!bounds.size().IsEmpty())
+    size = bounds_.size();
   bounds_ = bounds;
+  bounds_.set_size(size);
 
   // Even if the pixel bounds didn't change this call to the delegate should
   // still happen. The device scale factor may have changed which effectively

--- a/ui/platform_window/x11/x11_window_base.h
+++ b/ui/platform_window/x11/x11_window_base.h
@@ -58,6 +58,7 @@ class X11_WINDOW_EXPORT X11WindowBase : public PlatformWindow {
   void ReleasePointerGrab();
 
   PlatformWindowDelegate* delegate() { return delegate_; }
+
   XDisplay* xdisplay() { return xdisplay_; }
   XID xwindow() const { return xwindow_; }
 

--- a/ui/platform_window/x11/x11_window_ozone.cc
+++ b/ui/platform_window/x11/x11_window_ozone.cc
@@ -41,6 +41,11 @@ X11WindowOzone::X11WindowOzone(X11WindowManagerOzone* window_manager,
     event_source->AddPlatformEventDispatcher(this);
     event_source->AddXEventDispatcher(this);
   }
+
+// TODO(msisov, tonikitoo): Add a dummy implementation for chromeos.
+#if !defined(OS_CHROMEOS)
+  move_loop_client_.reset(new WindowMoveLoopClient());
+#endif
 }
 
 X11WindowOzone::~X11WindowOzone() {
@@ -72,6 +77,24 @@ void X11WindowOzone::ReleaseCapture() {
 void X11WindowOzone::SetCursor(PlatformCursor cursor) {
   X11CursorOzone* cursor_ozone = static_cast<X11CursorOzone*>(cursor);
   XDefineCursor(xdisplay(), xwindow(), cursor_ozone->xcursor());
+}
+
+bool X11WindowOzone::RunMoveLoop(const gfx::Vector2d& drag_offset) {
+// TODO(msisov, tonikitoo): Add a dummy implementation for chromeos.
+#if !defined(OS_CHROMEOS)
+  DCHECK(move_loop_client_);
+  ReleaseCapture();
+  return move_loop_client_->RunMoveLoop(this, drag_offset);
+#endif
+  return true;
+}
+
+void X11WindowOzone::StopMoveLoop() {
+// TODO(msisov, tonikitoo): Add a dummy implementation for chromeos.
+#if !defined(OS_CHROMEOS)
+  ReleaseCapture();
+  move_loop_client_->EndMoveLoop();
+#endif
 }
 
 bool X11WindowOzone::DispatchXEvent(XEvent* xev) {

--- a/ui/platform_window/x11/x11_window_ozone.h
+++ b/ui/platform_window/x11/x11_window_ozone.h
@@ -8,6 +8,7 @@
 #include "base/macros.h"
 #include "ui/events/platform/platform_event_dispatcher.h"
 #include "ui/events/platform/x11/x11_event_source_libevent.h"
+#include "ui/platform_window/window_move_loop_client.h"
 #include "ui/platform_window/x11/x11_window_base.h"
 #include "ui/platform_window/x11/x11_window_export.h"
 
@@ -30,6 +31,8 @@ class X11_WINDOW_EXPORT X11WindowOzone : public X11WindowBase,
   void SetCapture() override;
   void ReleaseCapture() override;
   void SetCursor(PlatformCursor cursor) override;
+  bool RunMoveLoop(const gfx::Vector2d& drag_offset) override;
+  void StopMoveLoop() override;
 
   // XEventDispatcher:
   bool DispatchXEvent(XEvent* event) override;
@@ -53,6 +56,11 @@ class X11_WINDOW_EXPORT X11WindowOzone : public X11WindowBase,
   uint32_t DispatchEvent(const PlatformEvent& event) override;
 
   X11WindowManagerOzone* window_manager_;
+
+// TODO(msisov, tonikitoo): Add a dummy implementation for chromeos.
+#if !defined(OS_CHROMEOS)
+  std::unique_ptr<WindowMoveLoopClient> move_loop_client_;
+#endif
 
   DISALLOW_COPY_AND_ASSIGN(X11WindowOzone);
 };

--- a/ui/views/mus/desktop_window_tree_host_mus.cc
+++ b/ui/views/mus/desktop_window_tree_host_mus.cc
@@ -734,7 +734,7 @@ Widget::MoveLoopResult DesktopWindowTreeHostMus::RunMoveLoop(
   gfx::Point cursor_location =
       display::Screen::GetScreen()->GetCursorScreenPoint();
   WindowTreeHostMus::PerformWindowMove(
-      mus_source, cursor_location,
+      mus_source, cursor_location, drag_offset,
       base::Bind(OnMoveLoopEnd, &success, run_loop.QuitClosure()));
 
   run_loop.Run();

--- a/ui/views/widget/desktop_aura/x11_move_loop_delegate.h
+++ b/ui/views/widget/desktop_aura/x11_move_loop_delegate.h
@@ -14,6 +14,8 @@ namespace views {
 // Receives mouse events while the X11MoveLoop is tracking a drag.
 class X11MoveLoopDelegate {
  public:
+  virtual ~X11MoveLoopDelegate() {}
+
   // Called when we receive a mouse move event.
   virtual void OnMouseMovement(const gfx::Point& screen_point,
                                int flags,


### PR DESCRIPTION
[ozone/mus] Add inital support for a tab drag window.
    
tl;dr
This patch adds an initial support to start a move loop and create
a new window by dragging a tab. To start with, this commit
extends WindowTree::PerformWindowMove, which calls
WindowServer::StartMoveLoop -> PlatformWindow::RunMoveLoop.
  
X11 Ozone implementation of PlatformWindow uses
WindowMoveLoopClient, which instantiates the move loop and
WholeScreenMoveLoop, which creates an invisible window
and intercepts all the events from it. Then the system screen
location is taken and sent to WindowMoveLoopClient, which
updates actual bounds of X11WindowBase.
    
The way it works is precisly the same as in stock X11, but
further work to share the code is needed, because there are
some difference between stock x11 and ozone x11 event
handlings, bounds set and etc.

Known issues:
1) Dragging a tab out of a window and dragging it back results in broken capture. User has to
click on the non-client area (the topmost) to restore the capture.

2) Dragging a tab back and forth to detach and attach the tab, might result in corrupted widget,
which doesn't show anything, but some garbage.

3) Attaching a window into a tab strip might result to segfault for hit test aggregator.
Which is actually a race between switch hit test regions and destroyed ozone window and its components.

And full description:
The point where run loop starts in mus is DesktopWindowTreeHostMus::RunMoveLoop.
It calls to WindowTreeClient::PerformWindowMove, which asks WindowTree to do actual move loop.
Once the request goes through the access policy, WindowServer::StartMoveLoop is called.
Then ws::PlatformDisplay is taken and native PlatformWindow is asked to perform a move loop.

A move loop consists of several objects - X11WindowOzone, who instantiates the move loop on ozone side, WindowMoveLoopClient, who manages WholeScreenMoveLoop and receives mouse coordinates, and the mentioned WholeScreenMoveLoop, who creates an invisible window, sets an explicit mouse grab on it and starts actual RunLoop intercepting all the events, modifying their locations to system coordinates locations and sending them both to the next dispatchers (which get the events, propagate to aura and modify the actual mouse locations both in mus and aura side, which is extremely important for TabDragController to work, because it always checks where the pointer is,once the pointer is on top of the location with a tab strip, it can attach a window inside a tab strip and make a tab out of that) and WindowMoveLoopClient, which adds a drag offset to the coordinates it has received and updates the location of the X11WindowOzone.

Once WholeScreenMoveLoop receives a mouse release event or keyboard escape event, it stops the move loop and WholeScreenMoveLoop::RunMoveLoop returns the success of the operation to WindowTree. In turn, WindowTree calls OnChangeCompleted(result).
    
Issue #264

