### PR TITLE
fixup! [ozone/mus] Add inital support for a tab drag window.

### DIFF
--- a/ui/ozone/platform/drm/host/drm_window_host.cc
+++ b/ui/ozone/platform/drm/host/drm_window_host.cc
@@ -131,6 +131,12 @@ PlatformImeController* DrmWindowHost::GetPlatformImeController() {
 
 void DrmWindowHost::PerformNativeWindowDragOrResize(uint32_t hittest) {}
 
+bool DrmWindowHost::RunMoveLoop(const gfx::Vector2d& drag_offset) {
+  return false;
+}
+
+void DrmWindowHost::StopMoveLoop() {}
+
 bool DrmWindowHost::CanDispatchEvent(const PlatformEvent& ne) {
   DCHECK(ne);
   Event* event = static_cast<Event*>(ne);

--- a/ui/ozone/platform/drm/host/drm_window_host.h
+++ b/ui/ozone/platform/drm/host/drm_window_host.h
@@ -76,6 +76,8 @@ class DrmWindowHost : public PlatformWindow,
   void ConfineCursorToBounds(const gfx::Rect& bounds) override;
   PlatformImeController* GetPlatformImeController() override;
   void PerformNativeWindowDragOrResize(uint32_t hittest) override;
+  bool RunMoveLoop(const gfx::Vector2d& drag_offset) override;
+  void StopMoveLoop() override;
 
   // PlatformEventDispatcher:
   bool CanDispatchEvent(const PlatformEvent& event) override;

--- a/ui/platform_window/BUILD.gn
+++ b/ui/platform_window/BUILD.gn
@@ -19,15 +19,6 @@ source_set("platform_window") {
     "//ui/base/ime:text_input_types",
     "//ui/gfx",
   ]
-
-  if (use_ozone && !is_chromeos) {
-    sources += [
-      "whole_screen_move_loop.cc",
-      "whole_screen_move_loop.h",
-      "window_move_loop_client.cc",
-      "window_move_loop_client.h",
-    ]
-  }
 }
 
 group("platform_impls") {

--- a/ui/platform_window/x11/BUILD.gn
+++ b/ui/platform_window/x11/BUILD.gn
@@ -41,6 +41,10 @@ component("x11") {
       "x11_window_manager_ozone.h",
       "x11_window_ozone.cc",
       "x11_window_ozone.h",
+      "whole_screen_move_loop.cc",
+      "whole_screen_move_loop.h",
+      "window_move_loop_client.cc",
+      "window_move_loop_client.h",
     ]
     deps += [
       "//ui/base",

--- a/ui/platform_window/x11/whole_screen_move_loop.cc
+++ b/ui/platform_window/x11/whole_screen_move_loop.cc
@@ -2,9 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "ui/platform_window/whole_screen_move_loop.h"
-
-#include "ui/platform_window/window_move_loop_client.h"
+#include "ui/platform_window/x11/whole_screen_move_loop.h"
 
 #include <stddef.h>
 #include <X11/keysym.h>

--- a/ui/platform_window/x11/whole_screen_move_loop.h
+++ b/ui/platform_window/x11/whole_screen_move_loop.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef UI_PLATFORM_WINDOW_WHOLE_SCREEN_MOVE_LOOP_H_
-#define UI_PLATFORM_WINDOW_WHOLE_SCREEN_MOVE_LOOP_H_
+#ifndef UI_PLATFORM_WINDOW_X11_WHOLE_SCREEN_MOVE_LOOP_H_
+#define UI_PLATFORM_WINDOW_X11_WHOLE_SCREEN_MOVE_LOOP_H_
 
 #include <stdint.h>
 
@@ -87,4 +87,4 @@ class WholeScreenMoveLoop : public ui::PlatformEventDispatcher {
 
 }  // namespace ui
 
-#endif  // UI_PLATFORM_WINDOW_WHOLE_SCREEN_MOVE_LOOP_H_
+#endif  // UI_PLATFORM_WINDOW_X11_WHOLE_SCREEN_MOVE_LOOP_H_

--- a/ui/platform_window/x11/window_move_loop_client.cc
+++ b/ui/platform_window/x11/window_move_loop_client.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "ui/platform_window/window_move_loop_client.h"
+#include "ui/platform_window/x11/window_move_loop_client.h"
 
 #include <X11/Xlib.h>
 

--- a/ui/platform_window/x11/window_move_loop_client.h
+++ b/ui/platform_window/x11/window_move_loop_client.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef UI_PLATFORM_WINDOW_WINDOW_MOVE_LOOP_CLIENT_H_
-#define UI_PLATFORM_WINDOW_WINDOW_MOVE_LOOP_CLIENT_H_
+#ifndef UI_PLATFORM_WINDOW_X11_WINDOW_MOVE_LOOP_CLIENT_H_
+#define UI_PLATFORM_WINDOW_X11_WINDOW_MOVE_LOOP_CLIENT_H_
 
 #include <X11/Xlib.h>
 
@@ -12,7 +12,7 @@
 #include "base/message_loop/message_loop.h"
 #include "ui/gfx/geometry/point.h"
 #include "ui/views/views_export.h"
-#include "ui/platform_window/whole_screen_move_loop.h"
+#include "ui/platform_window/x11/whole_screen_move_loop.h"
 #include "ui/wm/public/window_move_client.h"
 
 namespace ui {
@@ -50,4 +50,4 @@ class WindowMoveLoopClient : public views::X11MoveLoopDelegate {
 
 }  // namespace ui
 
-#endif  // UI_PLATFORM_WINDOW_WINDOW_MOVE_LOOP_CLIENT_H_
+#endif  // UI_PLATFORM_WINDOW_X11_WINDOW_MOVE_LOOP_CLIENT_H_

--- a/ui/platform_window/x11/x11_window_base.cc
+++ b/ui/platform_window/x11/x11_window_base.cc
@@ -419,6 +419,12 @@ void X11WindowBase::PerformNativeWindowDragOrResize(uint32_t hittest) {
              SubstructureRedirectMask | SubstructureNotifyMask, &event);
 }
 
+bool X11WindowBase::RunMoveLoop(const gfx::Vector2d& drag_offset) {
+  return false;
+}
+
+void X11WindowBase::StopMoveLoop() {}
+
 bool X11WindowBase::IsEventForXWindow(const XEvent& xev) const {
   return xwindow_ != None && FindXEventTarget(xev) == xwindow_;
 }

--- a/ui/platform_window/x11/x11_window_base.h
+++ b/ui/platform_window/x11/x11_window_base.h
@@ -50,6 +50,8 @@ class X11_WINDOW_EXPORT X11WindowBase : public PlatformWindow {
   void ConfineCursorToBounds(const gfx::Rect& bounds) override;
   PlatformImeController* GetPlatformImeController() override;
   void PerformNativeWindowDragOrResize(uint32_t hittest) override;
+  bool RunMoveLoop(const gfx::Vector2d& drag_offset) override;
+  void StopMoveLoop() override;
 
  protected:
   void Destroy();

--- a/ui/platform_window/x11/x11_window_ozone.h
+++ b/ui/platform_window/x11/x11_window_ozone.h
@@ -8,7 +8,7 @@
 #include "base/macros.h"
 #include "ui/events/platform/platform_event_dispatcher.h"
 #include "ui/events/platform/x11/x11_event_source_libevent.h"
-#include "ui/platform_window/window_move_loop_client.h"
+#include "ui/platform_window/x11/window_move_loop_client.h"
 #include "ui/platform_window/x11/x11_window_base.h"
 #include "ui/platform_window/x11/x11_window_export.h"
 


### PR DESCRIPTION
Fix compilation failures for non ozone x11 and gbm chrome os platform
Temporarerly move window_move_loop_client and
whole_screen_move_loop to ui/platform_window/x11. Once
code is shared between non-ozone x11 and ozone x11, the files
will be placed to proper locations.