### PR TITLE
Prevent client->server->client cycle when setting bounds

### DIFF
--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -1869,10 +1869,10 @@ void WindowTree::SetWindowBounds(
       WindowManagerDisplayRoot* display_root =
           GetWindowManagerDisplayRoot(window);
       if (display_root && display_root->GetClientVisibleRoot() == window) {
+        Operation op(this, window_server_, OperationType::SET_WINDOW_BOUNDS);
         Display* display = GetDisplay(window);
         DCHECK(display);
         display->SetBounds(bounds);
-
         client()->OnChangeCompleted(change_id, success);
         return;
       }


### PR DESCRIPTION
fixup! Handle OnBoundsChange in external mode.

If we are receiving a bound change from the client, make sure we do not call the client back with it.

TBR=msisov@igalia.com

Issue #265