### PR TITLE
Use ::DISPLAY_MANUALLY_CREATED for the our window type instead on ::EMBED

### DIFF
--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -2344,7 +2344,7 @@ void WindowTreeClient::OnWindowTreeHostConfineCursorToBounds(
 std::unique_ptr<WindowPortMus> WindowTreeClient::CreateWindowPortForTopLevel(
     const std::map<std::string, std::vector<uint8_t>>* properties) {
   WindowMusType window_type = in_external_window_mode_
-                                  ? WindowMusType::EMBED
+                                  ? WindowMusType::DISPLAY_MANUALLY_CREATED
                                   : WindowMusType::TOP_LEVEL;
 
   std::unique_ptr<WindowPortMus> window_port =


### PR DESCRIPTION
fixup! c++ / mojo changes for 'external window mode'

Use ::DISPLAY_MANUALLY_CREATED for the our window type instead
on ::EMBED. Reason: we actually are creating ws::Display's manually,
similarly to chromeos/mus, and this WindowMus type takes care of
various scenarios, like generating new LocalSurfaceId's uppon client
side bounds change, etc.

Issue #266

TBR=msisov