### PR TITLE
fixup! [ozone/wayland] Implement Tooltip using subsurface

### DIFF
--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -212,9 +212,12 @@ void WaylandWindow::Show() {
 
 void WaylandWindow::Hide() {
   if (is_tooltip_) {
-    tooltip_subsurface_.reset();
     wl_surface_attach(surface_.get(), NULL, 0, 0);
     wl_surface_commit(surface_.get());
+    // Tooltip subsurface must be reset only after the buffer is detached.
+    // Otherwise, gnome shell, for example, can end up with broken event
+    // pipe.
+    tooltip_subsurface_.reset();
     return;
   }
   if (child_window_)


### PR DESCRIPTION
Fix crash on gnome shell by destroying subsurface only after a
buffer is detached.