### PR TITLE
Revert "Consider ResizeParams.local_surface_id when comparing whether size changed"

### DIFF
--- a/content/browser/renderer_host/render_widget_host_impl.cc
+++ b/content/browser/renderer_host/render_widget_host_impl.cc
@@ -781,7 +781,6 @@ bool RenderWidgetHostImpl::GetResizeParams(ResizeParams* resize_params) {
        !resize_params->physical_backing_size.IsEmpty());
   bool dirty =
       size_changed ||
-      old_resize_params_->local_surface_id != resize_params->local_surface_id ||
       old_resize_params_->screen_info != resize_params->screen_info ||
       old_resize_params_->physical_backing_size !=
           resize_params->physical_backing_size ||


### PR DESCRIPTION
This reverts commit 0e799e55a36b96f9e07bbc0fc0839f89074b6bec.

https://crrev.com/c/646072 has introduced the same check as
PR #159, so we can drop this now.

Issue #266