### PR TITLE
Remove custom WTC::ConfigureWindowDataFromServer method

### DIFF
--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -585,16 +585,6 @@ std::unique_ptr<WindowTreeHostMus> WindowTreeClient::CreateWindowTreeHost(
   std::unique_ptr<WindowTreeHostMus> window_tree_host =
       std::make_unique<WindowTreeHostMus>(std::move(init_params));
   window_tree_host->InitHost();
-
-  ConfigureWindowDataFromServer(window_tree_host.get(), window_data,
-                                local_surface_id);
-  return window_tree_host;
-}
-
-void WindowTreeClient::ConfigureWindowDataFromServer(
-    WindowTreeHostMus* window_tree_host,
-    const ui::mojom::WindowData& window_data,
-    const base::Optional<viz::LocalSurfaceId>& local_surface_id) {
   SetLocalPropertiesFromServerProperties(
       WindowMus::Get(window_tree_host->window()), window_data);
   if (window_data.visible) {
@@ -604,6 +594,7 @@ void WindowTreeClient::ConfigureWindowDataFromServer(
   WindowMus* window = WindowMus::Get(window_tree_host->window());
 
   SetWindowBoundsFromServer(window, window_data.bounds, local_surface_id);
+  return window_tree_host;
 }
 
 WindowMus* WindowTreeClient::NewWindowFromWindowData(

--- a/ui/aura/mus/window_tree_client.h
+++ b/ui/aura/mus/window_tree_client.h
@@ -271,11 +271,6 @@ class AURA_EXPORT WindowTreeClient
       const base::Optional<viz::LocalSurfaceId>& local_surface_id =
           base::nullopt);
 
-  void ConfigureWindowDataFromServer(
-      WindowTreeHostMus* window_tree_host,
-      const ui::mojom::WindowData& window_data,
-      const base::Optional<viz::LocalSurfaceId>& local_surface_id);
-
   WindowMus* NewWindowFromWindowData(WindowMus* parent,
                                      const ui::mojom::WindowData& window_data);
 


### PR DESCRIPTION
fixup! c++ / mojo changes for 'external window mode'

Remove custom WTC::ConfigureWindowDataFromServer method
now that we switched to using WTC::OnTopLevelCreatedImpl
(also custom).

Issue #256