### PR TITLE
Use aura::WindowTreeHostMus::ForWindow to a WindowTreeHostMus in WindowEventFilter::MaybeDispatchHostWindowDragMovement

### DIFF
--- a/ui/views/mus/desktop_window_tree_host_mus.cc
+++ b/ui/views/mus/desktop_window_tree_host_mus.cc
@@ -835,10 +835,6 @@ bool DesktopWindowTreeHostMus::ShouldCreateVisibilityController() const {
   return false;
 }
 
-void DesktopWindowTreeHostMus::PerformNativeWindowDragOrResize(int hittest) {
-  WindowTreeHostMus::PerformNativeWindowDragOrResize(hittest);
-}
-
 void DesktopWindowTreeHostMus::OnWindowManagerFrameValuesChanged() {
   NonClientView* non_client_view =
       native_widget_delegate_->AsWidget()->non_client_view();

--- a/ui/views/mus/desktop_window_tree_host_mus.h
+++ b/ui/views/mus/desktop_window_tree_host_mus.h
@@ -133,7 +133,6 @@ class VIEWS_MUS_EXPORT DesktopWindowTreeHostMus
   bool ShouldUpdateWindowTransparency() const override;
   bool ShouldUseDesktopNativeCursorManager() const override;
   bool ShouldCreateVisibilityController() const override;
-  void PerformNativeWindowDragOrResize(int hittest) override;
 
   // MusClientObserver:
   void OnWindowManagerFrameValuesChanged() override;

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host.h
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host.h
@@ -170,10 +170,6 @@ class VIEWS_EXPORT DesktopWindowTreeHost {
 
   // Returns whether a VisibilityController should be created.
   virtual bool ShouldCreateVisibilityController() const = 0;
-
-  // Tells the native window manager to start interactive drag or resize of a
-  // window.
-  virtual void PerformNativeWindowDragOrResize(int hittest) = 0;
 };
 
 }  // namespace views

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.cc
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.cc
@@ -1147,8 +1147,6 @@ bool DesktopWindowTreeHostX11::ShouldCreateVisibilityController() const {
   return true;
 }
 
-void DesktopWindowTreeHostX11::PerformNativeWindowDragOrResize(int hittest) {}
-
 ////////////////////////////////////////////////////////////////////////////////
 // DesktopWindowTreeHostX11, aura::WindowTreeHost implementation:
 

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.h
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.h
@@ -152,7 +152,6 @@ class VIEWS_EXPORT DesktopWindowTreeHostX11
   bool ShouldUpdateWindowTransparency() const override;
   bool ShouldUseDesktopNativeCursorManager() const override;
   bool ShouldCreateVisibilityController() const override;
-  void PerformNativeWindowDragOrResize(int hittest) override;
 
   // Overridden from aura::WindowTreeHost:
   gfx::Transform GetRootTransform() const override;

--- a/ui/views/widget/desktop_aura/window_event_filter.cc
+++ b/ui/views/widget/desktop_aura/window_event_filter.cc
@@ -18,6 +18,7 @@
 #include "ui/views/widget/desktop_aura/desktop_window_tree_host.h"
 #include "ui/views/widget/native_widget_aura.h"
 #include "ui/views/widget/widget.h"
+#include "ui/aura/mus/window_tree_host_mus.h"
 
 namespace views {
 
@@ -175,7 +176,12 @@ void WindowEventFilter::MaybeDispatchHostWindowDragMovement(int hittest,
   if ((event->type() == ui::ET_TOUCH_PRESSED ||
        event->AsMouseEvent()->IsLeftMouseButton()) &&
       CanPerformDragOrResize(hittest)) {
-    window_tree_host_->PerformNativeWindowDragOrResize(hittest);
+    auto* target = static_cast<aura::Window*>(event->target());
+    if (target) {
+      aura::WindowTreeHostMus* wth = aura::WindowTreeHostMus::ForWindow(target);
+      DCHECK(wth);
+      wth->PerformNativeWindowDragOrResize(hittest);
+    }
     event->StopPropagation();
   }
 }


### PR DESCRIPTION
fixup! Handle events for interactive drag and resize of native windows.

Use aura::WindowTreeHostMus::ForWindow to a WindowTreeHostMus
instance off of an aura::Window, and avoid the need to plumb
the method through DesktopWindowTreeHost{Mus,X11} classes.

In practice, the changes in the follow files can be reverted:

- ui/views/mus/desktop_window_tree_host_mus.cc|h
- ui/views/widget/desktop_aura/desktop_window_tree_host.h
- ui/views/widget/desktop_aura/desktop_window_tree_host_x11.cc|h

Issue #256