### PR TITLE
Implement an unique identifier to be returned for ws::Display::GetId

### DIFF
--- a/ash/host/ash_window_tree_host.cc
+++ b/ash/host/ash_window_tree_host.cc
@@ -12,6 +12,7 @@
 #include "ash/host/ash_window_tree_host_unified.h"
 #include "ash/shell_port.h"
 #include "ui/aura/client/screen_position_client.h"
+#include "ui/aura/env.h"
 #include "ui/aura/window_tree_host.h"
 #include "ui/events/event.h"
 #include "ui/gfx/geometry/rect.h"
@@ -23,6 +24,11 @@ AshWindowTreeHost::AshWindowTreeHost() {}
 AshWindowTreeHost::~AshWindowTreeHost() = default;
 
 void AshWindowTreeHost::TranslateLocatedEvent(ui::LocatedEvent* event) {
+  // NOTE: This code is not called in mus/mash, it is handled on the server
+  // side.
+  // TODO(sky): remove this when mus is the default http://crbug.com/763996.
+  DCHECK_EQ(aura::Env::Mode::LOCAL, aura::Env::GetInstance()->mode());
+
   if (event->IsTouchEvent())
     return;
 

--- a/content/renderer/mus/renderer_window_tree_client.cc
+++ b/content/renderer/mus/renderer_window_tree_client.cc
@@ -279,6 +279,7 @@ void RendererWindowTreeClient::OnWindowInputEvent(
     uint32_t event_id,
     ui::Id window_id,
     int64_t display_id,
+    const gfx::PointF& event_location_in_screen_pixel_layout,
     std::unique_ptr<ui::Event> event,
     bool matches_pointer_watcher) {
   NOTREACHED();

--- a/content/renderer/mus/renderer_window_tree_client.h
+++ b/content/renderer/mus/renderer_window_tree_client.h
@@ -163,11 +163,13 @@ class RendererWindowTreeClient : public ui::mojom::WindowTreeClient,
       ui::Id window_id,
       const std::string& name,
       const base::Optional<std::vector<uint8_t>>& new_data) override;
-  void OnWindowInputEvent(uint32_t event_id,
-                          ui::Id window_id,
-                          int64_t display_id,
-                          std::unique_ptr<ui::Event> event,
-                          bool matches_pointer_watcher) override;
+  void OnWindowInputEvent(
+      uint32_t event_id,
+      ui::Id window_id,
+      int64_t display_id,
+      const gfx::PointF& event_location_in_screen_pixel_layout,
+      std::unique_ptr<ui::Event> event,
+      bool matches_pointer_watcher) override;
   void OnPointerEventObserved(std::unique_ptr<ui::Event> event,
                               uint32_t window_id,
                               int64_t display_id) override;

--- a/services/ui/public/interfaces/window_tree.mojom
+++ b/services/ui/public/interfaces/window_tree.mojom
@@ -490,9 +490,12 @@ interface WindowTreeClient {
   // specified by StartPointerWatcher(). The client will not receive farther
   // events until the event is ack'ed, regardless of the value of
   // |matches_pointer_watcher|.
+  // TODO(sky): remove |event_location_in_screen_pixel_layout| temporary until
+  // http://crbug.com/747465 is fixed.
   OnWindowInputEvent(uint32 event_id,
                      uint32 window,
                      int64 display_id,
+                     gfx.mojom.PointF event_location_in_screen_pixel_layout,
                      ui.mojom.Event event,
                      bool matches_pointer_watcher);
 

--- a/services/ui/ws/BUILD.gn
+++ b/services/ui/ws/BUILD.gn
@@ -47,6 +47,7 @@ static_library("lib") {
     "event_dispatcher.cc",
     "event_dispatcher.h",
     "event_dispatcher_delegate.h",
+    "event_location.h",
     "event_matcher.cc",
     "event_matcher.h",
     "event_targeter.cc",

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -92,7 +92,10 @@ void Display::Init(const display::ViewportMetrics& metrics,
 }
 
 int64_t Display::GetId() const {
-  // TODO(tonikitoo): Implement a different ID for external window mode.
+  if (window_server_->IsInExternalWindowMode()) {
+    DCHECK_NE(external_window_id_, -1);
+    return external_window_id_;
+  }
   return display_.id();
 }
 
@@ -326,6 +329,11 @@ void Display::CreateRootWindow(const gfx::Rect& bounds) {
   root_->SetVisible(true);
   focus_controller_ = base::MakeUnique<FocusController>(root_.get());
   focus_controller_->AddObserver(this);
+
+  if (window_server_->IsInExternalWindowMode()) {
+    DCHECK_EQ(external_window_id_, -1);
+    external_window_id_ = (id.client_id << 16) | id.window_id;
+  }
 }
 
 void Display::UpdateCursorConfig() {

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -106,6 +106,10 @@ const display::Display& Display::GetDisplay() {
   return display_;
 }
 
+const display::ViewportMetrics& Display::GetViewportMetrics() const {
+  return platform_display_->GetViewportMetrics();
+}
+
 DisplayManager* Display::display_manager() {
   return window_server_->display_manager();
 }
@@ -543,7 +547,7 @@ EventDispatchDetails Display::OnEventFromSource(Event* event) {
   WindowManagerDisplayRoot* display_root = GetActiveWindowManagerDisplayRoot();
   if (display_root) {
     WindowManagerState* wm_state = display_root->window_manager_state();
-    wm_state->ProcessEvent(*event, GetId());
+    wm_state->ProcessEvent(event, GetId());
   }
 
   UserActivityMonitor* activity_monitor =

--- a/services/ui/ws/display.h
+++ b/services/ui/ws/display.h
@@ -231,8 +231,12 @@ class Display : public PlatformDisplayDelegate,
   std::unique_ptr<FocusController> focus_controller_;
 
   // In internal window mode this contains information about the display. In
-  // external window mode this will be invalid.
+  // external window mode this will be invalid. See below.
   display::Display display_;
+
+  // Unique identifier of this ws::Display instance. This is returned
+  // from ::GetId in external window mode.
+  int64_t external_window_id_ = -1;
 
   viz::LocalSurfaceIdAllocator allocator_;
 

--- a/services/ui/ws/display.h
+++ b/services/ui/ws/display.h
@@ -80,6 +80,8 @@ class Display : public PlatformDisplayDelegate,
   // PlatformDisplayDelegate:
   const display::Display& GetDisplay() override;
 
+  const display::ViewportMetrics& GetViewportMetrics() const;
+
   DisplayManager* display_manager();
   const DisplayManager* display_manager() const;
 

--- a/services/ui/ws/display_manager.cc
+++ b/services/ui/ws/display_manager.cc
@@ -29,6 +29,7 @@
 #include "ui/display/screen_base.h"
 #include "ui/display/types/display_constants.h"
 #include "ui/events/event_rewriter.h"
+#include "ui/gfx/geometry/point_conversions.h"
 
 #if defined(OS_CHROMEOS)
 #include "ui/chromeos/events/event_rewriter_chromeos.h"
@@ -341,8 +342,8 @@ void DisplayManager::OnActiveUserIdChanged(const UserId& previously_active_id,
   int64_t mouse_display_id = 0;
   if (previous_window_manager_state) {
     mouse_location_on_display =
-        previous_window_manager_state->event_dispatcher()
-            ->mouse_pointer_last_location();
+        gfx::ToFlooredPoint(previous_window_manager_state->event_dispatcher()
+                                ->mouse_pointer_last_location());
     mouse_display_id = previous_window_manager_state->event_dispatcher()
                            ->mouse_pointer_display_id();
     previous_window_manager_state->Deactivate();

--- a/services/ui/ws/display_unittest.cc
+++ b/services/ui/ws/display_unittest.cc
@@ -277,7 +277,7 @@ TEST_F(DisplayTest, EventStateResetOnUserSwitch) {
 
   EXPECT_TRUE(EventDispatcherTestApi(active_wms->event_dispatcher())
                   .AreAnyPointersDown());
-  EXPECT_EQ(gfx::Point(20, 25),
+  EXPECT_EQ(gfx::PointF(20, 25),
             active_wms->event_dispatcher()->mouse_pointer_last_location());
 
   // Switch the user. Should trigger resetting state in old event dispatcher
@@ -291,7 +291,7 @@ TEST_F(DisplayTest, EventStateResetOnUserSwitch) {
   active_wms =
       display->GetActiveWindowManagerDisplayRoot()->window_manager_state();
   EXPECT_EQ(kTestId2, active_wms->user_id());
-  EXPECT_EQ(gfx::Point(20, 25),
+  EXPECT_EQ(gfx::PointF(20, 25),
             active_wms->event_dispatcher()->mouse_pointer_last_location());
   EXPECT_FALSE(EventDispatcherTestApi(active_wms->event_dispatcher())
                    .AreAnyPointersDown());

--- a/services/ui/ws/event_dispatcher_delegate.h
+++ b/services/ui/ws/event_dispatcher_delegate.h
@@ -10,7 +10,7 @@
 #include "services/ui/common/types.h"
 
 namespace gfx {
-class Point;
+class PointF;
 }
 
 namespace viz {
@@ -61,7 +61,7 @@ class EventDispatcherDelegate {
   virtual void OnCaptureChanged(ServerWindow* new_capture,
                                 ServerWindow* old_capture) = 0;
 
-  virtual void OnMouseCursorLocationChanged(const gfx::Point& point,
+  virtual void OnMouseCursorLocationChanged(const gfx::PointF& point,
                                             int64_t display_id) = 0;
 
   virtual void OnEventChangesCursorVisibility(const ui::Event& event,
@@ -73,7 +73,7 @@ class EventDispatcherDelegate {
   // Dispatches an event to the specific client.
   virtual void DispatchInputEventToWindow(ServerWindow* target,
                                           ClientSpecificId client_id,
-                                          int64_t display_id,
+                                          const EventLocation& event_location,
                                           const ui::Event& event,
                                           Accelerator* accelerator) = 0;
 
@@ -93,8 +93,7 @@ class EventDispatcherDelegate {
   // TODO(riajiang): No need to update |location_in_display| and |display_id|
   // after ozone drm can tell us the right display the cursor is on for
   // drag-n-drop events. crbug.com/726470
-  virtual ServerWindow* GetRootWindowContaining(gfx::Point* location_in_display,
-                                                int64_t* display_id) = 0;
+  virtual ServerWindow* GetRootWindowForDisplay(int64_t display_id) = 0;
 
   // Returns the root of |window| that is used for event dispatch. The returned
   // value is used for coordinate conversion.

--- a/services/ui/ws/event_dispatcher_unittest.cc
+++ b/services/ui/ws/event_dispatcher_unittest.cc
@@ -20,6 +20,7 @@
 #include "services/ui/public/interfaces/window_tree_constants.mojom.h"
 #include "services/ui/ws/accelerator.h"
 #include "services/ui/ws/event_dispatcher_delegate.h"
+#include "services/ui/ws/event_location.h"
 #include "services/ui/ws/server_window.h"
 #include "services/ui/ws/test_server_window_delegate.h"
 #include "services/ui/ws/test_utils.h"
@@ -149,7 +150,7 @@ class TestEventDispatcherDelegate : public EventDispatcherDelegate {
                         ServerWindow* old_capture_window) override {
     lost_capture_window_ = old_capture_window;
   }
-  void OnMouseCursorLocationChanged(const gfx::Point& point,
+  void OnMouseCursorLocationChanged(const gfx::PointF& point,
                                     int64_t display_id) override {}
   void OnEventChangesCursorVisibility(const ui::Event& event,
                                       bool visible) override {
@@ -159,7 +160,7 @@ class TestEventDispatcherDelegate : public EventDispatcherDelegate {
                                            bool visible) override {}
   void DispatchInputEventToWindow(ServerWindow* target,
                                   ClientSpecificId client_id,
-                                  int64_t display_id,
+                                  const EventLocation& event_location,
                                   const ui::Event& event,
                                   Accelerator* accelerator) override {
     std::unique_ptr<DispatchedEventDetails> details(new DispatchedEventDetails);
@@ -174,8 +175,7 @@ class TestEventDispatcherDelegate : public EventDispatcherDelegate {
                                           bool in_nonclient_area) override {
     return in_nonclient_area ? kNonclientAreaId : kClientAreaId;
   }
-  ServerWindow* GetRootWindowContaining(gfx::Point* location_in_display,
-                                        int64_t* display_id) override {
+  ServerWindow* GetRootWindowForDisplay(int64_t display_id) override {
     return root_;
   }
   void OnEventTargetNotFound(const ui::Event& event,
@@ -263,6 +263,15 @@ ui::mojom::EventMatcherPtr BuildKeyMatcher(ui::mojom::KeyboardCode code) {
   return matcher;
 }
 
+EventLocation EventLocationFromEvent(const Event& event) {
+  EventLocation event_location(0);
+  if (event.IsLocatedEvent()) {
+    event_location.raw_location = event_location.location =
+        event.AsLocatedEvent()->root_location_f();
+  }
+  return event_location;
+}
+
 }  // namespace
 
 // Test fixture for EventDispatcher with friend access to verify the internal
@@ -282,7 +291,6 @@ class EventDispatcherTest : public testing::TestWithParam<bool>,
 
   void DispatchEvent(EventDispatcher* dispatcher,
                      const ui::Event& event,
-                     int64_t display_id,
                      EventDispatcher::AcceleratorMatchPhase match_phase);
   void RunMouseEventTests(EventDispatcher* dispatcher,
                           TestEventDispatcherDelegate* dispatcher_delegate,
@@ -328,9 +336,8 @@ class EventDispatcherTest : public testing::TestWithParam<bool>,
 void EventDispatcherTest::DispatchEvent(
     EventDispatcher* dispatcher,
     const ui::Event& event,
-    int64_t display_id,
     EventDispatcher::AcceleratorMatchPhase match_phase) {
-  dispatcher->ProcessEvent(event, display_id, match_phase);
+  dispatcher->ProcessEvent(event, EventLocationFromEvent(event), match_phase);
   RunTasks();
 }
 
@@ -343,7 +350,7 @@ void EventDispatcherTest::RunMouseEventTests(
     const MouseEventTest& test = tests[i];
     ASSERT_FALSE(dispatcher_delegate->has_queued_events())
         << " unexpected queued events before running " << i;
-    DispatchEvent(dispatcher, ui::PointerEvent(*test.input_event), 0,
+    DispatchEvent(dispatcher, ui::PointerEvent(*test.input_event),
                   EventDispatcher::AcceleratorMatchPhase::ANY);
 
     std::unique_ptr<DispatchedEventDetails> details =
@@ -458,9 +465,8 @@ class EventDispatcherVizTargeterTest
 
   void DispatchEvent(EventDispatcher* dispatcher,
                      const ui::Event& event,
-                     int64_t display_id,
                      EventDispatcher::AcceleratorMatchPhase match_phase) {
-    dispatcher->ProcessEvent(event, display_id, match_phase);
+    dispatcher->ProcessEvent(event, EventLocationFromEvent(event), match_phase);
 
     if (!is_event_processing_async())
       return;
@@ -545,7 +551,7 @@ TEST_P(EventDispatcherTest, ProcessEvent) {
   const ui::PointerEvent ui_event(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(20, 25), gfx::Point(20, 25),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(event_dispatcher(), ui_event, 0,
+  DispatchEvent(event_dispatcher(), ui_event,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   std::unique_ptr<DispatchedEventDetails> details =
@@ -564,7 +570,7 @@ TEST_P(EventDispatcherTest, ProcessEvent) {
 TEST_P(EventDispatcherTest, ProcessEventNoTarget) {
   // Send event without a target.
   ui::KeyEvent key(ui::ET_KEY_PRESSED, ui::VKEY_A, ui::EF_NONE);
-  DispatchEvent(event_dispatcher(), key, 0,
+  DispatchEvent(event_dispatcher(), key,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   // Event wasn't dispatched to a target.
@@ -629,8 +635,7 @@ TEST_P(EventDispatcherTest, EventMatching) {
   dispatcher->AddAccelerator(accelerator_1, std::move(matcher));
 
   ui::KeyEvent key(ui::ET_KEY_PRESSED, ui::VKEY_W, ui::EF_CONTROL_DOWN);
-  DispatchEvent(dispatcher, key, 0,
-                EventDispatcher::AcceleratorMatchPhase::ANY);
+  DispatchEvent(dispatcher, key, EventDispatcher::AcceleratorMatchPhase::ANY);
   EXPECT_EQ(accelerator_1,
             event_dispatcher_delegate->GetAndClearLastAccelerator());
 
@@ -638,28 +643,24 @@ TEST_P(EventDispatcherTest, EventMatching) {
   // ignoring.
   key = ui::KeyEvent(ui::ET_KEY_PRESSED, ui::VKEY_W,
                      ui::EF_CONTROL_DOWN | ui::EF_NUM_LOCK_ON);
-  DispatchEvent(dispatcher, key, 0,
-                EventDispatcher::AcceleratorMatchPhase::ANY);
+  DispatchEvent(dispatcher, key, EventDispatcher::AcceleratorMatchPhase::ANY);
   EXPECT_EQ(accelerator_1,
             event_dispatcher_delegate->GetAndClearLastAccelerator());
 
   key = ui::KeyEvent(ui::ET_KEY_PRESSED, ui::VKEY_W, ui::EF_NONE);
-  DispatchEvent(dispatcher, key, 0,
-                EventDispatcher::AcceleratorMatchPhase::ANY);
+  DispatchEvent(dispatcher, key, EventDispatcher::AcceleratorMatchPhase::ANY);
   EXPECT_EQ(0u, event_dispatcher_delegate->GetAndClearLastAccelerator());
 
   uint32_t accelerator_2 = 2;
   matcher = ui::CreateKeyMatcher(ui::mojom::KeyboardCode::W,
                                  ui::mojom::kEventFlagNone);
   dispatcher->AddAccelerator(accelerator_2, std::move(matcher));
-  DispatchEvent(dispatcher, key, 0,
-                EventDispatcher::AcceleratorMatchPhase::ANY);
+  DispatchEvent(dispatcher, key, EventDispatcher::AcceleratorMatchPhase::ANY);
   EXPECT_EQ(accelerator_2,
             event_dispatcher_delegate->GetAndClearLastAccelerator());
 
   dispatcher->RemoveAccelerator(accelerator_2);
-  DispatchEvent(dispatcher, key, 0,
-                EventDispatcher::AcceleratorMatchPhase::ANY);
+  DispatchEvent(dispatcher, key, EventDispatcher::AcceleratorMatchPhase::ANY);
   EXPECT_EQ(0u, event_dispatcher_delegate->GetAndClearLastAccelerator());
 }
 
@@ -677,8 +678,7 @@ TEST_P(EventDispatcherTest, PostTargetAccelerator) {
 
   ui::KeyEvent key(ui::ET_KEY_PRESSED, ui::VKEY_W, ui::EF_CONTROL_DOWN);
   // The post-target accelerator should be fired if there is no focused window.
-  DispatchEvent(dispatcher, key, 0,
-                EventDispatcher::AcceleratorMatchPhase::ANY);
+  DispatchEvent(dispatcher, key, EventDispatcher::AcceleratorMatchPhase::ANY);
   EXPECT_EQ(accelerator_1,
             event_dispatcher_delegate->GetAndClearLastAccelerator());
   std::unique_ptr<DispatchedEventDetails> details =
@@ -690,8 +690,7 @@ TEST_P(EventDispatcherTest, PostTargetAccelerator) {
   event_dispatcher_delegate->SetFocusedWindowFromEventDispatcher(child.get());
 
   // With a focused window the event should be dispatched.
-  DispatchEvent(dispatcher, key, 0,
-                EventDispatcher::AcceleratorMatchPhase::ANY);
+  DispatchEvent(dispatcher, key, EventDispatcher::AcceleratorMatchPhase::ANY);
   EXPECT_EQ(0u, event_dispatcher_delegate->GetAndClearLastAccelerator());
   details = event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
   EXPECT_TRUE(details);
@@ -703,8 +702,7 @@ TEST_P(EventDispatcherTest, PostTargetAccelerator) {
   EXPECT_FALSE(accelerator_weak_ptr);
 
   // Post deletion there should be no accelerator
-  DispatchEvent(dispatcher, key, 0,
-                EventDispatcher::AcceleratorMatchPhase::ANY);
+  DispatchEvent(dispatcher, key, EventDispatcher::AcceleratorMatchPhase::ANY);
   EXPECT_EQ(0u, event_dispatcher_delegate->GetAndClearLastAccelerator());
   details = event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
   EXPECT_TRUE(details);
@@ -739,15 +737,14 @@ TEST_P(EventDispatcherTest, ProcessPost) {
   // Dispatch for ANY, which should trigger PRE and not call
   // DispatchInputEventToWindow().
   ui::KeyEvent key(ui::ET_KEY_PRESSED, ui::VKEY_W, ui::EF_CONTROL_DOWN);
-  DispatchEvent(dispatcher, key, 0,
-                EventDispatcher::AcceleratorMatchPhase::ANY);
+  DispatchEvent(dispatcher, key, EventDispatcher::AcceleratorMatchPhase::ANY);
   EXPECT_EQ(EventDispatcherDelegate::AcceleratorPhase::PRE,
             event_dispatcher_delegate->last_accelerator_phase());
   EXPECT_EQ(pre_id, event_dispatcher_delegate->GetAndClearLastAccelerator());
   EXPECT_FALSE(event_dispatcher_delegate->has_queued_events());
 
   // Dispatch for POST, which should trigger POST.
-  DispatchEvent(dispatcher, key, 0,
+  DispatchEvent(dispatcher, key,
                 EventDispatcher::AcceleratorMatchPhase::POST_ONLY);
   std::unique_ptr<DispatchedEventDetails> details =
       event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
@@ -865,7 +862,7 @@ TEST_P(EventDispatcherTest, ClientAreaGoesToOwner) {
   const ui::PointerEvent press_event(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(12, 12), gfx::Point(12, 12),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(dispatcher, press_event, 0,
+  DispatchEvent(dispatcher, press_event,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   // Events should target child and be in the non-client area.
@@ -880,7 +877,7 @@ TEST_P(EventDispatcherTest, ClientAreaGoesToOwner) {
   const ui::PointerEvent move_event(
       ui::MouseEvent(ui::ET_MOUSE_MOVED, gfx::Point(17, 18), gfx::Point(17, 18),
                      base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, 0));
-  DispatchEvent(dispatcher, move_event, 0,
+  DispatchEvent(dispatcher, move_event,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   // Still same target.
@@ -893,7 +890,7 @@ TEST_P(EventDispatcherTest, ClientAreaGoesToOwner) {
   const ui::PointerEvent release_event(ui::MouseEvent(
       ui::ET_MOUSE_RELEASED, gfx::Point(17, 18), gfx::Point(17, 18),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(dispatcher, release_event, 0,
+  DispatchEvent(dispatcher, release_event,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   // The event should not have been dispatched to the delegate.
@@ -907,7 +904,7 @@ TEST_P(EventDispatcherTest, ClientAreaGoesToOwner) {
   const ui::PointerEvent press_event2(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(21, 22), gfx::Point(21, 22),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(dispatcher, press_event2, 0,
+  DispatchEvent(dispatcher, press_event2,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
   details = event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
   EXPECT_TRUE(event_dispatcher_delegate->has_queued_events());
@@ -938,7 +935,7 @@ TEST_P(EventDispatcherTest, AdditionalClientArea) {
   const ui::PointerEvent press_event(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(28, 11), gfx::Point(28, 11),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(event_dispatcher(), press_event, 0,
+  DispatchEvent(event_dispatcher(), press_event,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   // Events should target child and be in the client area.
@@ -960,7 +957,7 @@ TEST_P(EventDispatcherTest, HitTestMask) {
   const ui::PointerEvent move1(ui::MouseEvent(
       ui::ET_MOUSE_MOVED, gfx::Point(11, 11), gfx::Point(11, 11),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, 0));
-  DispatchEvent(event_dispatcher(), move1, 0,
+  DispatchEvent(event_dispatcher(), move1,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   // Event went through the child window and hit the root.
@@ -975,7 +972,7 @@ TEST_P(EventDispatcherTest, HitTestMask) {
   const ui::PointerEvent move2(ui::MouseEvent(
       ui::ET_MOUSE_MOVED, gfx::Point(11, 12), gfx::Point(11, 12),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, 0));
-  DispatchEvent(event_dispatcher(), move2, 0,
+  DispatchEvent(event_dispatcher(), move2,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   // Mouse exits the root.
@@ -1004,7 +1001,7 @@ TEST_P(EventDispatcherTest, DontFocusOnSecondDown) {
   const ui::PointerEvent press_event(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(12, 12), gfx::Point(12, 12),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(dispatcher, press_event, 0,
+  DispatchEvent(dispatcher, press_event,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
   std::unique_ptr<DispatchedEventDetails> details =
       event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
@@ -1029,7 +1026,7 @@ TEST_P(EventDispatcherTest, TwoPointersActive) {
   const ui::PointerEvent touch_event1(ui::TouchEvent(
       ui::ET_TOUCH_PRESSED, gfx::Point(12, 13), base::TimeTicks(),
       ui::PointerDetails(ui::EventPointerType::POINTER_TYPE_TOUCH, 1)));
-  DispatchEvent(dispatcher, touch_event1, 0,
+  DispatchEvent(dispatcher, touch_event1,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
   std::unique_ptr<DispatchedEventDetails> details =
       event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
@@ -1039,7 +1036,7 @@ TEST_P(EventDispatcherTest, TwoPointersActive) {
   const ui::PointerEvent drag_event1(ui::TouchEvent(
       ui::ET_TOUCH_MOVED, gfx::Point(53, 54), base::TimeTicks(),
       ui::PointerDetails(ui::EventPointerType::POINTER_TYPE_TOUCH, 1)));
-  DispatchEvent(dispatcher, drag_event1, 0,
+  DispatchEvent(dispatcher, drag_event1,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
   details = event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
   EXPECT_EQ(child1.get(), details->window);
@@ -1048,7 +1045,7 @@ TEST_P(EventDispatcherTest, TwoPointersActive) {
   const ui::PointerEvent touch_event2(ui::TouchEvent(
       ui::ET_TOUCH_PRESSED, gfx::Point(54, 55), base::TimeTicks(),
       ui::PointerDetails(ui::EventPointerType::POINTER_TYPE_TOUCH, 2)));
-  DispatchEvent(dispatcher, touch_event2, 0,
+  DispatchEvent(dispatcher, touch_event2,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
   details = event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
   EXPECT_EQ(child2.get(), details->window);
@@ -1057,13 +1054,13 @@ TEST_P(EventDispatcherTest, TwoPointersActive) {
   const ui::PointerEvent drag_event2(ui::TouchEvent(
       ui::ET_TOUCH_MOVED, gfx::Point(13, 14), base::TimeTicks(),
       ui::PointerDetails(ui::EventPointerType::POINTER_TYPE_TOUCH, 2)));
-  DispatchEvent(dispatcher, drag_event2, 0,
+  DispatchEvent(dispatcher, drag_event2,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
   details = event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
   EXPECT_EQ(child2.get(), details->window);
 
   // Drag again with id 1, child1 should continue to get it.
-  DispatchEvent(dispatcher, drag_event1, 0,
+  DispatchEvent(dispatcher, drag_event1,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
   details = event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
   EXPECT_EQ(child1.get(), details->window);
@@ -1072,14 +1069,14 @@ TEST_P(EventDispatcherTest, TwoPointersActive) {
   const ui::PointerEvent touch_release(ui::TouchEvent(
       ui::ET_TOUCH_RELEASED, gfx::Point(54, 55), base::TimeTicks(),
       ui::PointerDetails(ui::EventPointerType::POINTER_TYPE_TOUCH, 1)));
-  DispatchEvent(dispatcher, touch_release, 0,
+  DispatchEvent(dispatcher, touch_release,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
   details = event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
   EXPECT_EQ(child1.get(), details->window);
   const ui::PointerEvent touch_event3(ui::TouchEvent(
       ui::ET_TOUCH_PRESSED, gfx::Point(54, 55), base::TimeTicks(),
       ui::PointerDetails(ui::EventPointerType::POINTER_TYPE_TOUCH, 2)));
-  DispatchEvent(dispatcher, touch_event3, 0,
+  DispatchEvent(dispatcher, touch_event3,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
   details = event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
   EXPECT_EQ(child2.get(), details->window);
@@ -1099,7 +1096,7 @@ TEST_P(EventDispatcherTest, DestroyWindowWhileGettingEvents) {
   const ui::PointerEvent touch_event1(ui::TouchEvent(
       ui::ET_TOUCH_PRESSED, gfx::Point(12, 13), base::TimeTicks(),
       ui::PointerDetails(ui::EventPointerType::POINTER_TYPE_TOUCH, 1)));
-  DispatchEvent(dispatcher, touch_event1, 0,
+  DispatchEvent(dispatcher, touch_event1,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
   std::unique_ptr<DispatchedEventDetails> details =
       event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
@@ -1112,7 +1109,7 @@ TEST_P(EventDispatcherTest, DestroyWindowWhileGettingEvents) {
   const ui::PointerEvent drag_event1(ui::TouchEvent(
       ui::ET_TOUCH_MOVED, gfx::Point(53, 54), base::TimeTicks(),
       ui::PointerDetails(ui::EventPointerType::POINTER_TYPE_TOUCH, 1)));
-  DispatchEvent(dispatcher, drag_event1, 0,
+  DispatchEvent(dispatcher, drag_event1,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
   details = event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
   EXPECT_EQ(nullptr, details.get());
@@ -1133,7 +1130,7 @@ TEST_P(EventDispatcherTest, MouseInExtendedHitTestRegion) {
   const ui::PointerEvent ui_event(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(8, 9), gfx::Point(8, 9),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(dispatcher, ui_event, 0,
+  DispatchEvent(dispatcher, ui_event,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
   std::unique_ptr<DispatchedEventDetails> details =
       event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
@@ -1143,7 +1140,7 @@ TEST_P(EventDispatcherTest, MouseInExtendedHitTestRegion) {
   const ui::PointerEvent release_event(ui::MouseEvent(
       ui::ET_MOUSE_RELEASED, gfx::Point(8, 9), gfx::Point(8, 9),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(dispatcher, release_event, 0,
+  DispatchEvent(dispatcher, release_event,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
   details = event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
   EXPECT_FALSE(event_dispatcher_delegate->has_queued_events());
@@ -1154,7 +1151,7 @@ TEST_P(EventDispatcherTest, MouseInExtendedHitTestRegion) {
   // region. Should result in exit for root, followed by press for child.
   root->set_extended_hit_test_regions_for_children(gfx::Insets(-5, -5, -5, -5),
                                                    gfx::Insets(-5, -5, -5, -5));
-  DispatchEvent(dispatcher, ui_event, 0,
+  DispatchEvent(dispatcher, ui_event,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
   details = event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
   EXPECT_EQ(root, details->window);
@@ -1221,7 +1218,7 @@ TEST_P(EventDispatcherTest, SetExplicitCapture) {
     const ui::PointerEvent left_press_event(ui::MouseEvent(
         ui::ET_MOUSE_PRESSED, gfx::Point(5, 5), gfx::Point(5, 5),
         base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-    DispatchEvent(dispatcher, left_press_event, 0,
+    DispatchEvent(dispatcher, left_press_event,
                   EventDispatcher::AcceleratorMatchPhase::ANY);
 
     // Events should target child.
@@ -1238,7 +1235,7 @@ TEST_P(EventDispatcherTest, SetExplicitCapture) {
         ui::ET_MOUSE_PRESSED, gfx::Point(5, 5), gfx::Point(5, 5),
         base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON | ui::EF_RIGHT_MOUSE_BUTTON,
         ui::EF_RIGHT_MOUSE_BUTTON));
-    DispatchEvent(dispatcher, right_press_event, 0,
+    DispatchEvent(dispatcher, right_press_event,
                   EventDispatcher::AcceleratorMatchPhase::ANY);
     details = event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
     EXPECT_TRUE(IsMouseButtonDown());
@@ -1248,7 +1245,7 @@ TEST_P(EventDispatcherTest, SetExplicitCapture) {
         ui::ET_MOUSE_RELEASED, gfx::Point(5, 5), gfx::Point(5, 5),
         base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON | ui::EF_RIGHT_MOUSE_BUTTON,
         ui::EF_LEFT_MOUSE_BUTTON));
-    DispatchEvent(dispatcher, left_release_event, 0,
+    DispatchEvent(dispatcher, left_release_event,
                   EventDispatcher::AcceleratorMatchPhase::ANY);
     details = event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
     EXPECT_TRUE(IsMouseButtonDown());
@@ -1257,7 +1254,7 @@ TEST_P(EventDispatcherTest, SetExplicitCapture) {
     const ui::PointerEvent touch_event(ui::TouchEvent(
         ui::ET_TOUCH_PRESSED, gfx::Point(15, 15), base::TimeTicks(),
         ui::PointerDetails(ui::EventPointerType::POINTER_TYPE_TOUCH, 2)));
-    DispatchEvent(dispatcher, touch_event, 0,
+    DispatchEvent(dispatcher, touch_event,
                   EventDispatcher::AcceleratorMatchPhase::ANY);
     details = event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
     EXPECT_TRUE(IsMouseButtonDown());
@@ -1267,7 +1264,7 @@ TEST_P(EventDispatcherTest, SetExplicitCapture) {
         ui::MouseEvent(ui::ET_MOUSE_MOVED, gfx::Point(15, 5), gfx::Point(15, 5),
                        base::TimeTicks(), ui::EF_RIGHT_MOUSE_BUTTON,
                        ui::EF_RIGHT_MOUSE_BUTTON));
-    DispatchEvent(dispatcher, move_event, 0,
+    DispatchEvent(dispatcher, move_event,
                   EventDispatcher::AcceleratorMatchPhase::ANY);
     details = event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
     EXPECT_TRUE(IsMouseButtonDown());
@@ -1277,7 +1274,7 @@ TEST_P(EventDispatcherTest, SetExplicitCapture) {
         ui::MouseEvent(ui::ET_MOUSE_RELEASED, gfx::Point(5, 5),
                        gfx::Point(5, 5), base::TimeTicks(),
                        ui::EF_RIGHT_MOUSE_BUTTON, ui::EF_RIGHT_MOUSE_BUTTON));
-    DispatchEvent(dispatcher, right_release_event, 0,
+    DispatchEvent(dispatcher, right_release_event,
                   EventDispatcher::AcceleratorMatchPhase::ANY);
     details = event_dispatcher_delegate->GetAndAdvanceDispatchedEventDetails();
     EXPECT_FALSE(IsMouseButtonDown());
@@ -1289,7 +1286,7 @@ TEST_P(EventDispatcherTest, SetExplicitCapture) {
     const ui::PointerEvent press_event(ui::MouseEvent(
         ui::ET_MOUSE_PRESSED, gfx::Point(5, 5), gfx::Point(5, 5),
         base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-    DispatchEvent(dispatcher, press_event, 0,
+    DispatchEvent(dispatcher, press_event,
                   EventDispatcher::AcceleratorMatchPhase::ANY);
 
     // Events should target the root.
@@ -1352,7 +1349,7 @@ TEST_P(EventDispatcherTest, ExplicitCaptureOverridesImplicitCapture) {
     const ui::PointerEvent touch_event(ui::TouchEvent(
         ui::ET_TOUCH_PRESSED, gfx::Point(12, 13), base::TimeTicks(),
         ui::PointerDetails(ui::EventPointerType::POINTER_TYPE_TOUCH, 1)));
-    DispatchEvent(dispatcher, touch_event, 0,
+    DispatchEvent(dispatcher, touch_event,
                   EventDispatcher::AcceleratorMatchPhase::ANY);
   }
 
@@ -1385,7 +1382,7 @@ TEST_P(EventDispatcherTest, ExplicitCaptureOverridesImplicitCapture) {
   const ui::PointerEvent press_event(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(15, 15), gfx::Point(15, 15),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(dispatcher, press_event, 0,
+  DispatchEvent(dispatcher, press_event,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   // Events should target the root.
@@ -1406,7 +1403,7 @@ TEST_P(EventDispatcherTest, CaptureUpdatesActivePointerTargets) {
     const ui::PointerEvent press_event(ui::MouseEvent(
         ui::ET_MOUSE_PRESSED, gfx::Point(5, 5), gfx::Point(5, 5),
         base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-    DispatchEvent(dispatcher, press_event, 0,
+    DispatchEvent(dispatcher, press_event,
                   EventDispatcher::AcceleratorMatchPhase::ANY);
 
     std::unique_ptr<DispatchedEventDetails> details =
@@ -1418,7 +1415,7 @@ TEST_P(EventDispatcherTest, CaptureUpdatesActivePointerTargets) {
     const ui::PointerEvent touch_event(ui::TouchEvent(
         ui::ET_TOUCH_PRESSED, gfx::Point(12, 13), base::TimeTicks(),
         ui::PointerDetails(ui::EventPointerType::POINTER_TYPE_TOUCH, 1)));
-    DispatchEvent(dispatcher, touch_event, 0,
+    DispatchEvent(dispatcher, touch_event,
                   EventDispatcher::AcceleratorMatchPhase::ANY);
   }
 
@@ -1489,7 +1486,7 @@ TEST_P(EventDispatcherTest, CaptureInNonClientAreaOverridesActualPoint) {
   const ui::PointerEvent press_event(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(6, 6), gfx::Point(6, 6),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(event_dispatcher(), press_event, 0,
+  DispatchEvent(event_dispatcher(), press_event,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   // Events should target child and be in the client area.
@@ -1510,7 +1507,7 @@ TEST_P(EventDispatcherTest, ProcessPointerEvents) {
     const ui::PointerEvent pointer_event(ui::MouseEvent(
         ui::ET_MOUSE_PRESSED, gfx::Point(20, 25), gfx::Point(20, 25),
         base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-    DispatchEvent(event_dispatcher(), pointer_event, 0,
+    DispatchEvent(event_dispatcher(), pointer_event,
                   EventDispatcher::AcceleratorMatchPhase::ANY);
 
     std::unique_ptr<DispatchedEventDetails> details =
@@ -1532,7 +1529,7 @@ TEST_P(EventDispatcherTest, ProcessPointerEvents) {
         ui::ET_TOUCH_RELEASED, gfx::Point(25, 20), base::TimeTicks(),
         ui::PointerDetails(ui::EventPointerType::POINTER_TYPE_TOUCH,
                            touch_id)));
-    DispatchEvent(event_dispatcher(), pointer_event, 0,
+    DispatchEvent(event_dispatcher(), pointer_event,
                   EventDispatcher::AcceleratorMatchPhase::ANY);
 
     std::unique_ptr<DispatchedEventDetails> details =
@@ -1560,7 +1557,7 @@ TEST_P(EventDispatcherTest, ResetClearsPointerDown) {
   const ui::PointerEvent ui_event(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(20, 25), gfx::Point(20, 25),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(event_dispatcher(), ui_event, 0,
+  DispatchEvent(event_dispatcher(), ui_event,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   std::unique_ptr<DispatchedEventDetails> details =
@@ -1604,7 +1601,7 @@ TEST_P(EventDispatcherTest, ModalWindowEventOnModalParent) {
   const ui::PointerEvent mouse_pressed(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(15, 15), gfx::Point(15, 15),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(event_dispatcher(), mouse_pressed, 0,
+  DispatchEvent(event_dispatcher(), mouse_pressed,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
   // As |w2| is modal and the event is over |w1|, no events should be queued,
   // and the delegate should be informed of this.
@@ -1616,7 +1613,7 @@ TEST_P(EventDispatcherTest, ModalWindowEventOnModalParent) {
   const ui::PointerEvent mouse_released(ui::MouseEvent(
       ui::ET_MOUSE_RELEASED, gfx::Point(15, 15), gfx::Point(15, 15),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(event_dispatcher(), mouse_released, 0,
+  DispatchEvent(event_dispatcher(), mouse_released,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
   ASSERT_FALSE(test_event_dispatcher_delegate()->has_queued_events());
   EXPECT_FALSE(test_event_dispatcher_delegate()->window_that_blocked_event());
@@ -1625,7 +1622,7 @@ TEST_P(EventDispatcherTest, ModalWindowEventOnModalParent) {
   const ui::PointerEvent mouse_pressed2(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(55, 15), gfx::Point(55, 15),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(event_dispatcher(), mouse_pressed2, 0,
+  DispatchEvent(event_dispatcher(), mouse_pressed2,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
   std::unique_ptr<DispatchedEventDetails> details =
       test_event_dispatcher_delegate()->GetAndAdvanceDispatchedEventDetails();
@@ -1657,7 +1654,7 @@ TEST_P(EventDispatcherTest, ModalWindowEventOnModalChild) {
   const ui::PointerEvent mouse_pressed(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(55, 15), gfx::Point(55, 15),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(event_dispatcher(), mouse_pressed, 0,
+  DispatchEvent(event_dispatcher(), mouse_pressed,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   std::unique_ptr<DispatchedEventDetails> details =
@@ -1693,7 +1690,7 @@ TEST_P(EventDispatcherTest, ModalWindowEventOnUnrelatedWindow) {
   const ui::PointerEvent mouse_pressed(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(75, 15), gfx::Point(75, 15),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(event_dispatcher(), mouse_pressed, 0,
+  DispatchEvent(event_dispatcher(), mouse_pressed,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   std::unique_ptr<DispatchedEventDetails> details =
@@ -1729,7 +1726,7 @@ TEST_P(EventDispatcherTest, ModalWindowEventOnDescendantOfModalParent) {
   const ui::PointerEvent mouse_pressed(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(25, 25), gfx::Point(25, 25),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(event_dispatcher(), mouse_pressed, 0,
+  DispatchEvent(event_dispatcher(), mouse_pressed,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   // The event is targeted at |w11|, but is blocked by the modal window |w2|.
@@ -1760,7 +1757,7 @@ TEST_P(EventDispatcherTest,
   const ui::PointerEvent mouse_pressed(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(25, 25), gfx::Point(25, 25),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(event_dispatcher(), mouse_pressed, 0,
+  DispatchEvent(event_dispatcher(), mouse_pressed,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   std::unique_ptr<DispatchedEventDetails> details =
@@ -1789,7 +1786,7 @@ TEST_P(EventDispatcherTest, ModalWindowEventOnSystemModal) {
   const ui::PointerEvent mouse_pressed(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(15, 15), gfx::Point(15, 15),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(event_dispatcher(), mouse_pressed, 0,
+  DispatchEvent(event_dispatcher(), mouse_pressed,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   std::unique_ptr<DispatchedEventDetails> details =
@@ -1819,7 +1816,7 @@ TEST_P(EventDispatcherTest, ModalWindowEventOutsideSystemModal) {
   const ui::PointerEvent mouse_pressed(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(45, 15), gfx::Point(45, 15),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(event_dispatcher(), mouse_pressed, 0,
+  DispatchEvent(event_dispatcher(), mouse_pressed,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   ASSERT_TRUE(test_event_dispatcher_delegate()->last_event_target_not_found());
@@ -1844,7 +1841,7 @@ TEST_P(EventDispatcherTest, ModalWindowEventOutsideSystemModalWithFallback) {
   const ui::PointerEvent mouse_pressed(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(45, 15), gfx::Point(45, 15),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(event_dispatcher(), mouse_pressed, 0,
+  DispatchEvent(event_dispatcher(), mouse_pressed,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   std::unique_ptr<DispatchedEventDetails> details =
@@ -1895,7 +1892,7 @@ TEST_P(EventDispatcherTest, ModalWindowEventSubWindowSystemModal) {
         ui::PointerEvent(ui::TouchEvent(
             ui::ET_TOUCH_PRESSED, kTouchData[i].location, base::TimeTicks(),
             ui::PointerDetails(ui::EventPointerType::POINTER_TYPE_TOUCH, 0))),
-        0, EventDispatcher::AcceleratorMatchPhase::ANY);
+        EventDispatcher::AcceleratorMatchPhase::ANY);
     std::unique_ptr<DispatchedEventDetails> details =
         test_event_dispatcher_delegate()->GetAndAdvanceDispatchedEventDetails();
     ASSERT_TRUE(details) << " details is nullptr " << i;
@@ -1907,7 +1904,7 @@ TEST_P(EventDispatcherTest, ModalWindowEventSubWindowSystemModal) {
         ui::PointerEvent(ui::TouchEvent(
             ui::ET_TOUCH_RELEASED, kTouchData[i].location, base::TimeTicks(),
             ui::PointerDetails(ui::EventPointerType::POINTER_TYPE_TOUCH, 0))),
-        0, EventDispatcher::AcceleratorMatchPhase::ANY);
+        EventDispatcher::AcceleratorMatchPhase::ANY);
     test_event_dispatcher_delegate()->GetAndAdvanceDispatchedEventDetails();
   }
 }
@@ -2028,7 +2025,7 @@ TEST_P(EventDispatcherTest, CaptureNotResetOnParentChange) {
   const ui::PointerEvent mouse_pressed(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(15, 15), gfx::Point(15, 15),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(event_dispatcher(), mouse_pressed, 0,
+  DispatchEvent(event_dispatcher(), mouse_pressed,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
   event_dispatcher()->SetCaptureWindow(w11.get(), kClientAreaId);
 
@@ -2166,7 +2163,7 @@ TEST_P(EventDispatcherTest, MousePointerClearedOnDestroy) {
   const ui::PointerEvent move_event(
       ui::MouseEvent(ui::ET_MOUSE_MOVED, gfx::Point(15, 15), gfx::Point(15, 15),
                      base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, 0));
-  DispatchEvent(event_dispatcher(), move_event, 0,
+  DispatchEvent(event_dispatcher(), move_event,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   EXPECT_EQ(c1.get(), event_dispatcher()->mouse_cursor_source_window());
@@ -2188,7 +2185,7 @@ TEST_P(EventDispatcherTest, LocationHonorsTransform) {
   const ui::PointerEvent ui_event(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(20, 25), gfx::Point(20, 25),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(event_dispatcher(), ui_event, 0,
+  DispatchEvent(event_dispatcher(), ui_event,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   std::unique_ptr<DispatchedEventDetails> details =
@@ -2211,7 +2208,7 @@ TEST_P(EventDispatcherTest, MouseMovementsShowCursor) {
   const ui::PointerEvent move1(
       ui::MouseEvent(ui::ET_MOUSE_MOVED, gfx::Point(11, 11), gfx::Point(11, 11),
                      base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, 0));
-  DispatchEvent(event_dispatcher(), move1, 0,
+  DispatchEvent(event_dispatcher(), move1,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   EXPECT_EQ(base::Optional<bool>(true),
@@ -2231,7 +2228,7 @@ TEST_P(EventDispatcherTest, KeyDoesntHideCursorWithNoList) {
   event_dispatcher_delegate->SetFocusedWindowFromEventDispatcher(child.get());
 
   ui::KeyEvent key(ui::ET_KEY_PRESSED, ui::VKEY_A, ui::EF_NONE);
-  DispatchEvent(event_dispatcher(), key, 0,
+  DispatchEvent(event_dispatcher(), key,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   EXPECT_EQ(base::Optional<bool>(),
@@ -2251,7 +2248,7 @@ TEST_P(EventDispatcherTest, KeyDoesntHideCursorOnMatch) {
   event_dispatcher_delegate->SetFocusedWindowFromEventDispatcher(child.get());
 
   ui::KeyEvent key(ui::ET_KEY_PRESSED, ui::VKEY_A, ui::EF_NONE);
-  DispatchEvent(event_dispatcher(), key, 0,
+  DispatchEvent(event_dispatcher(), key,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   EXPECT_EQ(base::Optional<bool>(),
@@ -2271,7 +2268,7 @@ TEST_P(EventDispatcherTest, KeyHidesCursorOnNoMatch) {
   event_dispatcher_delegate->SetFocusedWindowFromEventDispatcher(child.get());
 
   ui::KeyEvent key(ui::ET_KEY_PRESSED, ui::VKEY_A, ui::EF_NONE);
-  DispatchEvent(event_dispatcher(), key, 0,
+  DispatchEvent(event_dispatcher(), key,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   EXPECT_EQ(base::Optional<bool>(false),
@@ -2294,7 +2291,7 @@ TEST_P(EventDispatcherTest, ChildModal) {
   const ui::PointerEvent press_event(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(20, 25), gfx::Point(20, 25),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(event_dispatcher(), press_event, 0,
+  DispatchEvent(event_dispatcher(), press_event,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   // As the event falls over |modal_parent|, but there is a CHILD_MODAL window,
@@ -2340,7 +2337,7 @@ TEST_P(EventDispatcherTest, MouseCursorSourceWindowChangesWithSystemModal) {
   const ui::PointerEvent move(
       ui::MouseEvent(ui::ET_MOUSE_MOVED, gfx::Point(11, 11), gfx::Point(11, 11),
                      base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, 0));
-  DispatchEvent(event_dispatcher(), move, 0,
+  DispatchEvent(event_dispatcher(), move,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   EXPECT_EQ(nullptr, event_dispatcher()->mouse_cursor_source_window());
@@ -2364,14 +2361,15 @@ TEST_P(EventDispatcherTest, DontQueryWhileMouseIsDown) {
   const ui::PointerEvent press_event(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(20, 25), gfx::Point(20, 25),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(event_dispatcher(), press_event, 0,
+  DispatchEvent(event_dispatcher(), press_event,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
   ASSERT_FALSE(event_dispatcher()->IsProcessingEvent());
 
   const ui::PointerEvent move_event(ui::MouseEvent(
       ui::ET_MOUSE_MOVED, gfx::Point(20, 25), gfx::Point(20, 25),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  event_dispatcher()->ProcessEvent(move_event, 0,
+  event_dispatcher()->ProcessEvent(move_event,
+                                   EventLocationFromEvent(move_event),
                                    EventDispatcher::AcceleratorMatchPhase::ANY);
   EXPECT_FALSE(event_dispatcher()->IsProcessingEvent());
 }
@@ -2398,7 +2396,7 @@ TEST_P(EventDispatcherVizTargeterTest, ProcessEvent) {
   const ui::PointerEvent ui_event(ui::MouseEvent(
       ui::ET_MOUSE_PRESSED, gfx::Point(20, 25), gfx::Point(20, 25),
       base::TimeTicks(), ui::EF_LEFT_MOUSE_BUTTON, ui::EF_LEFT_MOUSE_BUTTON));
-  DispatchEvent(event_dispatcher(), ui_event, 0,
+  DispatchEvent(event_dispatcher(), ui_event,
                 EventDispatcher::AcceleratorMatchPhase::ANY);
 
   std::unique_ptr<DispatchedEventDetails> details =

--- a/services/ui/ws/event_location.h
+++ b/services/ui/ws/event_location.h
@@ -1,0 +1,59 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SERVICES_UI_WS_EVENT_LOCATION_H_
+#define SERVICES_UI_WS_EVENT_LOCATION_H_
+
+#include <stdint.h>
+
+#include "ui/display/types/display_constants.h"
+#include "ui/gfx/geometry/point_f.h"
+
+namespace ui {
+namespace ws {
+
+// Contains a location relative to a particular display in two different
+// coordinate systems. The location the event is received at is |raw_location|.
+// |raw_location| is in terms of the pixel display layout. |location| is derived
+// from |raw_location| and in terms of the DIP display layout (but in pixels).
+// Typically |raw_location| is on a single display, in which case |location| is
+// exactly the same value. If there is a grab then the events are still
+// generated for the display the grab was initiated on, even if the mouse moves
+// to another display. As the pixel layout of displays differs from the DIP
+// layout |location| is converted to follow the DIP layout (but in pixels).
+//
+// For example, two displays might have pixels bounds of:
+// 0,0 1000x1000 and 0,1060 1000x1000
+// where as the DIP bounds might be:
+// 0,0 500x500 and 500,0 1000x1000
+// Notice the pixel bounds are staggered along the y-axis and the DIP bounds
+// along the x-axis.
+// If there is a grab on the first display and the mouse moves into the second
+// display then |raw_location| would be 0,1060 which is converted to a
+// |location| of 1000,0 (|display_id| remains the same regardless of the display
+// the mouse is on.
+struct EventLocation {
+  EventLocation() : display_id(display::kInvalidDisplayId) {}
+  explicit EventLocation(int64_t display_id) : display_id(display_id) {}
+  EventLocation(const gfx::PointF& raw_location,
+                const gfx::PointF& location,
+                int64_t display_id)
+      : raw_location(raw_location),
+        location(location),
+        display_id(display_id) {}
+
+  // Location of event in terms of pixel display layout.
+  gfx::PointF raw_location;
+
+  // Location of event in terms of DIP display layout (but in pixels).
+  gfx::PointF location;
+
+  // Id of the display the event was generated from.
+  int64_t display_id;
+};
+
+}  // namespace ws
+}  // namespace ui
+
+#endif  // SERVICES_UI_WS_EVENT_LOCATION_H_

--- a/services/ui/ws/event_targeter.h
+++ b/services/ui/ws/event_targeter.h
@@ -17,19 +17,14 @@ namespace ui {
 namespace ws {
 
 class EventTargeterDelegate;
+struct EventLocation;
 
 namespace test {
 class EventTargeterTestApi;
 }
 
-// Contains a location relative to a particular display.
-struct DisplayLocation {
-  gfx::Point location;
-  int64_t display_id;
-};
-
 using HitTestCallback =
-    base::OnceCallback<void(const DisplayLocation&, const DeepestWindow&)>;
+    base::OnceCallback<void(const EventLocation&, const DeepestWindow&)>;
 
 // Finds the target window for a location.
 class EventTargeter {
@@ -40,14 +35,14 @@ class EventTargeter {
   // Calls WindowFinder to find the target for |display_location|. |callback| is
   // called with the found target.
   void FindTargetForLocation(EventSource event_source,
-                             const DisplayLocation& display_location,
+                             const EventLocation& event_location,
                              HitTestCallback callback);
 
  private:
   friend class test::EventTargeterTestApi;
 
   void FindTargetForLocationNow(EventSource event_source,
-                                const DisplayLocation& display_location,
+                                const EventLocation& display_location,
                                 HitTestCallback callback);
 
   EventTargeterDelegate* event_targeter_delegate_;

--- a/services/ui/ws/event_targeter_delegate.h
+++ b/services/ui/ws/event_targeter_delegate.h
@@ -7,10 +7,6 @@
 
 #include <stdint.h>
 
-namespace gfx {
-class Point;
-}
-
 namespace viz {
 class HitTestQuery;
 }
@@ -22,10 +18,9 @@ class ServerWindow;
 // Used by EventTargeter to talk to WindowManagerState.
 class EventTargeterDelegate {
  public:
-  // Calls EventDispatcherDelegate::GetRootWindowContaining, see
+  // Calls EventDispatcherDelegate::GetRootWindowForDisplay(), see
   // event_dispatcher_delegate.h for details.
-  virtual ServerWindow* GetRootWindowContaining(gfx::Point* location_in_display,
-                                                int64_t* display_id) = 0;
+  virtual ServerWindow* GetRootWindowForDisplay(int64_t display_id) = 0;
 
   // Calls EventDispatcherDelegate::ProcessNextAvailableEvent, see
   // event_dispatcher_delegate.h for details.

--- a/services/ui/ws/test_change_tracker.h
+++ b/services/ui/ws/test_change_tracker.h
@@ -15,6 +15,8 @@
 #include "services/ui/common/types.h"
 #include "services/ui/public/interfaces/window_tree.mojom.h"
 #include "ui/gfx/geometry/mojo/geometry.mojom.h"
+#include "ui/gfx/geometry/point.h"
+#include "ui/gfx/geometry/point_f.h"
 
 namespace ui {
 
@@ -97,6 +99,9 @@ struct Change {
   gfx::Transform transform;
   // Set in OnWindowInputEvent() if the event is a KeyEvent.
   std::unordered_map<std::string, std::vector<uint8_t>> key_event_properties;
+  int64_t display_id;
+  gfx::Point location1;
+  gfx::PointF location2;
 };
 
 // Converts Changes to string descriptions.
@@ -168,9 +173,12 @@ class TestChangeTracker {
   void OnWindowVisibilityChanged(Id window_id, bool visible);
   void OnWindowOpacityChanged(Id window_id, float opacity);
   void OnWindowParentDrawnStateChanged(Id window_id, bool drawn);
-  void OnWindowInputEvent(Id window_id,
-                          const ui::Event& event,
-                          bool matches_pointer_watcher);
+  void OnWindowInputEvent(
+      Id window_id,
+      const ui::Event& event,
+      int64_t display_id,
+      const gfx::PointF& event_location_in_screen_pixel_layout,
+      bool matches_pointer_watcher);
   void OnPointerEventObserved(const ui::Event& event,
                               uint32_t window_id);
   void OnWindowSharedPropertyChanged(

--- a/services/ui/ws/test_utils.cc
+++ b/services/ui/ws/test_utils.cc
@@ -47,6 +47,7 @@ display::ViewportMetrics MakeViewportMetrics(const display::Display& display) {
   display::ViewportMetrics metrics;
   metrics.bounds_in_pixels.set_size(pixel_size);
   metrics.device_scale_factor = display.device_scale_factor();
+  metrics.ui_scale_factor = 1;
   return metrics;
 }
 
@@ -109,10 +110,15 @@ int64_t TestScreenManager::AddDisplay(const display::Display& input_display) {
   return display_id;
 }
 
-void TestScreenManager::ModifyDisplay(const display::Display& display) {
+void TestScreenManager::ModifyDisplay(
+    const display::Display& display,
+    const base::Optional<display::ViewportMetrics>& metrics) {
   DCHECK(display_ids_.count(display.id()) == 1);
   screen_->display_list().UpdateDisplay(display);
-  delegate_->OnDisplayModified(display, MakeViewportMetrics(display));
+  if (metrics)
+    delegate_->OnDisplayModified(display, *metrics);
+  else
+    delegate_->OnDisplayModified(display, MakeViewportMetrics(display));
 }
 
 void TestScreenManager::RemoveDisplay(int64_t display_id) {
@@ -404,12 +410,16 @@ void TestWindowTreeClient::OnWindowSharedPropertyChanged(
   tracker_.OnWindowSharedPropertyChanged(window, name, new_data);
 }
 
-void TestWindowTreeClient::OnWindowInputEvent(uint32_t event_id,
-                                              uint32_t window,
-                                              int64_t display_id,
-                                              std::unique_ptr<ui::Event> event,
-                                              bool matches_pointer_watcher) {
-  tracker_.OnWindowInputEvent(window, *event.get(), matches_pointer_watcher);
+void TestWindowTreeClient::OnWindowInputEvent(
+    uint32_t event_id,
+    uint32_t window,
+    int64_t display_id,
+    const gfx::PointF& event_location_in_screen_pixel_layout,
+    std::unique_ptr<ui::Event> event,
+    bool matches_pointer_watcher) {
+  tracker_.OnWindowInputEvent(window, *event.get(), display_id,
+                              event_location_in_screen_pixel_layout,
+                              matches_pointer_watcher);
 }
 
 void TestWindowTreeClient::OnPointerEventObserved(

--- a/services/ui/ws/test_utils.h
+++ b/services/ui/ws/test_utils.h
@@ -14,6 +14,7 @@
 #include "base/atomicops.h"
 #include "base/memory/ptr_util.h"
 #include "base/message_loop/message_loop.h"
+#include "base/optional.h"
 #include "base/single_thread_task_runner.h"
 #include "services/service_manager/public/cpp/bind_source_info.h"
 #include "services/ui/display/screen_manager.h"
@@ -71,7 +72,9 @@ class TestScreenManager : public display::ScreenManager {
   int64_t AddDisplay(const display::Display& display);
 
   // Calls OnDisplayModified() on delegate.
-  void ModifyDisplay(const display::Display& display);
+  void ModifyDisplay(const display::Display& display,
+                     const base::Optional<display::ViewportMetrics>& metrics =
+                         base::Optional<display::ViewportMetrics>());
 
   // Calls OnDisplayRemoved() on delegate.
   void RemoveDisplay(int64_t id);
@@ -244,10 +247,10 @@ class WindowManagerStateTestApi {
 
   void DispatchInputEventToWindow(ServerWindow* target,
                                   ClientSpecificId client_id,
-                                  int64_t display_id,
+                                  const EventLocation& event_location,
                                   const ui::Event& event,
                                   Accelerator* accelerator) {
-    wms_->DispatchInputEventToWindow(target, client_id, display_id, event,
+    wms_->DispatchInputEventToWindow(target, client_id, event_location, event,
                                      accelerator);
   }
 
@@ -256,7 +259,7 @@ class WindowManagerStateTestApi {
     return wms_->GetEventTargetClientId(window, in_nonclient_area);
   }
 
-  void ProcessEvent(const ui::Event& event, int64_t display_id = 0) {
+  void ProcessEvent(ui::Event* event, int64_t display_id = 0) {
     wms_->ProcessEvent(event, display_id);
   }
 
@@ -528,11 +531,13 @@ class TestWindowTreeClient : public ui::mojom::WindowTreeClient {
       uint32_t window,
       const std::string& name,
       const base::Optional<std::vector<uint8_t>>& new_data) override;
-  void OnWindowInputEvent(uint32_t event_id,
-                          uint32_t window,
-                          int64_t display_id,
-                          std::unique_ptr<ui::Event> event,
-                          bool matches_pointer_watcher) override;
+  void OnWindowInputEvent(
+      uint32_t event_id,
+      uint32_t window,
+      int64_t display_id,
+      const gfx::PointF& event_location_in_screen_pixel_layout,
+      std::unique_ptr<ui::Event> event,
+      bool matches_pointer_watcher) override;
   void OnPointerEventObserved(std::unique_ptr<ui::Event> event,
                               uint32_t window_id,
                               int64_t display_id) override;

--- a/services/ui/ws/window_manager_state.cc
+++ b/services/ui/ws/window_manager_state.cc
@@ -17,6 +17,7 @@
 #include "services/ui/ws/display.h"
 #include "services/ui/ws/display_creation_config.h"
 #include "services/ui/ws/display_manager.h"
+#include "services/ui/ws/event_location.h"
 #include "services/ui/ws/event_targeter.h"
 #include "services/ui/ws/platform_display.h"
 #include "services/ui/ws/server_window.h"
@@ -29,6 +30,7 @@
 #include "ui/events/event.h"
 #include "ui/gfx/geometry/dip_util.h"
 #include "ui/gfx/geometry/point3_f.h"
+#include "ui/gfx/geometry/point_conversions.h"
 
 namespace ui {
 namespace ws {
@@ -46,7 +48,7 @@ base::TimeDelta GetDefaultAckTimerDelay() {
 #endif
 }
 
-bool EventsCanBeCoalesced(const ui::Event& one, const ui::Event& two) {
+bool CanEventsBeCoalesced(const ui::Event& one, const ui::Event& two) {
   if (one.type() != two.type() || one.flags() != two.flags())
     return false;
 
@@ -75,6 +77,24 @@ const ServerWindow* GetEmbedRoot(const ServerWindow* window) {
   while (embed_root && embed_root->id().client_id == window->id().client_id)
     embed_root = embed_root->parent();
   return embed_root;
+}
+
+const gfx::Rect& GetDisplayBoundsInPixels(Display* display) {
+  return display->GetViewportMetrics().bounds_in_pixels;
+}
+
+gfx::Point PixelsToDips(Display* display, const gfx::Point& location) {
+  return gfx::ConvertPointToDIP(
+      display->GetDisplay().device_scale_factor() /
+          display->GetViewportMetrics().ui_scale_factor,
+      location);
+}
+
+gfx::Point DipsToPixels(Display* display, const gfx::Point& location) {
+  return gfx::ConvertPointToPixel(
+      display->GetDisplay().device_scale_factor() /
+          display->GetViewportMetrics().ui_scale_factor,
+      location);
 }
 
 }  // namespace
@@ -135,8 +155,14 @@ bool WindowManagerState::DebugAccelerator::Matches(
          !event.is_char();
 }
 
-WindowManagerState::QueuedEvent::QueuedEvent() {}
-WindowManagerState::QueuedEvent::~QueuedEvent() {}
+struct WindowManagerState::QueuedEvent {
+  QueuedEvent() = default;
+  ~QueuedEvent() = default;
+
+  std::unique_ptr<Event> event;
+  std::unique_ptr<ProcessedEventTarget> processed_target;
+  EventLocation event_location;
+};
 
 WindowManagerState::WindowManagerState(WindowTree* window_tree)
     : window_tree_(window_tree),
@@ -312,13 +338,12 @@ void WindowManagerState::Activate(const gfx::Point& mouse_location_on_display,
 
   // Fake a mouse event to update cursor and ensure mouse location in client
   // is up to date.
-  const PointerEvent move_event(
-      ET_POINTER_MOVED, mouse_location_on_display, mouse_location_on_display,
-      EF_NONE, EF_NONE,
-      PointerDetails(EventPointerType::POINTER_TYPE_MOUSE,
-                     MouseEvent::kMousePointerId),
-      base::TimeTicks::Now());
-  ProcessEvent(move_event, display_id);
+  PointerEvent move_event(ET_POINTER_MOVED, mouse_location_on_display,
+                          mouse_location_on_display, EF_NONE, EF_NONE,
+                          PointerDetails(EventPointerType::POINTER_TYPE_MOUSE,
+                                         MouseEvent::kMousePointerId),
+                          base::TimeTicks::Now());
+  ProcessEvent(&move_event, display_id);
 }
 
 void WindowManagerState::Deactivate() {
@@ -330,24 +355,30 @@ void WindowManagerState::Deactivate() {
   event_queue.swap(event_queue_);
 }
 
-void WindowManagerState::ProcessEvent(const ui::Event& event,
-                                      int64_t display_id) {
+void WindowManagerState::ProcessEvent(ui::Event* event, int64_t display_id) {
+  EventLocation event_location(display_id);
+  if (event->IsLocatedEvent()) {
+    event_location.raw_location = event->AsLocatedEvent()->location_f();
+    AdjustEventLocation(display_id, event->AsLocatedEvent());
+    event_location.location = event->AsLocatedEvent()->root_location_f();
+  }
+
   // If this is still waiting for an ack from a previously sent event, then
   // queue up the event to be dispatched once the ack is received.
   if (event_dispatcher_.IsProcessingEvent() ||
       in_flight_event_dispatch_details_) {
     if (!event_queue_.empty() && !event_queue_.back()->processed_target &&
-        EventsCanBeCoalesced(*event_queue_.back()->event, event)) {
+        CanEventsBeCoalesced(*event_queue_.back()->event, *event)) {
       event_queue_.back()->event = CoalesceEvents(
-          std::move(event_queue_.back()->event), ui::Event::Clone(event));
-      event_queue_.back()->display_id = display_id;
+          std::move(event_queue_.back()->event), ui::Event::Clone(*event));
+      event_queue_.back()->event_location = event_location;
       return;
     }
-    QueueEvent(event, nullptr, display_id);
+    QueueEvent(*event, nullptr, event_location);
     return;
   }
 
-  ProcessEventImpl(event, display_id);
+  ProcessEventImpl(*event, event_location);
 }
 
 void WindowManagerState::OnAcceleratorAck(
@@ -365,7 +396,7 @@ void WindowManagerState::OnAcceleratorAck(
     if (!properties.empty())
       details->event->AsKeyEvent()->SetProperties(properties);
     event_dispatcher_.ProcessEvent(
-        *details->event, details->display_id,
+        *details->event, EventLocation(details->display_id),
         EventDispatcher::AcceleratorMatchPhase::POST_ONLY);
   } else {
     // We're not going to process the event any further, notify event observers.
@@ -460,23 +491,23 @@ void WindowManagerState::OnEventAckTimeout(ClientSpecificId client_id) {
 }
 
 void WindowManagerState::ProcessEventImpl(const ui::Event& event,
-                                          int64_t display_id) {
+                                          const EventLocation& event_location) {
   DCHECK(!in_flight_event_dispatch_details_ &&
          !event_dispatcher_.IsProcessingEvent());
   // Debug accelerators are always checked and don't interfere with processing.
-  ProcessDebugAccelerator(event, display_id);
-  event_dispatcher_.ProcessEvent(event, display_id,
+  ProcessDebugAccelerator(event, event_location.display_id);
+  event_dispatcher_.ProcessEvent(event, event_location,
                                  EventDispatcher::AcceleratorMatchPhase::ANY);
 }
 
 void WindowManagerState::QueueEvent(
     const ui::Event& event,
     std::unique_ptr<ProcessedEventTarget> processed_event_target,
-    int64_t display_id) {
+    const EventLocation& event_location) {
   std::unique_ptr<QueuedEvent> queued_event(new QueuedEvent);
   queued_event->event = ui::Event::Clone(event);
   queued_event->processed_target = std::move(processed_event_target);
-  queued_event->display_id = display_id;
+  queued_event->event_location = event_location;
   event_queue_.push(std::move(queued_event));
 }
 
@@ -485,7 +516,7 @@ void WindowManagerState::QueueEvent(
 void WindowManagerState::DispatchInputEventToWindowImpl(
     ServerWindow* target,
     ClientSpecificId client_id,
-    int64_t display_id,
+    const EventLocation& event_location,
     const ui::Event& event,
     base::WeakPtr<Accelerator> accelerator) {
   DCHECK(!in_flight_event_dispatch_details_);
@@ -500,16 +531,16 @@ void WindowManagerState::DispatchInputEventToWindowImpl(
 
   WindowTree* tree = window_server()->GetTreeWithId(client_id);
   DCHECK(tree);
-  ScheduleInputEventTimeout(tree, target, display_id, event,
+  ScheduleInputEventTimeout(tree, target, event_location.display_id, event,
                             EventDispatchPhase::TARGET);
   in_flight_event_dispatch_details_->post_target_accelerator = accelerator;
 
   // Ignore |tree| because it will receive the event via normal dispatch.
   window_server()->SendToPointerWatchers(event, user_id(), target, tree,
-                                         display_id);
+                                         event_location.display_id);
 
   tree->DispatchInputEvent(
-      target, event, display_id,
+      target, event, event_location,
       base::BindOnce(
           &WindowManagerState::OnEventAck,
           in_flight_event_dispatch_details_->weak_factory.GetWeakPtr(), tree));
@@ -602,6 +633,62 @@ bool WindowManagerState::ConvertPointToScreen(int64_t display_id,
   return true;
 }
 
+Display* WindowManagerState::FindDisplayContainingPixelLocation(
+    const gfx::Point& screen_pixels) {
+  for (auto& display_root_ptr : window_manager_display_roots_) {
+    if (GetDisplayBoundsInPixels(display_root_ptr->display())
+            .Contains(screen_pixels)) {
+      return display_root_ptr->display();
+    }
+  }
+  return nullptr;
+}
+
+void WindowManagerState::AdjustEventLocation(int64_t display_id,
+                                             LocatedEvent* event) {
+  if (window_manager_display_roots_.empty())
+    return;
+
+  Display* display = display_manager()->GetDisplayById(display_id);
+  if (!display)
+    return;
+
+  const gfx::Rect& display_bounds_in_pixels = GetDisplayBoundsInPixels(display);
+  // Typical case is the display contains the location.
+  if (gfx::Rect(display_bounds_in_pixels.size()).Contains(event->location())) {
+    return;
+  }
+
+  // The location is outside the bounds of the specified display. This generally
+  // happens when there is a grab and the mouse is moved to another display.
+  // When this happens the location of the event is in terms of the pixel
+  // display layout. Find the display using the pixel display layout.
+  const gfx::Point screen_pixels =
+      event->location() + display_bounds_in_pixels.origin().OffsetFromOrigin();
+  Display* containing_display =
+      FindDisplayContainingPixelLocation(screen_pixels);
+  if (!containing_display) {
+    DVLOG(1) << "Invalid event location " << event->location().ToString()
+             << " / display id " << display_id;
+    return;
+  }
+
+  // Adjust the location of the event to be in terms of the DIP display layout
+  // (but in pixels). See EventLocation for details on this.
+  const gfx::Point location_in_containing_display =
+      screen_pixels -
+      GetDisplayBoundsInPixels(containing_display).origin().OffsetFromOrigin();
+  const gfx::Point screen_dip_location =
+      containing_display->GetDisplay().bounds().origin() +
+      PixelsToDips(containing_display, location_in_containing_display)
+          .OffsetFromOrigin();
+  const gfx::Point pixel_relative_location = DipsToPixels(
+      display, screen_dip_location -
+                   display->GetDisplay().bounds().origin().OffsetFromOrigin());
+  event->set_location(pixel_relative_location);
+  event->set_root_location(pixel_relative_location);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // EventDispatcherDelegate:
 
@@ -676,9 +763,9 @@ void WindowManagerState::OnCaptureChanged(ServerWindow* new_capture,
 }
 
 void WindowManagerState::OnMouseCursorLocationChanged(
-    const gfx::Point& point_in_display,
+    const gfx::PointF& point_in_display,
     int64_t display_id) {
-  gfx::Point point_in_screen(point_in_display);
+  gfx::Point point_in_screen = gfx::ToFlooredPoint(point_in_display);
   if (ConvertPointToScreen(display_id, &point_in_screen)) {
     window_server()
         ->display_manager()
@@ -707,25 +794,26 @@ void WindowManagerState::OnEventChangesCursorTouchVisibility(
   cursor_state_.SetCursorTouchVisible(visible);
 }
 
-void WindowManagerState::DispatchInputEventToWindow(ServerWindow* target,
-                                                    ClientSpecificId client_id,
-                                                    int64_t display_id,
-                                                    const ui::Event& event,
-                                                    Accelerator* accelerator) {
+void WindowManagerState::DispatchInputEventToWindow(
+    ServerWindow* target,
+    ClientSpecificId client_id,
+    const EventLocation& event_location,
+    const ui::Event& event,
+    Accelerator* accelerator) {
   DCHECK(IsActive());
   // TODO(sky): this needs to see if another wms has capture and if so forward
   // to it.
   if (in_flight_event_dispatch_details_) {
     std::unique_ptr<ProcessedEventTarget> processed_event_target(
         new ProcessedEventTarget(target, client_id, accelerator));
-    QueueEvent(event, std::move(processed_event_target), display_id);
+    QueueEvent(event, std::move(processed_event_target), event_location);
     return;
   }
 
   base::WeakPtr<Accelerator> weak_accelerator;
   if (accelerator)
     weak_accelerator = accelerator->GetWeakPtr();
-  DispatchInputEventToWindowImpl(target, client_id, display_id, event,
+  DispatchInputEventToWindowImpl(target, client_id, event_location, event,
                                  weak_accelerator);
 }
 
@@ -743,14 +831,15 @@ void WindowManagerState::ProcessNextAvailableEvent() {
     std::unique_ptr<QueuedEvent> queued_event = std::move(event_queue_.front());
     event_queue_.pop();
     if (!queued_event->processed_target) {
-      ProcessEventImpl(*queued_event->event, queued_event->display_id);
+      ProcessEventImpl(*queued_event->event, queued_event->event_location);
       return;
     }
     if (queued_event->processed_target->IsValid()) {
       DispatchInputEventToWindowImpl(
           queued_event->processed_target->window(),
-          queued_event->processed_target->client_id(), queued_event->display_id,
-          *queued_event->event, queued_event->processed_target->accelerator());
+          queued_event->processed_target->client_id(),
+          queued_event->event_location, *queued_event->event,
+          queued_event->processed_target->accelerator());
       return;
     }
   }
@@ -784,46 +873,13 @@ ClientSpecificId WindowManagerState::GetEventTargetClientId(
   return tree->id();
 }
 
-ServerWindow* WindowManagerState::GetRootWindowContaining(
-    gfx::Point* location_in_display,
-    int64_t* display_id) {
-  if (window_manager_display_roots_.empty())
+ServerWindow* WindowManagerState::GetRootWindowForDisplay(int64_t display_id) {
+  Display* display = display_manager()->GetDisplayById(display_id);
+  if (!display)
     return nullptr;
 
-  gfx::Point location_in_screen(*location_in_display);
-  if (!ConvertPointToScreen(*display_id, &location_in_screen))
-    return nullptr;
-
-  WindowManagerDisplayRoot* target_display_root = nullptr;
-  for (auto& display_root_ptr : window_manager_display_roots_) {
-    if (display_root_ptr->display()->GetDisplay().bounds().Contains(
-            location_in_screen)) {
-      target_display_root = display_root_ptr.get();
-      break;
-    }
-  }
-
-  // TODO(kylechar): Better handle locations outside the window. Overlapping X11
-  // windows, dragging and touch sensors need to be handled properly.
-  if (!target_display_root) {
-    DVLOG(1) << "Invalid event location " << location_in_display->ToString()
-             << " / display id " << *display_id;
-    target_display_root = window_manager_display_roots_.begin()->get();
-  }
-
-  // Update |location_in_display| and |display_id| if the target display is
-  // different from the originated display, e.g. drag-and-drop.
-  if (*display_id != target_display_root->display()->GetId()) {
-    gfx::Point origin =
-        target_display_root->display()->GetDisplay().bounds().origin();
-    *location_in_display = location_in_screen - origin.OffsetFromOrigin();
-    *location_in_display = gfx::ConvertPointToPixel(
-        target_display_root->display()->GetDisplay().device_scale_factor(),
-        *location_in_display);
-    *display_id = target_display_root->display()->GetId();
-  }
-
-  return target_display_root->GetClientVisibleRoot();
+  return display->GetWindowManagerDisplayRootForUser(user_id())
+      ->GetClientVisibleRoot();
 }
 
 ServerWindow* WindowManagerState::GetRootWindowForEventDispatch(

--- a/services/ui/ws/window_manager_state.h
+++ b/services/ui/ws/window_manager_state.h
@@ -113,8 +113,9 @@ class WindowManagerState : public EventDispatcherDelegate,
                 int64_t display_id);
   void Deactivate();
 
-  // Processes an event from PlatformDisplay.
-  void ProcessEvent(const Event& event, int64_t display_id);
+  // Processes an event from PlatformDisplay. This doesn't take ownership of
+  // |event|, but it may modify it.
+  void ProcessEvent(ui::Event* event, int64_t display_id);
 
  private:
   class ProcessedEventTarget;
@@ -157,14 +158,7 @@ class WindowManagerState : public EventDispatcherDelegate,
   //   |processed_target| are valid.
   // The second case happens if EventDispatcher generates more than one event
   // at a time.
-  struct QueuedEvent {
-    QueuedEvent();
-    ~QueuedEvent();
-
-    std::unique_ptr<Event> event;
-    std::unique_ptr<ProcessedEventTarget> processed_target;
-    int64_t display_id;
-  };
+  struct QueuedEvent;
 
   // Tracks state associated with an event being dispatched to a client.
   struct InFlightEventDispatchDetails {
@@ -220,17 +214,18 @@ class WindowManagerState : public EventDispatcherDelegate,
 
   // Implemenation of processing an event with a match phase of all. This
   // handles debug accelerators and forwards to EventDispatcher.
-  void ProcessEventImpl(const Event& event, int64_t display_id);
+  void ProcessEventImpl(const Event& event,
+                        const EventLocation& event_location);
 
   // Schedules an event to be processed later.
   void QueueEvent(const Event& event,
                   std::unique_ptr<ProcessedEventTarget> processed_event_target,
-                  int64_t display_id);
+                  const EventLocation& event_location);
 
   // Dispatches the event to the appropriate client and starts the ack timer.
   void DispatchInputEventToWindowImpl(ServerWindow* target,
                                       ClientSpecificId client_id,
-                                      int64_t display_id,
+                                      const EventLocation& event_location,
                                       const Event& event,
                                       base::WeakPtr<Accelerator> accelerator);
 
@@ -257,6 +252,10 @@ class WindowManagerState : public EventDispatcherDelegate,
   // false otherwise.
   bool ConvertPointToScreen(int64_t display_id, gfx::Point* point);
 
+  Display* FindDisplayContainingPixelLocation(const gfx::Point& screen_pixels);
+
+  void AdjustEventLocation(int64_t display_id, LocatedEvent* event);
+
   // EventDispatcherDelegate:
   void OnAccelerator(uint32_t accelerator_id,
                      int64_t display_id,
@@ -269,7 +268,7 @@ class WindowManagerState : public EventDispatcherDelegate,
   void UpdateNativeCursorFromDispatcher() override;
   void OnCaptureChanged(ServerWindow* new_capture,
                         ServerWindow* old_capture) override;
-  void OnMouseCursorLocationChanged(const gfx::Point& point,
+  void OnMouseCursorLocationChanged(const gfx::PointF& point,
                                     int64_t display_id) override;
   void OnEventChangesCursorVisibility(const ui::Event& event,
                                       bool visible) override;
@@ -277,7 +276,7 @@ class WindowManagerState : public EventDispatcherDelegate,
                                            bool visible) override;
   void DispatchInputEventToWindow(ServerWindow* target,
                                   ClientSpecificId client_id,
-                                  int64_t display_id,
+                                  const EventLocation& event_location,
                                   const Event& event,
                                   Accelerator* accelerator) override;
   // Processes the next valid event in |event_queue_|. If the event has already
@@ -286,8 +285,7 @@ class WindowManagerState : public EventDispatcherDelegate,
   void ProcessNextAvailableEvent() override;
   ClientSpecificId GetEventTargetClientId(const ServerWindow* window,
                                           bool in_nonclient_area) override;
-  ServerWindow* GetRootWindowContaining(gfx::Point* location_in_display,
-                                        int64_t* display_id) override;
+  ServerWindow* GetRootWindowForDisplay(int64_t display_id) override;
   ServerWindow* GetRootWindowForEventDispatch(ServerWindow* window) override;
   void OnEventTargetNotFound(const Event& event, int64_t display_id) override;
   ServerWindow* GetFallbackTargetForEventBlockedByModal(

--- a/services/ui/ws/window_manager_state_unittest.cc
+++ b/services/ui/ws/window_manager_state_unittest.cc
@@ -19,6 +19,7 @@
 #include "services/ui/ws/cursor_location_manager.h"
 #include "services/ui/ws/display.h"
 #include "services/ui/ws/display_manager.h"
+#include "services/ui/ws/event_location.h"
 #include "services/ui/ws/platform_display.h"
 #include "services/ui/ws/test_change_tracker.h"
 #include "services/ui/ws/test_server_window_delegate.h"
@@ -50,7 +51,7 @@ class WindowManagerStateTest : public testing::Test {
                            ServerWindow** server_window);
 
   void DispatchInputEventToWindow(ServerWindow* target,
-                                  int64_t display_id,
+                                  const EventLocation& event_location,
                                   const ui::Event& event,
                                   Accelerator* accelerator);
   void OnEventAckTimeout(ClientSpecificId client_id);
@@ -145,12 +146,12 @@ void WindowManagerStateTest::CreateSecondaryTree(
 
 void WindowManagerStateTest::DispatchInputEventToWindow(
     ServerWindow* target,
-    int64_t display_id,
+    const EventLocation& event_location,
     const ui::Event& event,
     Accelerator* accelerator) {
   WindowManagerStateTestApi test_api(window_manager_state_);
   ClientSpecificId client_id = test_api.GetEventTargetClientId(target, false);
-  test_api.DispatchInputEventToWindow(target, client_id, display_id, event,
+  test_api.DispatchInputEventToWindow(target, client_id, event_location, event,
                                       accelerator);
 }
 
@@ -170,7 +171,7 @@ void WindowManagerStateTest::SetUp() {
   window_tree_ = window_event_targeting_helper_.last_binding()->tree();
   window_tree_client_ =
       window_event_targeting_helper_.last_window_tree_client();
-  DCHECK(window_tree_->HasRoot(window_));
+  ASSERT_TRUE(window_tree_->HasRoot(window_));
 
   WindowTreeTestApi(tree()).set_window_manager_internal(&window_manager_);
   wm_client()->tracker()->changes()->clear();
@@ -200,6 +201,16 @@ class WindowManagerStateTestAsync : public WindowManagerStateTest {
   DISALLOW_COPY_AND_ASSIGN(WindowManagerStateTestAsync);
 };
 
+EventLocation EventLocationFromEvent(const Event& event,
+                                     const Display& display) {
+  EventLocation event_location(display.GetId());
+  if (event.IsLocatedEvent()) {
+    event_location.raw_location = event_location.location =
+        event.AsLocatedEvent()->root_location_f();
+  }
+  return event_location;
+}
+
 // Tests that when an event is dispatched with no accelerator, that post target
 // accelerator is not triggered.
 TEST_F(WindowManagerStateTest, NullAccelerator) {
@@ -208,9 +219,10 @@ TEST_F(WindowManagerStateTest, NullAccelerator) {
 
   ServerWindow* target = window();
   const Display* display = window_tree()->GetDisplay(target);
-  DCHECK(display);
+  ASSERT_TRUE(display);
   ui::KeyEvent key(ui::ET_KEY_PRESSED, ui::VKEY_W, ui::EF_CONTROL_DOWN);
-  DispatchInputEventToWindow(target, display->GetId(), key, nullptr);
+  DispatchInputEventToWindow(target, EventLocationFromEvent(key, *display), key,
+                             nullptr);
   WindowTree* target_tree = window_tree();
   TestChangeTracker* tracker = window_tree_client()->tracker();
   ASSERT_EQ(1u, tracker->changes()->size());
@@ -230,8 +242,9 @@ TEST_F(WindowManagerStateTest, PostTargetAccelerator) {
 
   ServerWindow* target = window();
   const Display* display = window_tree()->GetDisplay(target);
-  DCHECK(display);
-  DispatchInputEventToWindow(target, display->GetId(), key, accelerator.get());
+  ASSERT_TRUE(display);
+  DispatchInputEventToWindow(target, EventLocationFromEvent(key, *display), key,
+                             accelerator.get());
   TestChangeTracker* tracker = window_tree_client()->tracker();
   ASSERT_EQ(1u, tracker->changes()->size());
   EXPECT_EQ(
@@ -273,7 +286,7 @@ TEST_F(WindowManagerStateTest, PreTargetConsumed) {
 
   // Send and ensure only the pre accelerator is called.
   ui::KeyEvent key(ui::ET_KEY_PRESSED, ui::VKEY_W, ui::EF_CONTROL_DOWN);
-  window_manager_state()->ProcessEvent(key, 0);
+  window_manager_state()->ProcessEvent(&key, 0);
   EXPECT_TRUE(window_manager()->on_accelerator_called());
   EXPECT_EQ(accelerator_id, window_manager()->on_accelerator_id());
   EXPECT_TRUE(tracker->changes()->empty());
@@ -288,7 +301,7 @@ TEST_F(WindowManagerStateTest, PreTargetConsumed) {
   window_manager()->ClearAcceleratorCalled();
 
   // Repeat, but respond with UNHANDLED.
-  window_manager_state()->ProcessEvent(key, 0);
+  window_manager_state()->ProcessEvent(&key, 0);
   EXPECT_TRUE(window_manager()->on_accelerator_called());
   EXPECT_EQ(accelerator_id, window_manager()->on_accelerator_id());
   EXPECT_TRUE(tracker->changes()->empty());
@@ -329,7 +342,7 @@ TEST_F(WindowManagerStateTest, AckWithProperties) {
 
   // Send and ensure only the pre accelerator is called.
   ui::KeyEvent key(ui::ET_KEY_PRESSED, ui::VKEY_W, ui::EF_CONTROL_DOWN);
-  window_manager_state()->ProcessEvent(key, 0);
+  window_manager_state()->ProcessEvent(&key, 0);
   EXPECT_TRUE(window_manager()->on_accelerator_called());
   EXPECT_EQ(accelerator_id, window_manager()->on_accelerator_id());
   EXPECT_TRUE(tracker->changes()->empty());
@@ -358,7 +371,7 @@ TEST_F(WindowManagerStateTest, AckWithProperties) {
   // Send the event again, and ack with no properties. Ensure client gets no
   // properties.
   window_manager()->ClearAcceleratorCalled();
-  window_manager_state()->ProcessEvent(key, 0);
+  window_manager_state()->ProcessEvent(&key, 0);
   EXPECT_TRUE(window_manager()->on_accelerator_called());
   EXPECT_EQ(accelerator_id, window_manager()->on_accelerator_id());
   EXPECT_TRUE(tracker->changes()->empty());
@@ -382,8 +395,9 @@ TEST_F(WindowManagerStateTest, ClientHandlesEvent) {
 
   ServerWindow* target = window();
   const Display* display = window_tree()->GetDisplay(target);
-  DCHECK(display);
-  DispatchInputEventToWindow(target, display->GetId(), key, accelerator.get());
+  ASSERT_TRUE(display);
+  DispatchInputEventToWindow(target, EventLocationFromEvent(key, *display), key,
+                             accelerator.get());
   TestChangeTracker* tracker = window_tree_client()->tracker();
   ASSERT_EQ(1u, tracker->changes()->size());
   EXPECT_EQ(
@@ -403,8 +417,9 @@ TEST_F(WindowManagerStateTest, AcceleratorDeleted) {
 
   ServerWindow* target = window();
   const Display* display = window_tree()->GetDisplay(target);
-  DCHECK(display);
-  DispatchInputEventToWindow(target, display->GetId(), key, accelerator.get());
+  ASSERT_TRUE(display);
+  DispatchInputEventToWindow(target, EventLocationFromEvent(key, *display), key,
+                             accelerator.get());
   TestChangeTracker* tracker = window_tree_client()->tracker();
   ASSERT_EQ(1u, tracker->changes()->size());
   EXPECT_EQ(
@@ -425,8 +440,9 @@ TEST_F(WindowManagerStateTest, EnqueuedAccelerators) {
 
   ServerWindow* target = window();
   const Display* display = window_tree()->GetDisplay(target);
-  DCHECK(display);
-  DispatchInputEventToWindow(target, display->GetId(), key, accelerator.get());
+  ASSERT_TRUE(display);
+  DispatchInputEventToWindow(target, EventLocationFromEvent(key, *display), key,
+                             accelerator.get());
   TestChangeTracker* tracker = window_tree_client()->tracker();
   ASSERT_EQ(1u, tracker->changes()->size());
   EXPECT_EQ(
@@ -441,8 +457,8 @@ TEST_F(WindowManagerStateTest, EnqueuedAccelerators) {
   uint32_t accelerator_id = 2;
   std::unique_ptr<Accelerator> accelerator2(
       new Accelerator(accelerator_id, *matcher));
-  DispatchInputEventToWindow(target, display->GetId(), key2,
-                             accelerator2.get());
+  DispatchInputEventToWindow(target, EventLocationFromEvent(key2, *display),
+                             key2, accelerator2.get());
   EXPECT_TRUE(tracker->changes()->empty());
 
   WindowTreeTestApi(window_tree()).AckOldestEvent();
@@ -461,8 +477,9 @@ TEST_F(WindowManagerStateTest, DeleteTree) {
 
   ServerWindow* target = window();
   const Display* display = window_tree()->GetDisplay(target);
-  DCHECK(display);
-  DispatchInputEventToWindow(target, display->GetId(), key, accelerator.get());
+  ASSERT_TRUE(display);
+  DispatchInputEventToWindow(target, EventLocationFromEvent(key, *display), key,
+                             accelerator.get());
   TestChangeTracker* tracker = window_tree_client()->tracker();
   ASSERT_EQ(1u, tracker->changes()->size());
   EXPECT_EQ(
@@ -487,8 +504,9 @@ TEST_F(WindowManagerStateTest, DeleteNonRootTree) {
   ui::KeyEvent key(ui::ET_KEY_PRESSED, ui::VKEY_W, ui::EF_CONTROL_DOWN);
   std::unique_ptr<Accelerator> accelerator = CreateAccelerator();
   const Display* display = target_tree->GetDisplay(target);
-  DCHECK(display);
-  DispatchInputEventToWindow(target, display->GetId(), key, accelerator.get());
+  ASSERT_TRUE(display);
+  DispatchInputEventToWindow(target, EventLocationFromEvent(key, *display), key,
+                             accelerator.get());
   TestChangeTracker* tracker = embed_connection->tracker();
   ASSERT_EQ(1u, tracker->changes()->size());
   // clients that created this window is receiving the event, so client_id part
@@ -509,11 +527,12 @@ TEST_F(WindowManagerStateTest, DontSendQueuedEventsToADeadTree) {
   TestChangeTracker* tracker = window_tree_client()->tracker();
 
   const Display* display = window_tree()->GetDisplay(target);
-  DCHECK(display);
+  ASSERT_TRUE(display);
   ui::MouseEvent press(ui::ET_MOUSE_PRESSED, gfx::Point(5, 5), gfx::Point(5, 5),
                        base::TimeTicks(), EF_LEFT_MOUSE_BUTTON,
                        EF_LEFT_MOUSE_BUTTON);
-  DispatchInputEventToWindow(target, display->GetId(), press, nullptr);
+  DispatchInputEventToWindow(target, EventLocationFromEvent(press, *display),
+                             press, nullptr);
   ASSERT_EQ(1u, tracker->changes()->size());
   EXPECT_EQ(
       "InputEvent window=" + kWindowManagerClientIdString + ",1 event_action=1",
@@ -526,7 +545,8 @@ TEST_F(WindowManagerStateTest, DontSendQueuedEventsToADeadTree) {
   ui::MouseEvent release(ui::ET_MOUSE_RELEASED, gfx::Point(5, 5),
                          gfx::Point(5, 5), base::TimeTicks(),
                          EF_LEFT_MOUSE_BUTTON, EF_LEFT_MOUSE_BUTTON);
-  DispatchInputEventToWindow(target, display->GetId(), release, nullptr);
+  DispatchInputEventToWindow(target, EventLocationFromEvent(release, *display),
+                             release, nullptr);
   EXPECT_EQ(0u, tracker->changes()->size());
 
   // Destroying a window tree with an event in queue shouldn't crash.
@@ -538,9 +558,9 @@ TEST_F(WindowManagerStateTest, AckTimeout) {
   ui::KeyEvent key(ui::ET_KEY_PRESSED, ui::VKEY_W, ui::EF_CONTROL_DOWN);
   std::unique_ptr<Accelerator> accelerator = CreateAccelerator();
   const Display* display = window_tree()->GetDisplay(window());
-  DCHECK(display);
-  DispatchInputEventToWindow(window(), display->GetId(), key,
-                             accelerator.get());
+  ASSERT_TRUE(display);
+  DispatchInputEventToWindow(window(), EventLocationFromEvent(key, *display),
+                             key, accelerator.get());
   TestChangeTracker* tracker = window_tree_client()->tracker();
   ASSERT_EQ(1u, tracker->changes()->size());
   EXPECT_EQ(
@@ -577,10 +597,11 @@ TEST_F(WindowManagerStateTest, InterceptingEmbedderReceivesEvents) {
 
     // Send an event to the embed window. It should go to the embedded client.
     const Display* display = embed_tree->GetDisplay(embedder_window);
-    DCHECK(display);
+    ASSERT_TRUE(display);
     ui::MouseEvent mouse(ui::ET_MOUSE_MOVED, gfx::Point(), gfx::Point(),
                          base::TimeTicks(), 0, 0);
-    DispatchInputEventToWindow(embedder_window, display->GetId(), mouse,
+    DispatchInputEventToWindow(embedder_window,
+                               EventLocationFromEvent(mouse, *display), mouse,
                                nullptr);
     ASSERT_EQ(1u, embed_client_proxy->tracker()->changes()->size());
     EXPECT_EQ(CHANGE_TYPE_INPUT_EVENT,
@@ -603,10 +624,11 @@ TEST_F(WindowManagerStateTest, InterceptingEmbedderReceivesEvents) {
     // Send an event to the embed window. But this time, it should reach the
     // embedder.
     const Display* display = embed_tree->GetDisplay(embedder_window);
-    DCHECK(display);
+    ASSERT_TRUE(display);
     ui::MouseEvent mouse(ui::ET_MOUSE_MOVED, gfx::Point(), gfx::Point(),
                          base::TimeTicks(), 0, 0);
-    DispatchInputEventToWindow(embedder_window, display->GetId(), mouse,
+    DispatchInputEventToWindow(embedder_window,
+                               EventLocationFromEvent(mouse, *display), mouse,
                                nullptr);
     ASSERT_EQ(0u, embed_client_proxy->tracker()->changes()->size());
     ASSERT_EQ(1u, embedder_client->tracker()->changes()->size());
@@ -637,10 +659,11 @@ TEST_F(WindowManagerStateTest, InterceptingEmbedderReceivesEvents) {
     // the outermost embedder.
     ServerWindow* nested_embed_window =
         embed_tree->GetWindowByClientId(nested_embed_window_id);
-    DCHECK(nested_embed_window->parent());
+    ASSERT_TRUE(nested_embed_window->parent());
     mouse = ui::MouseEvent(ui::ET_MOUSE_MOVED, gfx::Point(), gfx::Point(),
                            base::TimeTicks(), 0, 0);
-    DispatchInputEventToWindow(nested_embed_window, display->GetId(), mouse,
+    DispatchInputEventToWindow(nested_embed_window,
+                               EventLocationFromEvent(mouse, *display), mouse,
                                nullptr);
     ASSERT_EQ(0u, nested_embed_client_proxy->tracker()->changes()->size());
     ASSERT_EQ(0u, embed_client_proxy->tracker()->changes()->size());
@@ -662,9 +685,10 @@ TEST_F(WindowManagerStateTest, PostAcceleratorForgotten) {
   std::unique_ptr<Accelerator> accelerator = CreateAccelerator();
   ServerWindow* target = window();
   const Display* display = window_tree()->GetDisplay(target);
-  DCHECK(display);
-  DispatchInputEventToWindow(target, display->GetId(), accelerator_key,
-                             accelerator.get());
+  ASSERT_TRUE(display);
+  DispatchInputEventToWindow(target,
+                             EventLocationFromEvent(accelerator_key, *display),
+                             accelerator_key, accelerator.get());
   TestChangeTracker* tracker = window_tree_client()->tracker();
   ASSERT_EQ(1u, tracker->changes()->size());
   EXPECT_EQ(
@@ -678,8 +702,9 @@ TEST_F(WindowManagerStateTest, PostAcceleratorForgotten) {
   // shouldn't be called.
   ui::KeyEvent non_accelerator_key(ui::ET_KEY_PRESSED, ui::VKEY_T,
                                    ui::EF_CONTROL_DOWN);
-  DispatchInputEventToWindow(target, display->GetId(), non_accelerator_key,
-                             nullptr);
+  DispatchInputEventToWindow(
+      target, EventLocationFromEvent(non_accelerator_key, *display),
+      non_accelerator_key, nullptr);
   ASSERT_EQ(1u, tracker->changes()->size());
   EXPECT_EQ(
       "InputEvent window=" + kWindowManagerClientIdString + ",1 event_action=7",
@@ -729,10 +754,51 @@ TEST_F(WindowManagerStateTest, CursorResetOverNoTarget) {
       ui::ET_POINTER_MOVED, gfx::Point(25, 25), gfx::Point(25, 25), 0, 0,
       ui::PointerDetails(EventPointerType::POINTER_TYPE_MOUSE, 0),
       base::TimeTicks());
-  window_manager_state()->ProcessEvent(move, 0);
+  window_manager_state()->ProcessEvent(&move, 0);
   // The event isn't over a valid target, which should trigger resetting the
   // cursor to POINTER.
   EXPECT_EQ(ui::CursorType::kPointer, cursor_type());
+}
+
+TEST(WindowManagerStateEventTest, AdjustEventLocation) {
+  WindowServerTestHelper ws_test_helper;
+  WindowServer* window_server = ws_test_helper.window_server();
+  TestScreenManager screen_manager;
+  screen_manager.Init(window_server->display_manager());
+  const UserId kUserId1 = "2";
+  AddWindowManager(window_server, kUserId1);
+  window_server->user_id_tracker()->AddUserId(kUserId1);
+  window_server->user_id_tracker()->SetActiveUserId(kUserId1);
+  const int64_t first_display_id = screen_manager.AddDisplay();
+  const int64_t second_display_id = screen_manager.AddDisplay();
+  Display* second_display =
+      window_server->display_manager()->GetDisplayById(second_display_id);
+  ASSERT_TRUE(second_display);
+  display::Display second_display_display = second_display->GetDisplay();
+  second_display_display.set_bounds(gfx::Rect(100, 0, 100, 100));
+  display::ViewportMetrics second_metrics;
+  // The DIP display layout is horizontal and the pixel layout vertical.
+  second_metrics.device_scale_factor = 1.0f;
+  second_metrics.bounds_in_pixels = gfx::Rect(0, 200, 100, 100);
+  second_metrics.ui_scale_factor = 1.0f;
+  screen_manager.ModifyDisplay(second_display_display, second_metrics);
+  const gfx::Point move_location(5, 210);
+  ui::PointerEvent move(
+      ui::ET_POINTER_MOVED, move_location, move_location, 0, 0,
+      ui::PointerDetails(EventPointerType::POINTER_TYPE_MOUSE, 0),
+      base::TimeTicks());
+  WindowManagerDisplayRoot* window_manager_display_root =
+      second_display->GetWindowManagerDisplayRootForUser(kUserId1);
+  TestChangeTracker* tracker =
+      ws_test_helper.window_server_delegate()->last_client()->tracker();
+  tracker->changes()->clear();
+  window_manager_display_root->window_manager_state()->ProcessEvent(
+      &move, first_display_id);
+  ASSERT_EQ(1u, tracker->changes()->size());
+  // |location2| is the location supplied in terms of the pixel display layout.
+  EXPECT_EQ(gfx::PointF(move_location), (*tracker->changes())[0].location2);
+  // |location1| is the location in DIP display layout.
+  EXPECT_EQ(gfx::Point(105, 10), (*tracker->changes())[0].location1);
 }
 
 TEST_F(WindowManagerStateTest, CursorLocationManagerUpdatedOnMouseMove) {
@@ -751,7 +817,7 @@ TEST_F(WindowManagerStateTest, CursorLocationManagerUpdatedOnMouseMove) {
       ui::PointerDetails(EventPointerType::POINTER_TYPE_MOUSE, 0),
       base::TimeTicks());
   // Tests add display with kInvalidDisplayId.
-  window_manager_state()->ProcessEvent(move, display::kInvalidDisplayId);
+  window_manager_state()->ProcessEvent(&move, display::kInvalidDisplayId);
   CursorLocationManager* cursor_location_manager =
       window_server()->display_manager()->GetCursorLocationManager(
           window_manager_state()->user_id());
@@ -788,7 +854,7 @@ TEST_F(WindowManagerStateTestAsync, CursorResetOverNoTargetAsync) {
       base::TimeTicks());
   WindowManagerStateTestApi test_api(window_manager_state());
   EXPECT_TRUE(test_api.is_event_queue_empty());
-  window_manager_state()->ProcessEvent(move, 0);
+  window_manager_state()->ProcessEvent(&move, 0);
   EXPECT_FALSE(test_api.tree_awaiting_input_ack());
   EXPECT_TRUE(window_manager_state()->event_dispatcher()->IsProcessingEvent());
   EXPECT_TRUE(test_api.is_event_queue_empty());

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -20,6 +20,7 @@
 #include "services/ui/ws/display.h"
 #include "services/ui/ws/display_manager.h"
 #include "services/ui/ws/event_dispatcher.h"
+#include "services/ui/ws/event_location.h"
 #include "services/ui/ws/event_matcher.h"
 #include "services/ui/ws/focus_controller.h"
 #include "services/ui/ws/frame_generator.h"
@@ -75,11 +76,11 @@ class TargetedEvent : public ServerWindowObserver {
  public:
   TargetedEvent(ServerWindow* target,
                 const ui::Event& event,
-                int64_t display_id,
+                const EventLocation& event_location,
                 WindowTree::DispatchEventCallback callback)
       : target_(target),
         event_(ui::Event::Clone(event)),
-        display_id_(display_id),
+        event_location_(event_location),
         callback_(std::move(callback)) {
     target_->AddObserver(this);
   }
@@ -90,7 +91,7 @@ class TargetedEvent : public ServerWindowObserver {
 
   ServerWindow* target() { return target_; }
   std::unique_ptr<ui::Event> TakeEvent() { return std::move(event_); }
-  int64_t display_id() const { return display_id_; }
+  const EventLocation& event_location() const { return event_location_; }
   WindowTree::DispatchEventCallback TakeCallback() {
     return std::move(callback_);
   }
@@ -105,7 +106,7 @@ class TargetedEvent : public ServerWindowObserver {
 
   ServerWindow* target_;
   std::unique_ptr<ui::Event> event_;
-  const int64_t display_id_;
+  const EventLocation event_location_;
   WindowTree::DispatchEventCallback callback_;
 
   DISALLOW_COPY_AND_ASSIGN(TargetedEvent);
@@ -783,12 +784,12 @@ bool WindowTree::Embed(const ClientWindowId& window_id,
 
 void WindowTree::DispatchInputEvent(ServerWindow* target,
                                     const ui::Event& event,
-                                    int64_t display_id,
+                                    const EventLocation& event_location,
                                     DispatchEventCallback callback) {
   if (event_ack_id_) {
     // This is currently waiting for an event ack. Add it to the queue.
-    event_queue_.push(base::MakeUnique<TargetedEvent>(target, event, display_id,
-                                                      std::move(callback)));
+    event_queue_.push(base::MakeUnique<TargetedEvent>(
+        target, event, event_location, std::move(callback)));
     // TODO(sad): If the |event_queue_| grows too large, then this should notify
     // Display, so that it can stop sending events.
     return;
@@ -798,12 +799,12 @@ void WindowTree::DispatchInputEvent(ServerWindow* target,
   // and dispatch the latest event from the queue instead that still has a live
   // target.
   if (!event_queue_.empty()) {
-    event_queue_.push(base::MakeUnique<TargetedEvent>(target, event, display_id,
-                                                      std::move(callback)));
+    event_queue_.push(base::MakeUnique<TargetedEvent>(
+        target, event, event_location, std::move(callback)));
     return;
   }
 
-  DispatchInputEventImpl(target, event, display_id, std::move(callback));
+  DispatchInputEventImpl(target, event, event_location, std::move(callback));
 }
 
 bool WindowTree::IsWaitingForNewTopLevelWindow(uint32_t wm_change_id) {
@@ -1572,7 +1573,7 @@ uint32_t WindowTree::GenerateEventAckId() {
 
 void WindowTree::DispatchInputEventImpl(ServerWindow* target,
                                         const ui::Event& event,
-                                        int64_t display_id,
+                                        const EventLocation& event_location,
                                         DispatchEventCallback callback) {
   // DispatchInputEventImpl() is called so often that log level 4 is used.
   DVLOG(4) << "DispatchInputEventImpl client=" << id_;
@@ -1584,9 +1585,10 @@ void WindowTree::DispatchInputEventImpl(ServerWindow* target,
   // Should only get events from windows attached to a host.
   DCHECK(event_source_wms_);
   bool matched_pointer_watcher = EventMatchesPointerWatcher(event);
-  client()->OnWindowInputEvent(event_ack_id_, TransportIdForWindow(target),
-                               display_id, ui::Event::Clone(event),
-                               matched_pointer_watcher);
+  client()->OnWindowInputEvent(
+      event_ack_id_, TransportIdForWindow(target), event_location.display_id,
+      event_location.raw_location, ui::Event::Clone(event),
+      matched_pointer_watcher);
 }
 
 bool WindowTree::EventMatchesPointerWatcher(const ui::Event& event) const {
@@ -2017,18 +2019,19 @@ void WindowTree::OnWindowInputEventAck(uint32_t event_id,
     ServerWindow* target = nullptr;
     std::unique_ptr<ui::Event> event;
     DispatchEventCallback callback;
-    int64_t display_id = display::kInvalidDisplayId;
+    EventLocation event_location;
     do {
       std::unique_ptr<TargetedEvent> targeted_event =
           std::move(event_queue_.front());
       event_queue_.pop();
       target = targeted_event->target();
       event = targeted_event->TakeEvent();
-      display_id = targeted_event->display_id();
+      event_location = targeted_event->event_location();
       callback = targeted_event->TakeCallback();
     } while (!event_queue_.empty() && !GetDisplay(target));
     if (target)
-      DispatchInputEventImpl(target, *event, display_id, std::move(callback));
+      DispatchInputEventImpl(target, *event, event_location,
+                             std::move(callback));
   }
 }
 

--- a/services/ui/ws/window_tree.h
+++ b/services/ui/ws/window_tree.h
@@ -56,6 +56,8 @@ class WindowManagerDisplayRoot;
 class WindowManagerState;
 class WindowServer;
 
+struct EventLocation;
+
 namespace test {
 class WindowTreeTestApi;
 }
@@ -224,7 +226,7 @@ class WindowTree : public mojom::WindowTree,
   using DispatchEventCallback = base::OnceCallback<void(mojom::EventResult)>;
   void DispatchInputEvent(ServerWindow* target,
                           const ui::Event& event,
-                          int64_t display_id,
+                          const EventLocation& event_location,
                           DispatchEventCallback callback);
 
   bool IsWaitingForNewTopLevelWindow(uint32_t wm_change_id);
@@ -438,7 +440,7 @@ class WindowTree : public mojom::WindowTree,
 
   void DispatchInputEventImpl(ServerWindow* target,
                               const ui::Event& event,
-                              int64_t display_id,
+                              const EventLocation& event_location,
                               DispatchEventCallback callback);
 
   // Returns true if the client has a pointer watcher and this event matches.

--- a/services/ui/ws/window_tree_client_unittest.cc
+++ b/services/ui/ws/window_tree_client_unittest.cc
@@ -394,11 +394,13 @@ class TestWindowTreeClient : public mojom::WindowTreeClient,
   void OnWindowParentDrawnStateChanged(uint32_t window, bool drawn) override {
     tracker()->OnWindowParentDrawnStateChanged(window, drawn);
   }
-  void OnWindowInputEvent(uint32_t event_id,
-                          Id window_id,
-                          int64_t display_id,
-                          std::unique_ptr<ui::Event> event,
-                          bool matches_pointer_watcher) override {
+  void OnWindowInputEvent(
+      uint32_t event_id,
+      Id window_id,
+      int64_t display_id,
+      const gfx::PointF& event_location_in_screen_pixel_layout,
+      std::unique_ptr<ui::Event> event,
+      bool matches_pointer_watcher) override {
     // Ack input events to clear the state on the server. These can be received
     // during test startup. X11Window::DispatchEvent sends a synthetic move
     // event to notify of entry.

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -1485,11 +1485,13 @@ void WindowTreeClient::OnWindowSharedPropertyChanged(
       name, transport_data.has_value() ? &transport_data.value() : nullptr);
 }
 
-void WindowTreeClient::OnWindowInputEvent(uint32_t event_id,
-                                          Id window_id,
-                                          int64_t display_id,
-                                          std::unique_ptr<ui::Event> event,
-                                          bool matches_pointer_watcher) {
+void WindowTreeClient::OnWindowInputEvent(
+    uint32_t event_id,
+    Id window_id,
+    int64_t display_id,
+    const gfx::PointF& event_location_in_screen_pixel_layout,
+    std::unique_ptr<ui::Event> event,
+    bool matches_pointer_watcher) {
   DCHECK(event);
 
   WindowMus* window = GetWindowByServerId(window_id);  // May be null.
@@ -1547,11 +1549,11 @@ void WindowTreeClient::OnWindowInputEvent(uint32_t event_id,
         static_cast<const base::NativeEvent&>(mapped_event.get()));
     // MouseEvent(NativeEvent) sets the root_location to location.
     mapped_event_with_native->set_root_location_f(
-        mapped_event->AsMouseEvent()->root_location_f());
+        event_location_in_screen_pixel_layout);
     // |mapped_event| is now the NativeEvent. It's expected the location of the
     // NativeEvent is the same as root_location.
     mapped_event->AsMouseEvent()->set_location_f(
-        mapped_event->AsMouseEvent()->root_location_f());
+        event_location_in_screen_pixel_layout);
     event_to_dispatch = mapped_event_with_native.get();
   }
 #endif

--- a/ui/aura/mus/window_tree_client.h
+++ b/ui/aura/mus/window_tree_client.h
@@ -414,11 +414,13 @@ class AURA_EXPORT WindowTreeClient
       Id window_id,
       const std::string& name,
       const base::Optional<std::vector<uint8_t>>& transport_data) override;
-  void OnWindowInputEvent(uint32_t event_id,
-                          Id window_id,
-                          int64_t display_id,
-                          std::unique_ptr<ui::Event> event,
-                          bool matches_pointer_watcher) override;
+  void OnWindowInputEvent(
+      uint32_t event_id,
+      Id window_id,
+      int64_t display_id,
+      const gfx::PointF& event_location_in_screen_pixel_layout,
+      std::unique_ptr<ui::Event> event,
+      bool matches_pointer_watcher) override;
   void OnPointerEventObserved(std::unique_ptr<ui::Event> event,
                               uint32_t window_id,
                               int64_t display_id) override;

--- a/ui/aura/mus/window_tree_client_unittest.cc
+++ b/ui/aura/mus/window_tree_client_unittest.cc
@@ -955,7 +955,8 @@ TEST_F(WindowTreeClientClientTest, InputEventBasic) {
                          gfx::Point(), ui::EventTimeForNow(), ui::EF_NONE, 0));
   window_tree_client()->OnWindowInputEvent(
       event_id, server_id(&child), window_tree_host.display_id(),
-      ui::Event::Clone(*ui_event.get()), 0);
+      gfx::PointF(event_location_in_child), ui::Event::Clone(*ui_event.get()),
+      0);
   EXPECT_TRUE(window_tree()->WasEventAcked(event_id));
   EXPECT_EQ(ui::mojom::EventResult::HANDLED,
             window_tree()->GetEventResult(event_id));
@@ -988,9 +989,9 @@ TEST_F(WindowTreeClientClientTest, InputEventPointerEvent) {
       ui::ET_POINTER_MOVED, event_location, gfx::Point(), ui::EF_NONE, 0,
       ui::PointerDetails(ui::EventPointerType::POINTER_TYPE_MOUSE, 0),
       base::TimeTicks());
-  window_tree_client()->OnWindowInputEvent(event_id, server_id(&child),
-                                           window_tree_host.display_id(),
-                                           ui::Event::Clone(pointer_event), 0);
+  window_tree_client()->OnWindowInputEvent(
+      event_id, server_id(&child), window_tree_host.display_id(),
+      gfx::PointF(event_location), ui::Event::Clone(pointer_event), 0);
   EXPECT_TRUE(window_tree()->WasEventAcked(event_id));
   EXPECT_EQ(ui::mojom::EventResult::HANDLED,
             window_tree()->GetEventResult(event_id));
@@ -1074,7 +1075,7 @@ TEST_F(WindowTreeClientClientTest, InputEventFindTargetAndConversion) {
                          ui::EventTimeForNow(), ui::EF_NONE, 0));
   window_tree_client()->OnWindowInputEvent(
       event_id, server_id(&child1), window_tree_host.display_id(),
-      ui::Event::Clone(*ui_event.get()), 0);
+      gfx::PointF(event_location), ui::Event::Clone(*ui_event.get()), 0);
   EXPECT_TRUE(window_tree()->WasEventAcked(event_id));
   EXPECT_EQ(ui::mojom::EventResult::HANDLED,
             window_tree()->GetEventResult(event_id));
@@ -1095,7 +1096,7 @@ TEST_F(WindowTreeClientClientTest, InputEventFindTargetAndConversion) {
                          ui::EventTimeForNow(), ui::EF_NONE, 0));
   window_tree_client()->OnWindowInputEvent(
       event_id, server_id(&child1), window_tree_host.display_id(),
-      ui::Event::Clone(*ui_event1.get()), 0);
+      gfx::PointF(event_location), ui::Event::Clone(*ui_event1.get()), 0);
   EXPECT_TRUE(window_tree()->WasEventAcked(event_id));
   EXPECT_EQ(ui::mojom::EventResult::HANDLED,
             window_tree()->GetEventResult(event_id));
@@ -1143,7 +1144,7 @@ TEST_F(WindowTreeClientClientTest, InputEventCustomWindowTargeter) {
                          ui::EventTimeForNow(), ui::EF_NONE, 0));
   window_tree_client()->OnWindowInputEvent(
       event_id, server_id(&child1), window_tree_host.display_id(),
-      ui::Event::Clone(*ui_event.get()), 0);
+      gfx::PointF(event_location), ui::Event::Clone(*ui_event.get()), 0);
   EXPECT_TRUE(window_tree()->WasEventAcked(event_id));
   EXPECT_EQ(ui::mojom::EventResult::HANDLED,
             window_tree()->GetEventResult(event_id));
@@ -1160,7 +1161,7 @@ TEST_F(WindowTreeClientClientTest, InputEventCustomWindowTargeter) {
   window_delegate2.set_event_id(event_id);
   window_tree_client()->OnWindowInputEvent(
       event_id, server_id(&child2), window_tree_host.display_id(),
-      ui::Event::Clone(*ui_event.get()), 0);
+      gfx::PointF(event_location), ui::Event::Clone(*ui_event.get()), 0);
   EXPECT_TRUE(window_tree()->WasEventAcked(event_id));
   EXPECT_EQ(ui::mojom::EventResult::HANDLED,
             window_tree()->GetEventResult(event_id));
@@ -1213,7 +1214,7 @@ TEST_F(WindowTreeClientClientTest, InputEventCaptureWindow) {
                          ui::EventTimeForNow(), ui::EF_NONE, 0));
   window_tree_client()->OnWindowInputEvent(
       event_id, server_id(child1.get()), window_tree_host->display_id(),
-      ui::Event::Clone(*ui_event.get()), 0);
+      gfx::PointF(root_location), ui::Event::Clone(*ui_event.get()), 0);
   EXPECT_TRUE(window_tree()->WasEventAcked(event_id));
   EXPECT_EQ(ui::mojom::EventResult::HANDLED,
             window_tree()->GetEventResult(event_id));
@@ -1236,7 +1237,7 @@ TEST_F(WindowTreeClientClientTest, InputEventCaptureWindow) {
   window_delegate2->set_event_id(event_id);
   window_tree_client()->OnWindowInputEvent(
       event_id, server_id(child1.get()), window_tree_host->display_id(),
-      ui::Event::Clone(*ui_event.get()), 0);
+      gfx::PointF(root_location), ui::Event::Clone(*ui_event.get()), 0);
   EXPECT_TRUE(window_tree()->WasEventAcked(event_id));
   EXPECT_EQ(ui::mojom::EventResult::HANDLED,
             window_tree()->GetEventResult(event_id));
@@ -1283,7 +1284,7 @@ TEST_F(WindowTreeClientClientTest, InputEventRootWindow) {
                          gfx::Point(), ui::EventTimeForNow(), ui::EF_NONE, 0));
   window_tree_client()->OnWindowInputEvent(
       event_id, server_id(top_level), window_tree_host.display_id(),
-      ui::Event::Clone(*ui_event.get()), 0);
+      gfx::PointF(), ui::Event::Clone(*ui_event.get()), 0);
 
   EXPECT_TRUE(window_tree()->WasEventAcked(event_id));
   EXPECT_EQ(ui::mojom::EventResult::HANDLED,
@@ -1327,7 +1328,7 @@ TEST_F(WindowTreeClientClientTest, InputMouseEventNoWindow) {
       ui::EventTimeForNow());
   window_tree_client()->OnWindowInputEvent(
       event_id, server_id(&child), window_tree_host.display_id(),
-      ui::Event::Clone(pointer_event_down), 0);
+      gfx::PointF(event_location), ui::Event::Clone(pointer_event_down), 0);
   EXPECT_TRUE(window_tree()->WasEventAcked(event_id));
   EXPECT_EQ(ui::mojom::EventResult::HANDLED,
             window_tree()->GetEventResult(event_id));
@@ -1347,7 +1348,7 @@ TEST_F(WindowTreeClientClientTest, InputMouseEventNoWindow) {
       ui::EventTimeForNow());
   window_tree_client()->OnWindowInputEvent(
       event_id, kInvalidServerId, window_tree_host.display_id(),
-      ui::Event::Clone(pointer_event_up), 0);
+      gfx::PointF(event_location), ui::Event::Clone(pointer_event_up), 0);
   EXPECT_TRUE(window_tree()->WasEventAcked(event_id));
   // WindowTreeClient::OnWindowInputEvent cannot find a target window with
   // kInvalidServerId but should use the event to update event states kept in
@@ -1389,7 +1390,7 @@ TEST_F(WindowTreeClientClientTest, InputTouchEventNoWindow) {
       ui::PointerDetails(ui::EventPointerType::POINTER_TYPE_TOUCH, 0),
       ui::EventTimeForNow());
   window_tree_client()->OnWindowInputEvent(
-      event_id, server_id(&child), window_tree_host.display_id(),
+      event_id, server_id(&child), window_tree_host.display_id(), gfx::PointF(),
       ui::Event::Clone(pointer_event_down), 0);
   EXPECT_TRUE(window_tree()->WasEventAcked(event_id));
   EXPECT_EQ(ui::mojom::EventResult::HANDLED,
@@ -1405,7 +1406,7 @@ TEST_F(WindowTreeClientClientTest, InputTouchEventNoWindow) {
       ui::PointerDetails(ui::EventPointerType::POINTER_TYPE_TOUCH, 0),
       ui::EventTimeForNow());
   window_tree_client()->OnWindowInputEvent(
-      event_id, kInvalidServerId, window_tree_host.display_id(),
+      event_id, kInvalidServerId, window_tree_host.display_id(), gfx::PointF(),
       ui::Event::Clone(pointer_event_up), 0);
   EXPECT_TRUE(window_tree()->WasEventAcked(event_id));
   // WindowTreeClient::OnWindowInputEvent cannot find a target window with
@@ -1502,6 +1503,7 @@ TEST_F(WindowTreeClientPointerObserverTest,
       ui::PointerDetails(ui::EventPointerType::POINTER_TYPE_TOUCH, 1),
       base::TimeTicks::Now()));
   window_tree_client()->OnWindowInputEvent(1, server_id(top_level), 0,
+                                           gfx::PointF(),
                                            std::move(pointer_event_down), true);
 
   // Delegate sensed the event.
@@ -2736,7 +2738,8 @@ TEST_F(WindowTreeClientClientTestHighDPI, InputEventsInDip) {
       ui::EventTimeForNow(), ui::EF_NONE, 0));
   window_tree_client()->OnWindowInputEvent(
       event_id, server_id(&child1), window_tree_host.display_id(),
-      ui::Event::Clone(*ui_event.get()), 0);
+      gfx::PointF(event_location_in_pixels), ui::Event::Clone(*ui_event.get()),
+      0);
   EXPECT_TRUE(window_tree()->WasEventAcked(event_id));
   EXPECT_EQ(ui::mojom::EventResult::HANDLED,
             window_tree()->GetEventResult(event_id));
@@ -2760,7 +2763,8 @@ TEST_F(WindowTreeClientClientTestHighDPI, InputEventsInDip) {
   window_delegate2.set_event_id(event_id);
   window_tree_client()->OnWindowInputEvent(
       event_id, server_id(&child2), window_tree_host.display_id(),
-      ui::Event::Clone(*ui_event.get()), 0);
+      gfx::PointF(event_location_in_pixels), ui::Event::Clone(*ui_event.get()),
+      0);
   EXPECT_TRUE(window_tree()->WasEventAcked(event_id));
   EXPECT_EQ(ui::mojom::EventResult::HANDLED,
             window_tree()->GetEventResult(event_id));

--- a/ui/aura/test/mus/window_tree_client_private.cc
+++ b/ui/aura/test/mus/window_tree_client_private.cc
@@ -59,9 +59,13 @@ void WindowTreeClientPrivate::CallOnWindowInputEvent(
   const uint32_t event_id = 0u;
   const uint32_t observer_id = 0u;
   const int64_t display_id = 0;
+  gfx::PointF event_location_in_screen_pixel_layout;
+  if (event->IsLocatedEvent())
+    event_location_in_screen_pixel_layout =
+        event->AsLocatedEvent()->root_location_f();
   tree_client_impl_->OnWindowInputEvent(
       event_id, WindowPortMus::Get(window)->server_id(), display_id,
-      std::move(event), observer_id);
+      event_location_in_screen_pixel_layout, std::move(event), observer_id);
 }
 
 void WindowTreeClientPrivate::CallOnPointerEventObserved(

--- a/ui/aura/window_tree_host.h
+++ b/ui/aura/window_tree_host.h
@@ -86,7 +86,7 @@ class AURA_EXPORT WindowTreeHost : public ui::internal::InputMethodDelegate,
   virtual gfx::Transform GetInverseRootTransform() const;
 
   // These functions are used in event translation for translating the local
-  // coordinates of LocatedEvents. Default implementation calls to non-event
+  // coordinates of LocatedEvents. Default implementation calls to non-local
   // ones (e.g. GetRootTransform()).
   virtual gfx::Transform GetRootTransformForLocalEventCoordinates() const;
   virtual gfx::Transform GetInverseRootTransformForLocalEventCoordinates()


### PR DESCRIPTION
This PR allows us to revert a local revert of "Implement an unique identifier to be returned for ws::Display::GetId" [1].

Basically [1] changed the event handling code to use ws::Display::GetId as an identifier of the Event. Since this returns an invalid value in external window mode, chrome was crashing.

PR fixes this by (ab)using the WindowId returned from ws::DisplayManger, at ws::Display creation time, and builds an unique identifier token off of it.

[1] https://crrev.com/c/659103