### PR TITLE
Occasional crash when creating tooltips

### DIFF
--- a/ui/ozone/platform/wayland/wayland_pointer.cc
+++ b/ui/ozone/platform/wayland/wayland_pointer.cc
@@ -50,6 +50,11 @@ void WaylandPointer::Leave(void* data,
                            wl_pointer* obj,
                            uint32_t serial,
                            wl_surface* surface) {
+  WaylandPointer* pointer = static_cast<WaylandPointer*>(data);
+  MouseEvent event(ET_MOUSE_EXITED, gfx::Point(), gfx::Point(),
+                   EventTimeForNow(), pointer->flags_, 0);
+  pointer->callback_.Run(&event);
+
   if (surface)
     WaylandWindow::FromSurface(surface)->set_pointer_focus(false);
 }

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -166,7 +166,15 @@ void WaylandWindow::CreateXdgSurface() {
 
 void WaylandWindow::CreateTooltipSubSurface() {
   parent_window_ = GetParentWindow();
-  DCHECK(parent_window_);
+
+  // Tooltip creation is an async operation. By the time Mus actually start to
+  // create the tooltip, it is possible that user has already moved the
+  // mouse/pointer out of the window who triggered the tooptip. In this case,
+  // parent_window_ is NULL.
+  if (!parent_window_) {
+    Hide();
+    return;
+  }
 
   wl_subcompositor* subcompositor = connection_->subcompositor();
   DCHECK(subcompositor);


### PR DESCRIPTION
fixup! [ozone/wayland] Implement Tooltip using subsurface
    
This CL takes care of two issues:
    
1) By the time one hovers mouse over something that creates a tooltip,
a message is sent from the client (browser/aura) to the server (mus).
It is async call, so when mus actually gets the message and starts
the logic that creates/shows a tooltip window, user might have already
moved the mouse off the window bound.
When pointer moves off-window, WaylandWindow::GetParentWindow will return NULL.
Patch turns the existing DCHECK into an early return check.
    
2) When one moves the mouse off the chrome window, emit a ET_MOUSE_EXITED
mouse event, so that ToolTipController has (see view::corewm::GetTooltipTarget).
    
Issue #295