### PR TITLE
Remove reference to enable_package_mash_services from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ and
 Here is the summary of commands to build and run Chrome for Wayland:
 
 ```
-gn args out/Ozone --args="use_ozone=true enable_package_mash_services=true use_xkbcommon=true"
+gn args out/Ozone --args="use_ozone=true enable_mus=true use_xkbcommon=true"
 ninja -C out/Ozone chrome
 ./out/Ozone/chrome --mus --ozone-platform=wayland
 


### PR DESCRIPTION
fixup! Add a README.

- Remove reference to 'enable_package_mash_services' config option
since it has been removed in https://crrev.com/c/754087.
- 'enable_mus=true' seems to be enough since them

Signed-off-by: Nick Diego Yamane <nick.diego@gmail.com>