### PR TITLE
Reset WaylandPointer::flags_ when entering interactive move/resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ ninja -C out/Ozone chrome
 
 Note that GN defaults to debug builds, which naturally take longer to finish and produce slower binaries at runtime. The 'is_debug=false' GN arguments disables it.
 
+Also note that some touch oriented Web pages like Google Maps, work better when the Touch Event API is explicitly enabled
+in chrome://flags or a command line argument --touch-events=enabled is passed.
+
 It is also possible to enable proprietary codecs (so that mp4, h264 medias play) with the following GN args: 'proprietary_codecs=true ffmpeg_branding=\"Chrome\"'.
 ```
 

--- a/ui/ozone/platform/wayland/wayland_connection.cc
+++ b/ui/ozone/platform/wayland/wayland_connection.cc
@@ -143,6 +143,11 @@ int WaylandConnection::GetKeyboardModifiers() {
   return modifiers;
 }
 
+void WaylandConnection::ResetPointerFlags() {
+  if (pointer_)
+    pointer_->ResetFlags();
+}
+
 void WaylandConnection::OnDispatcherListChanged() {
   StartProcessingEvents();
 }

--- a/ui/ozone/platform/wayland/wayland_connection.h
+++ b/ui/ozone/platform/wayland/wayland_connection.h
@@ -56,6 +56,13 @@ class WaylandConnection : public PlatformEventSource,
 
   int GetKeyboardModifiers();
 
+  // Resets flags and keyboard modifiers.
+  //
+  // This method is specially handy for cases when the WaylandPointer state is
+  // modified by a POINTER_DOWN event, but the respective POINTER_UP event is
+  // not delivered.
+  void ResetPointerFlags();
+
  private:
   void Flush();
   void DispatchUiEvent(Event* event);

--- a/ui/ozone/platform/wayland/wayland_pointer.cc
+++ b/ui/ozone/platform/wayland/wayland_pointer.cc
@@ -176,4 +176,9 @@ int WaylandPointer::GetFlagsWithKeyboardModifiers() {
   return flags_;
 }
 
+void WaylandPointer::ResetFlags() {
+  flags_ = 0;
+  keyboard_modifiers_ = 0;
+}
+
 }  // namespace ui

--- a/ui/ozone/platform/wayland/wayland_pointer.h
+++ b/ui/ozone/platform/wayland/wayland_pointer.h
@@ -25,6 +25,7 @@ class WaylandPointer {
   }
 
   int GetFlagsWithKeyboardModifiers();
+  void ResetFlags();
 
   WaylandCursor* cursor() { return cursor_.get(); }
 

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -373,6 +373,8 @@ PlatformImeController* WaylandWindow::GetPlatformImeController() {
 }
 
 void WaylandWindow::PerformNativeWindowDragOrResize(uint32_t hittest) {
+  connection_->ResetPointerFlags();
+
   if (hittest == HTCAPTION)
     xdg_surface_->SurfaceMove(connection_);
   else


### PR DESCRIPTION
fixup! Handle events for interactive drag and resize of native windows.

When starting an interactive drag or resize of native windows,
the first thing called is WaylandPointer::Button, and depending on
what mouse button is pressed, we set the appropriate flag to
WaylandPointer::flag_.

The problem is that when aura/mus informs WS that it is going to enter
an interactive move/resize, and this information gets to Ozone, the
"mouse up" event of the original "mouse down" isn't set.

This means than, when entering interactive move/resize mode, we left
WaylandPointer::flags_ set.

Now say user ends the interactive move/resize, and starts to hover around with
mouse into NON CLIENT areas, for resizing the window. It happens that mouse cursor
does not change to "resize types" when getting close the edge of the browser window.
This is because WaylandPointer::Motion is sending "mouse move" events
with WaylandPointer::flags_ still set. On Aura side, these events are
converted to "dragging" events (see ui/events/event.cc snippet below).

>  case ET_POINTER_MOVED:
>    if (pointer_event.flags() &
>        (EF_LEFT_MOUSE_BUTTON | EF_MIDDLE_MOUSE_BUTTON |
>         EF_RIGHT_MOUSE_BUTTON)) {
>      SetType(ET_MOUSE_DRAGGED);
>    } else {
>      SetType(ET_MOUSE_MOVED);
>    }
>    break;

... and in CompoundEventFilter::OnMouseEvent, ::UpdateCursor is not
called.

Patch fixes this by resetting WaylandPointer::flags_ whenever entering
interactive move/resize mode.

Issue #314