### PR TITLE
Reset ui::ws::EventDispatcher's states when capture is lost.

### DIFF
--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -359,8 +359,16 @@ void Display::OnAcceleratedWidgetAvailable() {
 
 void Display::OnNativeCaptureLost() {
   WindowManagerDisplayRoot* display_root = GetActiveWindowManagerDisplayRoot();
-  if (display_root)
-    display_root->window_manager_state()->SetCapture(nullptr, kInvalidClientId);
+  if (display_root) {
+    WindowManagerState* wms = display_root->window_manager_state();
+    wms->SetCapture(nullptr, kInvalidClientId);
+    // Reset event dispatcher's leftover states in case of lost capture.
+    // This is especially useful when another native window is created, and
+    // the previous window's event dispatcher is left with an outdated state
+    // leading to missed events.
+    if (window_server_->IsInExternalWindowMode())
+      wms->event_dispatcher()->Reset();
+  }
 }
 
 void Display::OnBoundsChanged(const gfx::Rect& new_bounds) {


### PR DESCRIPTION
This CL fixes a case, when a new native window is created and
all the events (including a button up event) go to that new window.

Before this CL, when a new window was created, the previous
window's EventDispatcher state was left with a button down
state, which caused events to be sent to a wrong target.

As of now, when a native window looses a capture, an EventDispatcher
is explicitly reset to make it possible to continue consuming events.

Issue #318