### PR TITLE
[chrome/ozone] Be more restrictive when to use '2x resources' for cursors

### DIFF
--- a/ui/base/cursor/cursors_aura.cc
+++ b/ui/base/cursor/cursors_aura.cc
@@ -232,9 +232,9 @@ bool SearchTable(const CursorData* table,
   for (size_t i = 0; i < table_length; ++i) {
     if (table[i].id == id) {
       *resource_id = table[i].resource_id;
-      *point = scale_factor == 1.0f || !resource_2x_available ?
-               gfx::Point(table[i].hot_1x.x, table[i].hot_1x.y) :
-               gfx::Point(table[i].hot_2x.x, table[i].hot_2x.y);
+      *point = scale_factor == 2.0f && resource_2x_available ?
+               gfx::Point(table[i].hot_2x.x, table[i].hot_2x.y) :
+               gfx::Point(table[i].hot_1x.x, table[i].hot_1x.y);
       return true;
     }
   }


### PR DESCRIPTION
When using NativeCursorManagerMus in chromeos/mash, the only
information used to build a ui::CursorData instance is ui::CursorType
(see ::SetCursor ui/views/mus/desktop_window_tree_host_mus.cc).
This is because in Mash builds, the platform specific 'PlatformCursor'
and scale factor values are only set on Ozone side.

This cursor type information is used to set the native cursor type as part of
the call chain to ui::ws::WindowTree::SetCursor.

  #0 0x558900d0e038 ui::(anonymous namespace)::SearchTable()
  #1 0x558900d0eaaa ui::GetCursorDataFor()
  #2 0x558900d0e1d2 ui::GetCursorBitmap()
  #3 0x558900d09fa3 ui::BitmapCursorFactoryOzone::GetDefaultCursorInternal()
  #4 0x558900d09e62 ui::BitmapCursorFactoryOzone::GetDefaultCursor()
  #5 0x558900d0eb51 ui::CursorLoaderOzone::SetPlatformCursor()
  #6 0x558902b5812a ui::ws::(anonymous namespace)::SetCursorOnResourceThread()
  #7 0x558902b58bdd ui::ThreadedImageCursors(..)
  (...)

In frame #4, BitmapCursorFactoryOzone::GetDefaultCursor is called only
with CursorType. The type passes through frame #3, and in frame #2
it is used to implicitly construct an ui::Cursor instance.

When the implicit ui::Cursor ctor is used, device_scale_factor defaults
to 0.0. Down the road, ::SearchTable ends up using "2x resources",
although the scale factor is not explicitly set to '2.0'. This causes
the cursor surface ends up offset'ed in both ChromeOS/Mash X11 and
Wayland builds.

Patch fixes this by only using 2x resource when a) device scale factor
is set to 2.0, and 2x resources are available. By default, hence, it
uses 1x resources, fixing the offset issue.

Issue #166