### PR TITLE
Rework "Resolve event clicking locations in X11" 

### DIFF
--- a/ui/events/event_utils.cc
+++ b/ui/events/event_utils.cc
@@ -130,4 +130,17 @@ void ComputeEventLatencyOS(const base::NativeEvent& native_event) {
   }
 }
 
+void ConvertEventLocationToTargetWindowLocation(
+    const gfx::Point& target_window_origin,
+    const gfx::Point& current_window_origin,
+    ui::LocatedEvent* located_event) {
+  DCHECK(located_event);
+  DCHECK(current_window_origin != target_window_origin);
+  gfx::Vector2d offset = current_window_origin - target_window_origin;
+  gfx::PointF location_in_pixel_in_host =
+      located_event->location_f() + gfx::Vector2dF(offset);
+  located_event->set_location_f(location_in_pixel_in_host);
+  located_event->set_root_location_f(location_in_pixel_in_host);
+}
+
 }  // namespace ui

--- a/ui/events/event_utils.h
+++ b/ui/events/event_utils.h
@@ -180,6 +180,14 @@ EVENTS_EXPORT void UpdateX11EventForChangedButtonFlags(MouseEvent* event);
 // Registers a custom event type.
 EVENTS_EXPORT int RegisterCustomEventType();
 
+// Updates the location of |located_event| from |current_window_origin| to be in
+// |target_window_origin|'s coordinate system so that it can be dispatched to a
+// window based on |target_window_origin|.
+EVENTS_EXPORT void ConvertEventLocationToTargetWindowLocation(
+    const gfx::Point& target_window_origin,
+    const gfx::Point& current_window_origin,
+    ui::LocatedEvent* located_event);
+
 }  // namespace ui
 
 #endif  // UI_EVENTS_EVENT_UTILS_H_

--- a/ui/platform_window/x11/x11_window_manager_ozone.cc
+++ b/ui/platform_window/x11/x11_window_manager_ozone.cc
@@ -7,14 +7,13 @@
 #include <X11/Xlib.h>
 
 #include "ui/base/x/x11_pointer_grab.h"
+#include "ui/platform_window/x11/x11_window_ozone.h"
 
 namespace ui {
 
 X11WindowManagerOzone::X11WindowManagerOzone() : event_grabber_(nullptr) {}
 
-X11WindowManagerOzone::~X11WindowManagerOzone() {
-  DCHECK(x11_windows_.empty());
-}
+X11WindowManagerOzone::~X11WindowManagerOzone() {}
 
 void X11WindowManagerOzone::GrabEvents(X11WindowOzone* window) {
   if (event_grabber_ == window)
@@ -32,27 +31,6 @@ void X11WindowManagerOzone::UngrabEvents(X11WindowOzone* window) {
     return;
   event_grabber_->OnLostCapture();
   event_grabber_ = nullptr;
-}
-
-void X11WindowManagerOzone::AddX11Window(X11WindowOzone* window) {
-  auto it = std::find(x11_windows_.begin(), x11_windows_.end(), window);
-  DCHECK(it == x11_windows_.end());
-  x11_windows_.push_back(window);
-}
-
-void X11WindowManagerOzone::DeleteX11Window(X11WindowOzone* window) {
-  auto it = std::find(x11_windows_.begin(), x11_windows_.end(), window);
-  if (it != x11_windows_.end())
-    x11_windows_.erase(it);
-}
-
-X11WindowOzone* X11WindowManagerOzone::GetX11WindowByTarget(
-    const XID& xwindow) {
-  for (auto* x11_window : x11_windows_) {
-    if (x11_window->xwindow() == xwindow)
-      return x11_window;
-  }
-  return nullptr;
 }
 
 }  // namespace ui

--- a/ui/platform_window/x11/x11_window_manager_ozone.h
+++ b/ui/platform_window/x11/x11_window_manager_ozone.h
@@ -7,9 +7,10 @@
 
 #include "base/macros.h"
 #include "ui/platform_window/x11/x11_window_export.h"
-#include "ui/platform_window/x11/x11_window_ozone.h"
 
 namespace ui {
+
+class X11WindowOzone;
 
 class X11_WINDOW_EXPORT X11WindowManagerOzone {
  public:
@@ -26,19 +27,8 @@ class X11_WINDOW_EXPORT X11WindowManagerOzone {
   // Gets the current X11WindowOzone recipient of mouse events.
   X11WindowOzone* event_grabber() const { return event_grabber_; }
 
-  // Stores raw pointers to X11WindowOzone.
-  void AddX11Window(X11WindowOzone* window);
-
-  // Removes raw pointers to X11WindowOzone.
-  void DeleteX11Window(X11WindowOzone* window);
-
-  // Returns pointer to X11WindowOzone found by XID.
-  X11WindowOzone* GetX11WindowByTarget(const XID& xwindow);
-
  private:
   X11WindowOzone* event_grabber_;
-
-  std::vector<X11WindowOzone*> x11_windows_;
 
   DISALLOW_COPY_AND_ASSIGN(X11WindowManagerOzone);
 };

--- a/ui/platform_window/x11/x11_window_ozone.h
+++ b/ui/platform_window/x11/x11_window_ozone.h
@@ -15,7 +15,6 @@
 namespace ui {
 
 class X11WindowManagerOzone;
-class LocatedEvent;
 
 // PlatformWindow implementation for X11 Ozone. PlatformEvents are ui::Events.
 class X11_WINDOW_EXPORT X11WindowOzone : public X11WindowBase,
@@ -41,19 +40,11 @@ class X11_WINDOW_EXPORT X11WindowOzone : public X11WindowBase,
   bool DispatchXEvent(XEvent* event) override;
 
  private:
-  // Calls OnLostCapture() and xwindow().
+  // Calls OnLostCapture().
   friend X11WindowManagerOzone;
 
-  // Called by |window_manager_| once capture is set to another xwindow.
+  // Called by |window_manager_| once capture is set to another X11WindowOzone.
   void OnLostCapture();
-
-  // Converts events' location if they are originally from background windows,
-  // but capture is set to another foreground window.
-  // TODO(msisov, tonikitoo): share this logic with DesktopWindowTreeHostX11
-  // and WaylandWindow.
-  void ConvertEventLocationToCurrentWindowLocation(
-      X11WindowOzone* target,
-      ui::LocatedEvent* located_event);
 
   // PlatformEventDispatcher:
   bool CanDispatchEvent(const PlatformEvent& event) override;

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.cc
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.cc
@@ -1768,7 +1768,9 @@ void DesktopWindowTreeHostX11::DispatchMouseEvent(ui::MouseEvent* event) {
   } else {
     // Another DesktopWindowTreeHostX11 has installed itself as
     // capture. Translate the event's location and dispatch to the other.
-    ConvertEventToDifferentHost(event, g_current_capture);
+    ConvertEventLocationToTargetWindowLocation(
+        g_current_capture->GetLocationOnScreenInPixels(),
+        GetLocationOnScreenInPixels(), event->AsLocatedEvent());
     g_current_capture->SendEventToSink(event);
   }
 }
@@ -1776,7 +1778,9 @@ void DesktopWindowTreeHostX11::DispatchMouseEvent(ui::MouseEvent* event) {
 void DesktopWindowTreeHostX11::DispatchTouchEvent(ui::TouchEvent* event) {
   if (g_current_capture && g_current_capture != this &&
       event->type() == ui::ET_TOUCH_PRESSED) {
-    ConvertEventToDifferentHost(event, g_current_capture);
+    ConvertEventLocationToTargetWindowLocation(
+        g_current_capture->GetLocationOnScreenInPixels(),
+        GetLocationOnScreenInPixels(), event->AsLocatedEvent());
     g_current_capture->SendEventToSink(event);
   } else {
     SendEventToSink(event);
@@ -1786,20 +1790,6 @@ void DesktopWindowTreeHostX11::DispatchTouchEvent(ui::TouchEvent* event) {
 void DesktopWindowTreeHostX11::DispatchKeyEvent(ui::KeyEvent* event) {
   if (native_widget_delegate_->AsWidget()->IsActive())
     SendEventToSink(event);
-}
-
-void DesktopWindowTreeHostX11::ConvertEventToDifferentHost(
-    ui::LocatedEvent* located_event,
-    DesktopWindowTreeHostX11* host) {
-  DCHECK_NE(this, host);
-  DCHECK_EQ(ui::GetScaleFactorForNativeView(window()),
-            ui::GetScaleFactorForNativeView(host->window()));
-  gfx::Vector2d offset =
-      GetLocationOnScreenInPixels() - host->GetLocationOnScreenInPixels();
-  gfx::PointF location_in_pixel_in_host =
-      located_event->location_f() + gfx::Vector2dF(offset);
-  located_event->set_location_f(location_in_pixel_in_host);
-  located_event->set_root_location_f(location_in_pixel_in_host);
 }
 
 void DesktopWindowTreeHostX11::ResetWindowRegion() {

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.h
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.h
@@ -245,11 +245,6 @@ class VIEWS_EXPORT DesktopWindowTreeHostX11
   // Dispatches a key event.
   void DispatchKeyEvent(ui::KeyEvent* event);
 
-  // Updates the location of |located_event| to be in |host|'s coordinate system
-  // so that it can be dispatched to |host|.
-  void ConvertEventToDifferentHost(ui::LocatedEvent* located_event,
-                                   DesktopWindowTreeHostX11* host);
-
   // Resets the window region for the current widget bounds if necessary.
   void ResetWindowRegion();
 


### PR DESCRIPTION
This pull request reworks the above mentioned commit by removing unnecessary stuff from X11WindowManagerOzone and sharing ConvertEventLocationToTargetWindowLocation, which used to be named ConvertEventLocationToCurrentWindowLocation.

Basically, this is also an adapt to https://chromium-review.googlesource.com/c/chromium/src/+/774778 that we have already had in our branch.