### PR TITLE
Use WTC::OnWindowMusCreated as the entry point to create native windows.

### DIFF
--- a/ui/aura/mus/window_tree_host_mus.cc
+++ b/ui/aura/mus/window_tree_host_mus.cc
@@ -41,6 +41,11 @@ WindowTreeHostMus::WindowTreeHostMus(WindowTreeHostMusInitParams init_params)
       delegate_(init_params.window_tree_client) {
   gfx::Rect bounds_in_pixels;
   display_init_params_ = std::move(init_params.display_init_params);
+
+  // Copy the mus properties here in the display init paramaters instance,
+  // so that it is accessible from WTC::OnWindowMusCreated.
+  mus_init_properties_ = init_params.properties;
+
   if (display_init_params_) {
     bounds_in_pixels = display_init_params_->viewport_metrics.bounds_in_pixels;
     if (display_init_params_->display)

--- a/ui/aura/mus/window_tree_host_mus.h
+++ b/ui/aura/mus/window_tree_host_mus.h
@@ -93,6 +93,14 @@ class AURA_EXPORT WindowTreeHostMus : public aura::WindowTreeHostPlatform {
   // supplied to the constructor.
   std::unique_ptr<DisplayInitParams> ReleaseDisplayInitParams();
 
+  // Used during the initial set up (in external window mode). It holds a
+  // copy of the properties needed by the window server when creating a
+  // root server window.
+  const std::map<std::string, std::vector<uint8_t>>& mus_init_properties()
+      const {
+    return mus_init_properties_;
+  }
+
   // Intended only for WindowTreeClient to call.
   void set_display_id(int64_t id) { display_id_ = id; }
   int64_t display_id() const { return display_id_; }
@@ -119,6 +127,8 @@ class AURA_EXPORT WindowTreeHostMus : public aura::WindowTreeHostPlatform {
   std::unique_ptr<InputMethodMus> input_method_;
 
   std::unique_ptr<DisplayInitParams> display_init_params_;
+
+  std::map<std::string, std::vector<uint8_t>> mus_init_properties_;
 
   DISALLOW_COPY_AND_ASSIGN(WindowTreeHostMus);
 };


### PR DESCRIPTION
fixup! c++ / mojo changes for 'external window mode'
    
Patch moves our external window creation entry point from
WTC::CreateWindowPortForTopLevel to WTC::OnWindowMusCreated.
    
The later is the same spot used in ChromeOS/Mus to create
the WindowManager's root window, so we concentrate changes and
logic in one place.
    
The early return in ::CreateWindowPortForTopLevel, is because
we do not want to set server_id there, otherwise the first line in
::OnWindowMusCreated bails out early.
    
Issue #266 