### PR TITLE
[ozone/wayland] use KeyboardEvDev for keyboard handling

### DIFF
--- a/ui/ozone/platform/wayland/BUILD.gn
+++ b/ui/ozone/platform/wayland/BUILD.gn
@@ -67,6 +67,7 @@ source_set("wayland") {
     "//ui/display/manager",
     "//ui/events",
     "//ui/events:dom_keycode_converter",
+    "//ui/events/ozone:events_ozone_evdev",
     "//ui/events/ozone:events_ozone_layout",
     "//ui/events/platform",
     "//ui/gfx",

--- a/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+++ b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
@@ -88,10 +88,6 @@ class OzonePlatformWayland : public OzonePlatform {
   }
 
   void InitializeUI(const InitParams& args) override {
-    connection_.reset(new WaylandConnection);
-    if (!connection_->Initialize())
-      LOG(FATAL) << "Failed to initialize Wayland platform";
-
 #if BUILDFLAG(USE_XKBCOMMON)
     KeyboardLayoutEngineManager::SetKeyboardLayoutEngine(
         std::make_unique<WaylandXkbKeyboardLayoutEngine>(
@@ -100,6 +96,9 @@ class OzonePlatformWayland : public OzonePlatform {
     KeyboardLayoutEngineManager::SetKeyboardLayoutEngine(
         std::make_unique<StubKeyboardLayoutEngine>());
 #endif
+    connection_.reset(new WaylandConnection);
+    if (!connection_->Initialize())
+      LOG(FATAL) << "Failed to initialize Wayland platform";
 
     cursor_factory_.reset(new BitmapCursorFactoryOzone);
     overlay_manager_.reset(new StubOverlayManager);

--- a/ui/ozone/platform/wayland/wayland_keyboard.cc
+++ b/ui/ozone/platform/wayland/wayland_keyboard.cc
@@ -24,15 +24,13 @@
 
 namespace ui {
 
-namespace {
-
-const int kXkbKeycodeOffset = 8;
-
-}  // namespace
-
 WaylandKeyboard::WaylandKeyboard(wl_keyboard* keyboard,
                                  const EventDispatchCallback& callback)
-    : obj_(keyboard), callback_(callback) {
+    : obj_(keyboard),
+      callback_(callback),
+      evdev_keyboard_(&modifiers_,
+                      KeyboardLayoutEngineManager::GetKeyboardLayoutEngine(),
+                      callback_) {
   static const wl_keyboard_listener listener = {
       &WaylandKeyboard::Keymap,    &WaylandKeyboard::Enter,
       &WaylandKeyboard::Leave,     &WaylandKeyboard::Key,
@@ -93,25 +91,9 @@ void WaylandKeyboard::Key(void* data,
   WaylandKeyboard* keyboard = static_cast<WaylandKeyboard*>(data);
   keyboard->connection_->set_serial(serial);
 
-  DomCode dom_code =
-      KeycodeConverter::NativeKeycodeToDomCode(key + kXkbKeycodeOffset);
-  if (dom_code == ui::DomCode::NONE)
-    return;
-
-  uint8_t flags = keyboard->modifiers_;
-  DomKey dom_key;
-  KeyboardCode key_code;
-  if (!KeyboardLayoutEngineManager::GetKeyboardLayoutEngine()->Lookup(
-          dom_code, flags, &dom_key, &key_code))
-    return;
-
-  // TODO(tonikitoo): handle repeat here.
-  bool down = state == WL_KEYBOARD_KEY_STATE_PRESSED;
-  ui::KeyEvent event(down ? ET_KEY_PRESSED : ET_KEY_RELEASED, key_code,
-                     dom_code, keyboard->modifiers_, dom_key,
-                     EventTimeForNow());
-  event.set_source_device_id(keyboard->obj_.id());
-  keyboard->callback_.Run(&event);
+  keyboard->evdev_keyboard_.OnKeyChange(
+      key, state == WL_KEYBOARD_KEY_STATE_PRESSED, false, EventTimeForNow(),
+      keyboard->obj_.id());
 }
 
 void WaylandKeyboard::Modifiers(void* data,
@@ -121,23 +103,14 @@ void WaylandKeyboard::Modifiers(void* data,
                                 uint32_t mods_latched,
                                 uint32_t mods_locked,
                                 uint32_t group) {
-#if BUILDFLAG(USE_XKBCOMMON)
-  WaylandKeyboard* keyboard = static_cast<WaylandKeyboard*>(data);
-  auto* engine = static_cast<WaylandXkbKeyboardLayoutEngine*>(
-      KeyboardLayoutEngineManager::GetKeyboardLayoutEngine());
-
-  keyboard->modifiers_ =
-      engine->UpdateModifiers(mods_depressed, mods_latched, mods_locked, group);
-
-#endif
+  // KeyboardEvDev handles modifiers.
 }
 
 void WaylandKeyboard::RepeatInfo(void* data,
                                  wl_keyboard* obj,
                                  int32_t rate,
                                  int32_t delay) {
-  // TODO(tonikitoo): Implement proper repeat handling.
-  NOTIMPLEMENTED();
+  // KeyboardEvDev handles key repeat.
 }
 
 }  // namespace ui

--- a/ui/ozone/platform/wayland/wayland_keyboard.h
+++ b/ui/ozone/platform/wayland/wayland_keyboard.h
@@ -5,7 +5,9 @@
 #ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_KEYBOARD_H_
 #define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_KEYBOARD_H_
 
+#include "ui/events/event_modifiers.h"
 #include "ui/events/ozone/evdev/event_dispatch_callback.h"
+#include "ui/events/ozone/evdev/keyboard_evdev.h"
 #include "ui/ozone/platform/wayland/wayland_object.h"
 
 namespace ui {
@@ -21,7 +23,7 @@ class WaylandKeyboard {
     connection_ = connection;
   }
 
-  int modifiers() { return modifiers_; }
+  int modifiers() { return modifiers_.GetModifierFlags(); }
 
  private:
   // wl_keyboard_listener
@@ -60,7 +62,9 @@ class WaylandKeyboard {
   WaylandConnection* connection_ = nullptr;
   wl::Object<wl_keyboard> obj_;
   EventDispatchCallback callback_;
-  int modifiers_ = 0;
+
+  EventModifiers modifiers_;
+  KeyboardEvdev evdev_keyboard_;
 };
 
 }  // namespace ui


### PR DESCRIPTION
In WaylandKeyboard::Key's body, we deliberately duplicate some of the
logic in KeyboardEvdev::DispatchKey. The idea was to use the bits of
KeyboardEvDev needed for proper keyboard input handling.
It turns out that features like key repeat and specific cases involving
modifiers were not functional.

Instead of continue to duplicate stable and existing logic, CL adopts
the use of KeyboardEvDev from WaylandKeyboard, fixing all these issues
and being able to do some code clean ups (follow ups).

CL also changes the KeyboardLayoutManager instantiation order in
OzonePlatformWayland::InitializeUI, so that it happens prior to
WaylandConnection instantiation.
Reason: once WaylandConnection creates WaylandKeyboard and (implicitly)
KeyboardEvDev, the later needs the KeyboardLayoutEngine properly set.

Issue #331