### PR TITLE
fixup! [ozone/wayland] use KeyboardEvDev for keyboard handling

### DIFF
--- a/ui/events/ozone/evdev/keyboard_evdev.cc
+++ b/ui/events/ozone/evdev/keyboard_evdev.cc
@@ -217,7 +217,9 @@ void KeyboardEvdev::OnRepeatCommit(unsigned int sequence) {
   DispatchKey(repeat_key_, true /* down */, true /* repeat */,
               EventTimeForNow(), repeat_device_id_);
 
-  ScheduleKeyRepeat(repeat_interval_);
+  // Do not schedule auto repeat if it has been turned out.
+  if (IsAutoRepeatEnabled())
+    ScheduleKeyRepeat(repeat_interval_);
 }
 
 void KeyboardEvdev::DispatchKey(unsigned int key,

--- a/ui/events/ozone/evdev/keyboard_evdev.h
+++ b/ui/events/ozone/evdev/keyboard_evdev.h
@@ -61,6 +61,8 @@ class EVENTS_OZONE_EVDEV_EXPORT KeyboardEvdev {
   // Handle keyboard layout changes.
   bool SetCurrentLayoutByName(const std::string& layout_name);
 
+  void StopKeyRepeat();
+
  private:
   void UpdateModifier(int modifier_flag, bool down);
   void RefreshModifiers();
@@ -70,7 +72,6 @@ class EVENTS_OZONE_EVDEV_EXPORT KeyboardEvdev {
                        bool suppress_auto_repeat,
                        int device_id);
   void StartKeyRepeat(unsigned int key, int device_id);
-  void StopKeyRepeat();
   void ScheduleKeyRepeat(const base::TimeDelta& delay);
   void OnRepeatTimeout(unsigned int sequence);
   void OnRepeatCommit(unsigned int sequence);


### PR DESCRIPTION
A couple of points were missed, when we switched to use KeyboardEvdev.

First of all, when user switches between windows by pressing alt+tab,
KeyboardEvdev may find itself in a situation, when auto repeating of
the alt key is scheduled over and over again. In order to fix this,
KeyboardEvdev::StopRepeating is called on Leave event.

Secondly, once user alternates between windows and then returns back
to the same window, a text input may be broken due to set modidifers.
That is, when user switches to another window, the alt key is still
treated pressed and modifiers are not updated at all before user
switches back and presses the alt key again. The fix to this problem
is to reset modifiers on Leave event.

Last but not least, WaylandKeyboard::RepeatInfo sends delay and rate
information that is usefull for KeyboardEvdev. Thus, desired repeating
settings can be set. What is more, wayland documentation says if
rate is send as 0, then auto repeat should be turned off.

TBR=tonikitoo@igalia.com