### PR TITLE
Refactor setting ozone x11 and wayland window states

### DIFF
--- a/services/ui/ws/platform_display_default.h
+++ b/services/ui/ws/platform_display_default.h
@@ -91,6 +91,10 @@ class PlatformDisplayDefault : public PlatformDisplay,
   std::unique_ptr<ui::PlatformWindow> platform_window_;
   gfx::AcceleratedWidget widget_;
 
+  // Set to true once ozone is in a process of telling a server window of
+  // changed window state.
+  bool applying_window_state_changes_ = false;
+
   DISALLOW_COPY_AND_ASSIGN(PlatformDisplayDefault);
 };
 

--- a/ui/ozone/platform/wayland/BUILD.gn
+++ b/ui/ozone/platform/wayland/BUILD.gn
@@ -41,6 +41,7 @@ source_set("wayland") {
     "xdg_popup_wrapper_v5.h",
     "xdg_popup_wrapper_v6.cc",
     "xdg_popup_wrapper_v6.h",
+    "xdg_surface_wrapper.cc",
     "xdg_surface_wrapper.h",
     "xdg_surface_wrapper_v5.cc",
     "xdg_surface_wrapper_v5.h",

--- a/ui/ozone/platform/wayland/fake_server.cc
+++ b/ui/ozone/platform/wayland/fake_server.cc
@@ -226,16 +226,16 @@ void UnsetMaximized(wl_client* client, wl_resource* resource) {
       ->UnsetMaximized();
 }
 
-void SetFullScreen(wl_client* client,
+void SetFullscreen(wl_client* client,
                    wl_resource* resource,
                    wl_resource* output) {
   static_cast<MockXdgSurface*>(wl_resource_get_user_data(resource))
-      ->SetFullScreen();
+      ->SetFullscreen();
 }
 
-void UnsetFullScreen(wl_client* client, wl_resource* resource) {
+void UnsetFullscreen(wl_client* client, wl_resource* resource) {
   static_cast<MockXdgSurface*>(wl_resource_get_user_data(resource))
-      ->UnsetFullScreen();
+      ->UnsetFullscreen();
 }
 
 void SetMinimized(wl_client* client, wl_resource* resource) {
@@ -255,8 +255,8 @@ const struct xdg_surface_interface xdg_surface_impl = {
     &SetWindowGeometry,  // set_window_geometry
     &SetMaximized,       // set_maximized
     &UnsetMaximized,     // set_unmaximized
-    &SetFullScreen,      // set_fullscreen
-    &UnsetFullScreen,    // unset_fullscreen
+    &SetFullscreen,      // set_fullscreen
+    &UnsetFullscreen,    // unset_fullscreen
     &SetMinimized,       // set_minimized
 };
 
@@ -299,8 +299,8 @@ const struct zxdg_toplevel_v6_interface zxdg_toplevel_v6_impl = {
     nullptr,           // set_min_size
     &SetMaximized,     // set_maximized
     &UnsetMaximized,   // set_unmaximized
-    &SetFullScreen,    // set_fullscreen
-    &UnsetFullScreen,  // unset_fullscreen
+    &SetFullscreen,    // set_fullscreen
+    &UnsetFullscreen,  // unset_fullscreen
     &SetMinimized,     // set_minimized
 };
 

--- a/ui/ozone/platform/wayland/fake_server.h
+++ b/ui/ozone/platform/wayland/fake_server.h
@@ -57,8 +57,8 @@ class MockXdgSurface : public ServerObject {
                void(int32_t x, int32_t y, int32_t widht, int32_t height));
   MOCK_METHOD0(SetMaximized, void());
   MOCK_METHOD0(UnsetMaximized, void());
-  MOCK_METHOD0(SetFullScreen, void());
-  MOCK_METHOD0(UnsetFullScreen, void());
+  MOCK_METHOD0(SetFullscreen, void());
+  MOCK_METHOD0(UnsetFullscreen, void());
   MOCK_METHOD0(SetMinimized, void());
 
   // Used when xdg v6 is used.

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -17,7 +17,6 @@
 #include "ui/ozone/platform/wayland/xdg_popup_wrapper_v6.h"
 #include "ui/ozone/platform/wayland/xdg_surface_wrapper_v5.h"
 #include "ui/ozone/platform/wayland/xdg_surface_wrapper_v6.h"
-#include "ui/platform_window/platform_window_delegate.h"
 
 namespace ui {
 
@@ -76,7 +75,8 @@ WaylandWindow::WaylandWindow(PlatformWindowDelegate* delegate,
     : delegate_(delegate),
       connection_(connection),
       xdg_shell_objects_factory_(new XDGShellObjectFactory()),
-      bounds_(bounds) {}
+      bounds_(bounds),
+      state_(ui::PlatformWindowState::PLATFORM_WINDOW_STATE_UNKNOWN) {}
 
 WaylandWindow::~WaylandWindow() {
   PlatformEventSource::GetInstance()->RemovePlatformEventDispatcher(this);
@@ -279,69 +279,52 @@ void WaylandWindow::ReleaseCapture() {
 }
 
 void WaylandWindow::ToggleFullscreen() {
-  // Don't fullscreen popup.
-  if (xdg_popup_)
-    return;
-
   DCHECK(xdg_surface_);
+  DCHECK(!IsMinimized());
 
   // TODO(msisov, tonikitoo): add multiscreen support. As the documentation says
   // if xdg_surface_set_fullscreen() is not provided with wl_output, it's up to
   // the compositor to choose which display will be used to map this surface.
-  if (!IsFullScreen())
+  if (!IsFullscreen())
     xdg_surface_->SetFullscreen();
   else
     xdg_surface_->UnSetFullscreen();
-
   connection_->ScheduleFlush();
 }
 
 void WaylandWindow::Maximize() {
-  // Don't maximize popup.
-  if (xdg_popup_ || IsMaximized())
-    return;
-
   DCHECK(xdg_surface_);
-  // Unfullscreen the window if it is fullscreen.
-  if (IsFullScreen())
+  DCHECK(!IsMaximized());
+
+  if (IsFullscreen())
     ToggleFullscreen();
 
-  previous_bounds_in_pixels_ = bounds_;
   xdg_surface_->SetMaximized();
   connection_->ScheduleFlush();
 }
 
 void WaylandWindow::Minimize() {
-  // Don't Minimize popup.
-  if (xdg_popup_)
-    return;
-
   DCHECK(xdg_surface_);
-  if (IsMinimized())
-    return;
+  DCHECK(!IsMinimized());
 
   xdg_surface_->SetMinimized();
   connection_->ScheduleFlush();
-  is_minimized_ = true;
-  was_minimized_ = false;
+
+  // Wayland doesn't say if a window is minimized. Handle this case manually
+  // here. We can track if the window was unminimized once wayland sends the
+  // window is activated, and the previous state was minimized.
+  state_ = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MINIMIZED;
 }
 
 void WaylandWindow::Restore() {
-  if (xdg_popup_ || !xdg_surface_)
-    return;
+  DCHECK(xdg_surface_);
 
   // Unfullscreen the window if it is fullscreen.
-  if (IsFullScreen())
+  if (IsFullscreen())
     ToggleFullscreen();
 
-  if (IsMaximized()) {
-    previous_bounds_in_pixels_ = bounds_;
-    xdg_surface_->UnSetMaximized();
-    connection_->ScheduleFlush();
-  }
-  if (is_minimized_)
-    was_minimized_ = is_minimized_;
-  is_minimized_ = false;
+  xdg_surface_->UnSetMaximized();
+  connection_->ScheduleFlush();
 }
 
 void WaylandWindow::SetCursor(PlatformCursor cursor) {
@@ -436,56 +419,27 @@ void WaylandWindow::HandleSurfaceConfigure(int32_t width,
                                            bool is_maximized,
                                            bool is_fullscreen,
                                            bool is_activated) {
-  // Handle restore state from wayland side: if the state was minimized and
-  // a user restore windows from panel tray, the only way to know that the
-  // window is restored is by checking if the window has been minimized and
-  // |is_activated| is set to true.
-  if (is_minimized_ && is_activated) {
-    is_minimized_ = false;
-    was_minimized_ = true;
-  }
+  // Change the window state only if the window is activated, because it's the
+  // only way to know if the window is not minimized.
+  if (is_activated) {
+    bool was_minimized = IsMinimized();
 
-  bool was_maximized = is_maximized_;
-  ResetWindowStates();
-  is_maximized_ = is_maximized;
-  is_fullscreen_ = is_fullscreen;
+    state_ = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_NORMAL;
+    if (is_maximized && !is_fullscreen)
+      state_ = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MAXIMIZED;
+    else if (is_fullscreen)
+      state_ = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_FULLSCREEN;
+
+    // Do not flood the WindowServer unless the previous state was minimized.
+    if (was_minimized)
+      delegate_->OnWindowStateChanged(state_);
+  }
 
   // Width or height set 0 means that we should decide on width and height by
   // ourselves, but we don't want to set to anything else. Use previous size.
   if (width == 0 || height == 0) {
     width = GetBounds().width();
     height = GetBounds().height();
-    if (was_maximized) {
-      // In weston, unmaximize asks client to decide on bounds. It's ok if
-      // the state has been changed from normal to maximize and back to normal.
-      // In that case, previous bounds are known. But if the browser has been
-      // started in maximized mode, unmaximize bounds are unknown or better to
-      // say those correspond to the maximized state bounds. A client must
-      // decide which bounds to use. At this point, use half of the maximized
-      // bounds.
-      width = previous_bounds_in_pixels_.width();
-      height = previous_bounds_in_pixels_.height();
-      if (previous_bounds_in_pixels_ == GetBounds()) {
-        // TODO(msisov, tonikitoo): fix this hack.
-        width = width / 2;
-        height = height / 2;
-      }
-    }
-  }
-
-  ui::PlatformWindowState state =
-      ui::PlatformWindowState::PLATFORM_WINDOW_STATE_NORMAL;
-  if (IsMaximized())
-    state = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MAXIMIZED;
-  else if (IsMinimized())
-    state = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MINIMIZED;
-
-  if ((previous_bounds_in_pixels_.IsEmpty() &&
-       IsMaximized() != was_maximized) ||
-      IsMinimized() != was_minimized_) {
-    delegate_->OnWindowStateChanged(state);
-    if (!is_minimized_)
-      was_minimized_ = false;
   }
 
   was_active_ = is_active_;
@@ -498,7 +452,6 @@ void WaylandWindow::HandleSurfaceConfigure(int32_t width,
   // when it has finished processing events. We may get many configure events
   // in a row during an interactive resize, and only the last one matters.
   pending_bounds_ = gfx::Rect(0, 0, width, height);
-  previous_bounds_in_pixels_ = gfx::Rect();
 }
 
 void WaylandWindow::OnCloseRequest() {
@@ -508,21 +461,16 @@ void WaylandWindow::OnCloseRequest() {
   delegate_->OnCloseRequest();
 }
 
-bool WaylandWindow::IsMinimized() {
-  return is_minimized_;
+bool WaylandWindow::IsMinimized() const {
+  return state_ == ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MINIMIZED;
 }
 
-bool WaylandWindow::IsMaximized() {
-  return is_maximized_;
+bool WaylandWindow::IsMaximized() const {
+  return state_ == ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MAXIMIZED;
 }
 
-bool WaylandWindow::IsFullScreen() {
-  return is_fullscreen_;
-}
-
-void WaylandWindow::ResetWindowStates() {
-  is_maximized_ = false;
-  is_fullscreen_ = false;
+bool WaylandWindow::IsFullscreen() const {
+  return state_ == ui::PlatformWindowState::PLATFORM_WINDOW_STATE_FULLSCREEN;
 }
 
 WaylandWindow* WaylandWindow::GetParentWindow() {

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -279,32 +279,47 @@ void WaylandWindow::ReleaseCapture() {
 }
 
 void WaylandWindow::ToggleFullscreen() {
-  DCHECK(xdg_surface_);
+  DCHECK(xdg_surface_ && !xdg_popup_);
   DCHECK(!IsMinimized());
 
   // TODO(msisov, tonikitoo): add multiscreen support. As the documentation says
   // if xdg_surface_set_fullscreen() is not provided with wl_output, it's up to
   // the compositor to choose which display will be used to map this surface.
-  if (!IsFullscreen())
+  if (!IsFullscreen()) {
+    // Client might have requested a fullscreen state while the window was in
+    // a maximized state. Thus, |restored_bounds_| can contain the bounds of a
+    // normal state before the window was maximized. If the |restored_bounds_|
+    // are empty, save the current bounds and request wayland to set window to
+    // be fullscreen. The |restored_bounds_| are reset once the state of the
+    // window becomes normal again.
+    if (restored_bounds_.IsEmpty())
+      restored_bounds_ = bounds_;
     xdg_surface_->SetFullscreen();
-  else
+  } else {
     xdg_surface_->UnSetFullscreen();
+  }
+
   connection_->ScheduleFlush();
 }
 
 void WaylandWindow::Maximize() {
-  DCHECK(xdg_surface_);
+  DCHECK(xdg_surface_ && !xdg_popup_);
   DCHECK(!IsMaximized());
 
   if (IsFullscreen())
     ToggleFullscreen();
 
+  // Save previous bounds in order to restore them when wayland requests so.
+  // If there are previous restored bounds (ToggleFullscreen() saved bounds,
+  // check the comments above), use them.
+  if (restored_bounds_.IsEmpty())
+    restored_bounds_ = bounds_;
   xdg_surface_->SetMaximized();
   connection_->ScheduleFlush();
 }
 
 void WaylandWindow::Minimize() {
-  DCHECK(xdg_surface_);
+  DCHECK(xdg_surface_ && !xdg_popup_);
   DCHECK(!IsMinimized());
 
   xdg_surface_->SetMinimized();
@@ -317,7 +332,7 @@ void WaylandWindow::Minimize() {
 }
 
 void WaylandWindow::Restore() {
-  DCHECK(xdg_surface_);
+  DCHECK(xdg_surface_ && !xdg_popup_);
 
   // Unfullscreen the window if it is fullscreen.
   if (IsFullscreen())
@@ -435,23 +450,33 @@ void WaylandWindow::HandleSurfaceConfigure(int32_t width,
       delegate_->OnWindowStateChanged(state_);
   }
 
-  // Width or height set 0 means that we should decide on width and height by
-  // ourselves, but we don't want to set to anything else. Use previous size.
-  if (width == 0 || height == 0) {
-    width = GetBounds().width();
-    height = GetBounds().height();
-  }
-
-  was_active_ = is_active_;
-  is_active_ = is_activated;
-  if (was_active_ != is_active_)
-    delegate_->OnActivationChanged(is_active_);
-
   // Rather than call SetBounds here for every configure event, just save the
   // most recent bounds, and have WaylandConnection call ApplyPendingBounds
   // when it has finished processing events. We may get many configure events
   // in a row during an interactive resize, and only the last one matters.
   pending_bounds_ = gfx::Rect(0, 0, width, height);
+
+  // Width or height set 0 means that we should decide on width and height by
+  // ourselves, but we don't want to set to anything else. Use restored bounds
+  // size or the current bounds.
+  //
+  // Hack: if the browser was started with --start-fullscreen and a user exits
+  // the fullscreen mode, wayland may set the width and height to be 1. Instead,
+  // explicitly set the bounds to the current desired ones or the previous
+  // bounds.
+  if (width == 0 || height == 0 || (width == 1 && height == 1)) {
+    pending_bounds_.set_size(restored_bounds_.IsEmpty()
+                                 ? GetBounds().size()
+                                 : restored_bounds_.size());
+  }
+
+  if (!IsFullscreen() && !IsMaximized())
+    restored_bounds_ = gfx::Rect();
+
+  was_active_ = is_active_;
+  is_active_ = is_activated;
+  if (was_active_ != is_active_)
+    delegate_->OnActivationChanged(is_active_);
 }
 
 void WaylandWindow::OnCloseRequest() {

--- a/ui/ozone/platform/wayland/wayland_window.h
+++ b/ui/ozone/platform/wayland/wayland_window.h
@@ -11,6 +11,7 @@
 #include "ui/gfx/native_widget_types.h"
 #include "ui/ozone/platform/wayland/wayland_object.h"
 #include "ui/platform_window/platform_window.h"
+#include "ui/platform_window/platform_window_delegate.h"
 
 namespace ui {
 
@@ -105,6 +106,10 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
   PlatformWindowDelegate* delegate() { return delegate_; }
 
  private:
+  bool IsMinimized() const;
+  bool IsMaximized() const;
+  bool IsFullscreen() const;
+
   // TODO(msisov, tonikitoo): share this with X11WindowOzone and
   // DesktopWindowTreeHostX11.
   void ConvertEventLocationToCurrentWindowLocation(ui::Event* located_event);
@@ -118,14 +123,6 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
 
   // Tells if |this| has capture.
   bool HasCapture();
-
-  // TODO(msisov, tonikitoo): share this with X11WindowBase.
-  bool IsMinimized();
-  bool IsMaximized();
-  bool IsFullScreen();
-
-  // Resets the maximized and fullscreen window states.
-  void ResetWindowStates();
 
   // Gets a parent window for this window.
   WaylandWindow* GetParentWindow();
@@ -150,21 +147,18 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
   scoped_refptr<BitmapCursorOzone> bitmap_;
 
   gfx::Rect bounds_;
-  gfx::Rect previous_bounds_in_pixels_;
   gfx::Rect pending_bounds_;
   bool has_pointer_focus_ = false;
   bool has_keyboard_focus_ = false;
   bool has_touch_focus_ = false;
 
-  bool is_minimized_ = false;
-  bool was_minimized_ = false;
-  bool is_maximized_ = false;
-  bool is_fullscreen_ = false;
-
   bool was_active_ = false;
   bool is_active_ = false;
 
   bool is_tooltip_ = false;
+
+  // Stores current states of the window.
+  ui::PlatformWindowState state_;
 
   DISALLOW_COPY_AND_ASSIGN(WaylandWindow);
 };

--- a/ui/ozone/platform/wayland/wayland_window.h
+++ b/ui/ozone/platform/wayland/wayland_window.h
@@ -148,6 +148,7 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
 
   gfx::Rect bounds_;
   gfx::Rect pending_bounds_;
+  gfx::Rect restored_bounds_;
   bool has_pointer_focus_ = false;
   bool has_keyboard_focus_ = false;
   bool has_touch_focus_ = false;

--- a/ui/ozone/platform/wayland/wayland_window_unittest.cc
+++ b/ui/ozone/platform/wayland/wayland_window_unittest.cc
@@ -71,8 +71,13 @@ class WaylandWindowTest : public WaylandTest {
 
   void SetWlArrayWithState(uint32_t state, wl_array* states) {
     uint32_t* s;
-    s = (uint32_t*)wl_array_add(states, sizeof *s);
+    s = static_cast<uint32_t*>(wl_array_add(states, sizeof *s));
     *s = state;
+  }
+
+  void InitializeWlArrayWithActivatedState(wl_array* states) {
+    wl_array_init(states);
+    SetWlArrayWithState(XDG_SURFACE_STATE_ACTIVATED, states);
   }
 
   wl::MockXdgSurface* xdg_surface;
@@ -91,7 +96,8 @@ TEST_P(WaylandWindowTest, SetTitle) {
 TEST_P(WaylandWindowTest, MaximizeAndRestore) {
   uint32_t serial = 12;
   wl_array states;
-  wl_array_init(&states);
+  InitializeWlArrayWithActivatedState(&states);
+
   SetWlArrayWithState(XDG_SURFACE_STATE_MAXIMIZED, &states);
 
   EXPECT_CALL(*GetXdgSurface(), SetMaximized());
@@ -108,13 +114,14 @@ TEST_P(WaylandWindowTest, Minimize) {
   window.Minimize();
 }
 
-TEST_P(WaylandWindowTest, SetFullScreenAndRestore) {
+TEST_P(WaylandWindowTest, SetFullscreenAndRestore) {
   wl_array states;
-  wl_array_init(&states);
+  InitializeWlArrayWithActivatedState(&states);
+
   SetWlArrayWithState(XDG_SURFACE_STATE_FULLSCREEN, &states);
 
-  EXPECT_CALL(*GetXdgSurface(), SetFullScreen());
-  EXPECT_CALL(*GetXdgSurface(), UnsetFullScreen());
+  EXPECT_CALL(*GetXdgSurface(), SetFullscreen());
+  EXPECT_CALL(*GetXdgSurface(), UnsetFullscreen());
   window.ToggleFullscreen();
   SendConfigureEvent(0, 0, 1, &states);
   Sync();
@@ -122,12 +129,12 @@ TEST_P(WaylandWindowTest, SetFullScreenAndRestore) {
   window.Restore();
 }
 
-TEST_P(WaylandWindowTest, SetMaximizedFullScreenAndRestore) {
+TEST_P(WaylandWindowTest, SetMaximizedFullscreenAndRestore) {
   wl_array states;
-  wl_array_init(&states);
+  InitializeWlArrayWithActivatedState(&states);
 
-  EXPECT_CALL(*GetXdgSurface(), SetFullScreen());
-  EXPECT_CALL(*GetXdgSurface(), UnsetFullScreen());
+  EXPECT_CALL(*GetXdgSurface(), SetFullscreen());
+  EXPECT_CALL(*GetXdgSurface(), UnsetFullscreen());
   EXPECT_CALL(*GetXdgSurface(), SetMaximized());
   EXPECT_CALL(*GetXdgSurface(), UnsetMaximized());
 

--- a/ui/ozone/platform/wayland/xdg_surface_wrapper.cc
+++ b/ui/ozone/platform/wayland/xdg_surface_wrapper.cc
@@ -1,0 +1,24 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/ozone/platform/wayland/xdg_surface_wrapper.h"
+
+namespace ui {
+
+bool CheckIfWlArrayHasValue(struct wl_array* wl_array, uint32_t value) {
+  // wl_array_for_each has a bug in upstream. It tries to assign void* to
+  // uint32_t *, which is not allowed in C++. Explicit cast should be
+  // performed. In other words, one just cannot assign void * to other pointer
+  // type implicitly in C++ as in C. We can't modify wayland-util.h, because
+  // it is fetched with gclient sync. Thus, use own loop.
+  uint32_t* data = reinterpret_cast<uint32_t*>(wl_array->data);
+  size_t array_size = wl_array->size / sizeof(uint32_t);
+  for (size_t i = 0; i < array_size; i++) {
+    if (data[i] == value)
+      return true;
+  }
+  return false;
+}
+
+}  // namespace ui

--- a/ui/ozone/platform/wayland/xdg_surface_wrapper.h
+++ b/ui/ozone/platform/wayland/xdg_surface_wrapper.h
@@ -59,6 +59,8 @@ class XDGSurfaceWrapper {
   virtual void SetWindowGeometry(const gfx::Rect& bounds) = 0;
 };
 
+bool CheckIfWlArrayHasValue(struct wl_array* wl_array, uint32_t value);
+
 }  // namespace ui
 
 #endif  // UI_OZONE_PLATFORM_WAYLAND_XDG_SURFACE_WRAPPER_H_

--- a/ui/ozone/platform/wayland/xdg_surface_wrapper_v5.cc
+++ b/ui/ozone/platform/wayland/xdg_surface_wrapper_v5.cc
@@ -129,34 +129,12 @@ void XDGSurfaceWrapperV5::Configure(void* data,
                                     uint32_t serial) {
   XDGSurfaceWrapperV5* surface = static_cast<XDGSurfaceWrapperV5*>(data);
 
-  bool is_maximized = false;
-  bool is_fullscreen = false;
-  bool is_activated = false;
-
-  // wl_array_for_each has a bug in upstream. It tries to assign void* to
-  // uint32_t *, which is not allowed in C++. Explicit cast should be
-  // performed. In other words, one just cannot assign void * to other pointer
-  // type implicitly in C++ as in C. We can't modify wayland-util.h, because
-  // it is fetched with gclient sync. Thus, use own loop.
-  // TODO(msisov, tonikitoo): use wl_array_for_each as soon as
-  // https://bugs.freedesktop.org/show_bug.cgi?id=101618 is resolved.
-  uint32_t* state = reinterpret_cast<uint32_t*>(states->data);
-  size_t array_size = states->size / sizeof(uint32_t);
-  for (size_t i = 0; i < array_size; i++) {
-    switch (state[i]) {
-      case (XDG_SURFACE_STATE_MAXIMIZED):
-        is_maximized = true;
-        break;
-      case (XDG_SURFACE_STATE_FULLSCREEN):
-        is_fullscreen = true;
-        break;
-      case (XDG_SURFACE_STATE_ACTIVATED):
-        is_activated = true;
-        break;
-      default:
-        break;
-    }
-  }
+  bool is_maximized =
+      CheckIfWlArrayHasValue(states, XDG_SURFACE_STATE_MAXIMIZED);
+  bool is_fullscreen =
+      CheckIfWlArrayHasValue(states, XDG_SURFACE_STATE_FULLSCREEN);
+  bool is_activated =
+      CheckIfWlArrayHasValue(states, XDG_SURFACE_STATE_ACTIVATED);
 
   surface->pending_configure_serial_ = serial;
   surface->wayland_window_->HandleSurfaceConfigure(width, height, is_maximized,

--- a/ui/ozone/platform/wayland/xdg_surface_wrapper_v6.cc
+++ b/ui/ozone/platform/wayland/xdg_surface_wrapper_v6.cc
@@ -184,34 +184,12 @@ void XDGSurfaceWrapperV6::ConfigureTopLevel(
     struct wl_array* states) {
   XDGSurfaceWrapperV6* surface = static_cast<XDGSurfaceWrapperV6*>(data);
 
-  bool is_maximized = false;
-  bool is_fullscreen = false;
-  bool is_activated = false;
-
-  // wl_array_for_each has a bug in upstream. It tries to assign void* to
-  // uint32_t *, which is not allowed in C++. Explicit cast should be
-  // performed. In other words, one just cannot assign void * to other pointer
-  // type implicitly in C++ as in C. We can't modify wayland-util.h, because
-  // it is fetched with gclient sync. Thus, use own loop.
-  // TODO(msisov, tonikitoo): use wl_array_for_each as soon as
-  // https://bugs.freedesktop.org/show_bug.cgi?id=101618 is resolved.
-  uint32_t* state = reinterpret_cast<uint32_t*>(states->data);
-  size_t array_size = states->size / sizeof(uint32_t);
-  for (size_t i = 0; i < array_size; i++) {
-    switch (state[i]) {
-      case (ZXDG_TOPLEVEL_V6_STATE_MAXIMIZED):
-        is_maximized = true;
-        break;
-      case (ZXDG_TOPLEVEL_V6_STATE_FULLSCREEN):
-        is_fullscreen = true;
-        break;
-      case (ZXDG_TOPLEVEL_V6_STATE_ACTIVATED):
-        is_activated = true;
-        break;
-      default:
-        break;
-    }
-  }
+  bool is_maximized =
+      CheckIfWlArrayHasValue(states, ZXDG_TOPLEVEL_V6_STATE_MAXIMIZED);
+  bool is_fullscreen =
+      CheckIfWlArrayHasValue(states, ZXDG_TOPLEVEL_V6_STATE_FULLSCREEN);
+  bool is_activated =
+      CheckIfWlArrayHasValue(states, ZXDG_TOPLEVEL_V6_STATE_ACTIVATED);
 
   surface->wayland_window_->HandleSurfaceConfigure(width, height, is_maximized,
                                                    is_fullscreen, is_activated);

--- a/ui/platform_window/x11/x11_window_base.cc
+++ b/ui/platform_window/x11/x11_window_base.cc
@@ -344,28 +344,28 @@ void X11WindowBase::ReleaseCapture() {
 }
 
 void X11WindowBase::ToggleFullscreen() {
-  SetWMSpecState(!is_fullscreen_, gfx::GetAtom("_NET_WM_STATE_FULLSCREEN"),
+  DCHECK(!IsMinimized());
+  SetWMSpecState(!IsFullScreen(), gfx::GetAtom("_NET_WM_STATE_FULLSCREEN"),
                  x11::None);
-  is_fullscreen_ = !is_fullscreen_;
 }
 
 void X11WindowBase::Maximize() {
-  // Unfullscreen the window if it is fullscreen.
+  // X11 may end up in a situation, when the window is maximized and in a
+  // fullscreen mode at the same time. If that happens, the X11WindowBase has
+  // two states at the same time. Thus, when the window is maximized again after
+  // fullscreen, DCHECK ensures there is maximized state. Otherwise, just check
+  // if the state is not maximized.
+  DCHECK(IsFullScreen() || !IsMaximized());
+
   if (IsFullScreen())
     ToggleFullscreen();
-
-  // When we are in the process of requesting to maximize a window, we can
-  // accurately keep track of our restored bounds instead of relying on the
-  // heuristics that are in the PropertyNotify and ConfigureNotify handlers.
-  restored_bounds_in_pixels_ = bounds_;
 
   SetWMSpecState(true, gfx::GetAtom("_NET_WM_STATE_MAXIMIZED_VERT"),
                  gfx::GetAtom("_NET_WM_STATE_MAXIMIZED_HORZ"));
 }
 
 void X11WindowBase::Minimize() {
-  if (IsMinimized())
-    return;
+  DCHECK(!IsMinimized());
   XIconifyWindow(xdisplay_, xwindow_, 0);
 }
 
@@ -374,7 +374,6 @@ void X11WindowBase::Restore() {
     ToggleFullscreen();
 
   if (IsMaximized()) {
-    restored_bounds_in_pixels_ = bounds_;
     SetWMSpecState(false, gfx::GetAtom("_NET_WM_STATE_MAXIMIZED_VERT"),
                    gfx::GetAtom("_NET_WM_STATE_MAXIMIZED_HORZ"));
   }
@@ -538,7 +537,6 @@ void X11WindowBase::OnWMStateUpdated() {
   ui::GetAtomArrayProperty(xwindow_, "_NET_WM_STATE", &atom_list);
 
   bool was_minimized = IsMinimized();
-  bool was_maximized = IsMaximized();
 
   window_properties_.clear();
   std::copy(atom_list.begin(), atom_list.end(),
@@ -549,21 +547,14 @@ void X11WindowBase::OnWMStateUpdated() {
       ui::PlatformWindowState::PLATFORM_WINDOW_STATE_NORMAL;
   if (IsMaximized())
     state = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MAXIMIZED;
+  else if (IsFullScreen())
+    state = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_FULLSCREEN;
   else if (IsMinimized())
     state = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MINIMIZED;
 
-  // |restored_bounds_in_pixels_| can tell if the maximize/restore has been
-  // triggered by client or not. Typically, if it was the client who triggered
-  // that, |restored_bounds_in_pixels_| had values stored. Thus, we can be
-  // sure the client is not flooded with window states when the sources of a
-  // change has been the client itself.
-  if ((restored_bounds_in_pixels_.IsEmpty() &&
-       IsMaximized() != was_maximized) ||
-      IsMinimized() != was_minimized) {
+  // Do not flood the WindowServer unless the previous state was minimized.
+  if (was_minimized)
     delegate_->OnWindowStateChanged(state);
-  }
-
-  restored_bounds_in_pixels_ = gfx::Rect();
 }
 
 void X11WindowBase::BeforeActivationStateChanged() {
@@ -729,7 +720,7 @@ bool X11WindowBase::IsMaximized() const {
 }
 
 bool X11WindowBase::IsFullScreen() const {
-  return is_fullscreen_;
+  return (HasWMSpecProperty("_NET_WM_STATE_FULLSCREEN"));
 }
 
 }  // namespace ui

--- a/ui/platform_window/x11/x11_window_base.h
+++ b/ui/platform_window/x11/x11_window_base.h
@@ -148,9 +148,6 @@ class X11_WINDOW_EXPORT X11WindowBase : public PlatformWindow {
   // The bounds of |xwindow_|.
   gfx::Rect bounds_;
 
-  // The bounds of our window before we were maximized.
-  gfx::Rect restored_bounds_in_pixels_;
-
   // The point on xroot_window_, where a ButtonPress event occurred.
   // Used for interactive window drag/resize.
   gfx::Point xroot_window_event_location_;
@@ -159,7 +156,6 @@ class X11_WINDOW_EXPORT X11WindowBase : public PlatformWindow {
   std::set<::Atom> window_properties_;
 
   bool window_mapped_ = false;
-  bool is_fullscreen_ = false;
 
   DISALLOW_COPY_AND_ASSIGN(X11WindowBase);
 };


### PR DESCRIPTION
This is an effort to refactor "window states" patches and have them more logical and easier to follow.
What is more, I've addressed upstream comments in these patches as well.

One patch has been reverted: some of the changes were refactored, and some changes were merged into right commits