### PR TITLE
[TEMP] Revert "mus: Do not host viz by default."

### DIFF
--- a/chrome/app/chrome_main.cc
+++ b/chrome/app/chrome_main.cc
@@ -114,6 +114,9 @@ int ChromeMain(int argc, const char** argv) {
   if (command_line->HasSwitch(switches::kMus)) {
     params.create_discardable_memory = true;
     params.env_mode = aura::Env::Mode::MUS;
+    // TODO(786453): Remove when mus no longer needs to host viz.
+    base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
+        switches::kMus, switches::kMusHostVizValue);
   }
   if (service_manager::ServiceManagerIsRemote() ||
       command_line->HasSwitch(switches::kMash)) {

--- a/content/browser/renderer_host/render_widget_host_view_child_frame_browsertest.cc
+++ b/content/browser/renderer_host/render_widget_host_view_child_frame_browsertest.cc
@@ -23,7 +23,6 @@
 #include "content/test/test_content_browser_client.h"
 #include "net/dns/mock_host_resolver.h"
 #include "net/test/embedded_test_server/embedded_test_server.h"
-#include "ui/base/ui_base_switches_util.h"
 #include "ui/gfx/geometry/size.h"
 
 namespace content {
@@ -156,9 +155,8 @@ IN_PROC_BROWSER_TEST_F(RenderWidgetHostViewChildFrameTest,
 // Tests that while in mus, the child frame receives an updated FrameSinkId
 // representing the frame sink used by the RenderFrameProxy.
 IN_PROC_BROWSER_TEST_F(RenderWidgetHostViewChildFrameTest, ChildFrameSinkId) {
-  // Only when mus hosts viz do we expect a RenderFrameProxy to provide the
-  // FrameSinkId.
-  if (!switches::IsMusHostingViz())
+  // Only in mus do we expect a RenderFrameProxy to provide the FrameSinkId.
+  if (!IsUsingMus())
     return;
 
   GURL main_url(embedded_test_server()->GetURL("/site_per_process_main.html"));

--- a/content/test/content_test_launcher.cc
+++ b/content/test/content_test_launcher.cc
@@ -52,6 +52,12 @@ class ContentBrowserTestSuite : public ContentTestSuiteBase {
  public:
   ContentBrowserTestSuite(int argc, char** argv)
       : ContentTestSuiteBase(argc, argv) {
+#if BUILDFLAG(ENABLE_MUS)
+    // TODO(786453): This should be removed once mus can run without viz.
+    auto* cmd = base::CommandLine::ForCurrentProcess();
+    if (cmd->HasSwitch(switches::kMus))
+      cmd->AppendSwitchASCII(switches::kMus, switches::kMusHostVizValue);
+#endif
   }
   ~ContentBrowserTestSuite() override {}
 

--- a/testing/buildbot/filters/mus.content_browsertests.filter
+++ b/testing/buildbot/filters/mus.content_browsertests.filter
@@ -108,7 +108,6 @@
 -SnapshotBrowserTest.AsyncMultiWindowTest
 -SnapshotBrowserTest.SingleWindowTest
 -SnapshotBrowserTest.SyncMultiWindowTest
--WebContentsViewAuraTest.ReplaceStateReloadPushState
 -WebRtcCaptureFromElementBrowserTest.CaptureFromCanvas2DHandlesContextLoss
 -WebRtcCaptureFromElementBrowserTest.CaptureFromOpaqueCanvas2DHandlesContextLoss
 


### PR DESCRIPTION
This reverts commit 418217886ac8dd904b0ba1e53ed42d34d6ae8cff.

Host viz by default before we get a solution, who should host
viz in external window mode if not mus.

Issue: #337