### PR TITLE
fixup! Implement filter to run browser tests with Linux/mus build.

### DIFF
--- a/testing/buildbot/filters/mus.browser_tests.external_window_mode.filter
+++ b/testing/buildbot/filters/mus.browser_tests.external_window_mode.filter
@@ -4,6 +4,8 @@
 -PluginPowerSaverBrowserTest.PosterTests 
 -PluginPowerSaverBrowserTest.SmallerThanPlayIcon 
 -PluginPowerSaverBrowserTest.SmallCrossOrigin 
+-BrowserTabRestoreTest.DelegateRestoreTabDisposition
+-StartupBrowserCreatorTest.ProfilesLaunchedAfterCrash
 
 # These might require to setup suid sandbox.
 -SandboxStatusUITest.testBPFSandboxEnabled 
@@ -146,4 +148,4 @@
 -SyncAwareCounterTest.PasswordCounter
 -SmartSessionRestoreTest.PRE_CorrectLoadingOrder
 -StartupHelperBrowserTest.ValidateCrx
--PrerenderBrowserTest.OpenTaskManagerBeforePrerender	
+-PrerenderBrowserTest.OpenTaskManagerBeforePrerender


### PR DESCRIPTION
Exclude failing tests from the buildbot run. These fails
both on mus and on non-mus builds.