### PR TITLE
Revert KeyboardEvDev and reworked our keyboard modifiers support.

### DIFF
--- a/ui/events/event_modifiers.cc
+++ b/ui/events/event_modifiers.cc
@@ -97,4 +97,36 @@ int EventModifiers::GetEventFlagFromModifier(unsigned int modifier) {
   return kEventFlagFromModifiers[modifier];
 }
 
+// static
+int EventModifiers::GetModifierFromEventFlag(int flag) {
+  switch (flag) {
+    case EF_SHIFT_DOWN:
+      return MODIFIER_SHIFT;
+    case EF_CONTROL_DOWN:
+      return MODIFIER_CONTROL;
+    case EF_ALT_DOWN:
+      return MODIFIER_ALT;
+    case EF_COMMAND_DOWN:
+      return MODIFIER_COMMAND;
+    case EF_ALTGR_DOWN:
+      return MODIFIER_ALTGR;
+    case EF_MOD3_DOWN:
+      return MODIFIER_MOD3;
+    case EF_CAPS_LOCK_ON:
+      return MODIFIER_CAPS_LOCK;
+    case EF_LEFT_MOUSE_BUTTON:
+      return MODIFIER_LEFT_MOUSE_BUTTON;
+    case EF_MIDDLE_MOUSE_BUTTON:
+      return MODIFIER_MIDDLE_MOUSE_BUTTON;
+    case EF_RIGHT_MOUSE_BUTTON:
+      return MODIFIER_RIGHT_MOUSE_BUTTON;
+    case EF_BACK_MOUSE_BUTTON:
+      return MODIFIER_BACK_MOUSE_BUTTON;
+    case EF_FORWARD_MOUSE_BUTTON:
+      return MODIFIER_FORWARD_MOUSE_BUTTON;
+    default:
+      return MODIFIER_NONE;
+  }
+}
+
 }  // namespace ui

--- a/ui/events/event_modifiers.h
+++ b/ui/events/event_modifiers.h
@@ -65,6 +65,9 @@ class EVENTS_EXPORT EventModifiers {
   // Return the mask for the specified modifier.
   static int GetEventFlagFromModifier(unsigned int modifier);
 
+  // Return the modifier for the specified mask.
+  static int GetModifierFromEventFlag(int flag);
+
  private:
   // Count of keys pressed for each modifier.
   int modifiers_down_[MODIFIER_NUM_MODIFIERS];

--- a/ui/events/ozone/evdev/keyboard_evdev.cc
+++ b/ui/events/ozone/evdev/keyboard_evdev.cc
@@ -24,37 +24,6 @@ namespace {
 const int kRepeatDelayMs = 500;
 const int kRepeatIntervalMs = 50;
 
-int EventFlagToEvdevModifier(int flag) {
-  switch (flag) {
-    case EF_SHIFT_DOWN:
-      return MODIFIER_SHIFT;
-    case EF_CONTROL_DOWN:
-      return MODIFIER_CONTROL;
-    case EF_ALT_DOWN:
-      return MODIFIER_ALT;
-    case EF_COMMAND_DOWN:
-      return MODIFIER_COMMAND;
-    case EF_ALTGR_DOWN:
-      return MODIFIER_ALTGR;
-    case EF_MOD3_DOWN:
-      return MODIFIER_MOD3;
-    case EF_CAPS_LOCK_ON:
-      return MODIFIER_CAPS_LOCK;
-    case EF_LEFT_MOUSE_BUTTON:
-      return MODIFIER_LEFT_MOUSE_BUTTON;
-    case EF_MIDDLE_MOUSE_BUTTON:
-      return MODIFIER_MIDDLE_MOUSE_BUTTON;
-    case EF_RIGHT_MOUSE_BUTTON:
-      return MODIFIER_RIGHT_MOUSE_BUTTON;
-    case EF_BACK_MOUSE_BUTTON:
-      return MODIFIER_BACK_MOUSE_BUTTON;
-    case EF_FORWARD_MOUSE_BUTTON:
-      return MODIFIER_FORWARD_MOUSE_BUTTON;
-    default:
-      return MODIFIER_NONE;
-  }
-}
-
 }  // namespace
 
 KeyboardEvdev::KeyboardEvdev(EventModifiers* modifiers,
@@ -127,7 +96,7 @@ void KeyboardEvdev::UpdateModifier(int modifier_flag, bool down) {
   if (modifier_flag == EF_NONE)
     return;
 
-  int modifier = EventFlagToEvdevModifier(modifier_flag);
+  int modifier = EventModifiers::GetModifierFromEventFlag(modifier_flag);
   if (modifier == MODIFIER_NONE)
     return;
 

--- a/ui/events/ozone/evdev/keyboard_evdev.cc
+++ b/ui/events/ozone/evdev/keyboard_evdev.cc
@@ -217,9 +217,7 @@ void KeyboardEvdev::OnRepeatCommit(unsigned int sequence) {
   DispatchKey(repeat_key_, true /* down */, true /* repeat */,
               EventTimeForNow(), repeat_device_id_);
 
-  // Do not schedule auto repeat if it has been turned out.
-  if (IsAutoRepeatEnabled())
-    ScheduleKeyRepeat(repeat_interval_);
+  ScheduleKeyRepeat(repeat_interval_);
 }
 
 void KeyboardEvdev::DispatchKey(unsigned int key,

--- a/ui/events/ozone/evdev/keyboard_evdev.h
+++ b/ui/events/ozone/evdev/keyboard_evdev.h
@@ -61,8 +61,6 @@ class EVENTS_OZONE_EVDEV_EXPORT KeyboardEvdev {
   // Handle keyboard layout changes.
   bool SetCurrentLayoutByName(const std::string& layout_name);
 
-  void StopKeyRepeat();
-
  private:
   void UpdateModifier(int modifier_flag, bool down);
   void RefreshModifiers();
@@ -72,6 +70,7 @@ class EVENTS_OZONE_EVDEV_EXPORT KeyboardEvdev {
                        bool suppress_auto_repeat,
                        int device_id);
   void StartKeyRepeat(unsigned int key, int device_id);
+  void StopKeyRepeat();
   void ScheduleKeyRepeat(const base::TimeDelta& delay);
   void OnRepeatTimeout(unsigned int sequence);
   void OnRepeatCommit(unsigned int sequence);

--- a/ui/ozone/platform/wayland/BUILD.gn
+++ b/ui/ozone/platform/wayland/BUILD.gn
@@ -68,7 +68,6 @@ source_set("wayland") {
     "//ui/display/manager",
     "//ui/events",
     "//ui/events:dom_keycode_converter",
-    "//ui/events/ozone:events_ozone_evdev",
     "//ui/events/ozone:events_ozone_layout",
     "//ui/events/platform",
     "//ui/gfx",

--- a/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+++ b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
@@ -88,10 +88,6 @@ class OzonePlatformWayland : public OzonePlatform {
   }
 
   void InitializeUI(const InitParams& args) override {
-    connection_.reset(new WaylandConnection);
-    if (!connection_->Initialize())
-      LOG(FATAL) << "Failed to initialize Wayland platform";
-
 #if BUILDFLAG(USE_XKBCOMMON)
     KeyboardLayoutEngineManager::SetKeyboardLayoutEngine(
         std::make_unique<WaylandXkbKeyboardLayoutEngine>(
@@ -100,6 +96,9 @@ class OzonePlatformWayland : public OzonePlatform {
     KeyboardLayoutEngineManager::SetKeyboardLayoutEngine(
         std::make_unique<StubKeyboardLayoutEngine>());
 #endif
+    connection_.reset(new WaylandConnection);
+    if (!connection_->Initialize())
+      LOG(FATAL) << "Failed to initialize Wayland platform";
 
     cursor_factory_.reset(new BitmapCursorFactoryOzone);
     overlay_manager_.reset(new StubOverlayManager);

--- a/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+++ b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
@@ -88,6 +88,10 @@ class OzonePlatformWayland : public OzonePlatform {
   }
 
   void InitializeUI(const InitParams& args) override {
+    connection_.reset(new WaylandConnection);
+    if (!connection_->Initialize())
+      LOG(FATAL) << "Failed to initialize Wayland platform";
+
 #if BUILDFLAG(USE_XKBCOMMON)
     KeyboardLayoutEngineManager::SetKeyboardLayoutEngine(
         std::make_unique<WaylandXkbKeyboardLayoutEngine>(
@@ -96,9 +100,6 @@ class OzonePlatformWayland : public OzonePlatform {
     KeyboardLayoutEngineManager::SetKeyboardLayoutEngine(
         std::make_unique<StubKeyboardLayoutEngine>());
 #endif
-    connection_.reset(new WaylandConnection);
-    if (!connection_->Initialize())
-      LOG(FATAL) << "Failed to initialize Wayland platform";
 
     cursor_factory_.reset(new BitmapCursorFactoryOzone);
     overlay_manager_.reset(new StubOverlayManager);

--- a/ui/ozone/platform/wayland/wayland_keyboard.cc
+++ b/ui/ozone/platform/wayland/wayland_keyboard.cc
@@ -38,6 +38,12 @@ WaylandKeyboard::WaylandKeyboard(wl_keyboard* keyboard,
       &WaylandKeyboard::Modifiers, &WaylandKeyboard::RepeatInfo,
   };
 
+#if BUILDFLAG(USE_XKBCOMMON)
+  auto* engine = static_cast<WaylandXkbKeyboardLayoutEngine*>(
+      KeyboardLayoutEngineManager::GetKeyboardLayoutEngine());
+  engine->set_event_modifiers(&event_modifiers_);
+#endif
+
   wl_keyboard_add_listener(obj_.get(), &listener, this);
 
   // TODO(tonikitoo): Default auto-repeat to ON here?
@@ -97,7 +103,7 @@ void WaylandKeyboard::Key(void* data,
   if (dom_code == ui::DomCode::NONE)
     return;
 
-  uint8_t flags = keyboard->modifiers_;
+  uint8_t flags = keyboard->event_modifiers_.GetModifierFlags();
   DomKey dom_key;
   KeyboardCode key_code;
   if (!KeyboardLayoutEngineManager::GetKeyboardLayoutEngine()->Lookup(
@@ -108,7 +114,7 @@ void WaylandKeyboard::Key(void* data,
   bool down = state == WL_KEYBOARD_KEY_STATE_PRESSED;
   ui::KeyEvent event(
       down ? ET_KEY_PRESSED : ET_KEY_RELEASED, key_code, dom_code,
-      keyboard->modifiers_, dom_key,
+      keyboard->event_modifiers_.GetModifierFlags(), dom_key,
       base::TimeTicks() + base::TimeDelta::FromMilliseconds(time));
   event.set_source_device_id(keyboard->obj_.id());
   keyboard->callback_.Run(&event);
@@ -122,13 +128,9 @@ void WaylandKeyboard::Modifiers(void* data,
                                 uint32_t mods_locked,
                                 uint32_t group) {
 #if BUILDFLAG(USE_XKBCOMMON)
-  WaylandKeyboard* keyboard = static_cast<WaylandKeyboard*>(data);
   auto* engine = static_cast<WaylandXkbKeyboardLayoutEngine*>(
       KeyboardLayoutEngineManager::GetKeyboardLayoutEngine());
-
-  keyboard->modifiers_ =
-      engine->UpdateModifiers(mods_depressed, mods_latched, mods_locked, group);
-
+  engine->UpdateModifiers(mods_depressed, mods_latched, mods_locked, group);
 #endif
 }
 

--- a/ui/ozone/platform/wayland/wayland_keyboard.cc
+++ b/ui/ozone/platform/wayland/wayland_keyboard.cc
@@ -14,6 +14,7 @@
 #include "ui/events/keycodes/dom/keycode_converter.h"
 #include "ui/events/ozone/layout/keyboard_layout_engine.h"
 #include "ui/events/ozone/layout/keyboard_layout_engine_manager.h"
+#include "ui/events/ozone/layout/layout_util.h"
 #include "ui/ozone/platform/wayland/wayland_connection.h"
 #include "ui/ozone/platform/wayland/wayland_window.h"
 
@@ -110,8 +111,12 @@ void WaylandKeyboard::Key(void* data,
           dom_code, flags, &dom_key, &key_code))
     return;
 
-  // TODO(tonikitoo): handle repeat here.
   bool down = state == WL_KEYBOARD_KEY_STATE_PRESSED;
+
+  // TODO(tonikitoo,msisov): only the two lines below if not handling repeat.
+  int flag = ModifierDomKeyToEventFlag(dom_key);
+  keyboard->UpdateModifier(flag, down);
+
   ui::KeyEvent event(
       down ? ET_KEY_PRESSED : ET_KEY_RELEASED, key_code, dom_code,
       keyboard->event_modifiers_.GetModifierFlags(), dom_key,
@@ -140,6 +145,18 @@ void WaylandKeyboard::RepeatInfo(void* data,
                                  int32_t delay) {
   // TODO(tonikitoo): Implement proper repeat handling.
   NOTIMPLEMENTED();
+}
+
+void WaylandKeyboard::UpdateModifier(int modifier_flag, bool down) {
+  if (modifier_flag == EF_NONE)
+    return;
+
+  int modifier = EventModifiers::GetModifierFromEventFlag(modifier_flag);
+  if (modifier == MODIFIER_NONE)
+    return;
+
+  // TODO(tonikitoo,msisov) handle capslock here.
+  event_modifiers_.UpdateModifier(modifier, down);
 }
 
 }  // namespace ui

--- a/ui/ozone/platform/wayland/wayland_keyboard.cc
+++ b/ui/ozone/platform/wayland/wayland_keyboard.cc
@@ -81,10 +81,7 @@ void WaylandKeyboard::Leave(void* data,
   if (surface)
     WaylandWindow::FromSurface(surface)->set_keyboard_focus(false);
 
-  // Stop auto repeat once keyboard looses focus. Otherwise, KeyboardEvdev
-  // may continue auto repeating despite lost focus.
   WaylandKeyboard* keyboard = static_cast<WaylandKeyboard*>(data);
-  keyboard->evdev_keyboard_.StopKeyRepeat();
 
   // Reset all modifiers once focus is lost. Otherwise, the modifiers may be
   // left with old flags, which are no longer valid.

--- a/ui/ozone/platform/wayland/wayland_keyboard.cc
+++ b/ui/ozone/platform/wayland/wayland_keyboard.cc
@@ -9,7 +9,6 @@
 
 #include "base/files/scoped_file.h"
 #include "ui/base/ui_features.h"
-#include "ui/events/base_event_utils.h"
 #include "ui/events/event.h"
 #include "ui/events/keycodes/dom/dom_code.h"
 #include "ui/events/keycodes/dom/keycode_converter.h"
@@ -24,13 +23,15 @@
 
 namespace ui {
 
+namespace {
+
+const int kXkbKeycodeOffset = 8;
+
+}  // namespace
+
 WaylandKeyboard::WaylandKeyboard(wl_keyboard* keyboard,
                                  const EventDispatchCallback& callback)
-    : obj_(keyboard),
-      callback_(callback),
-      evdev_keyboard_(&modifiers_,
-                      KeyboardLayoutEngineManager::GetKeyboardLayoutEngine(),
-                      callback_) {
+    : obj_(keyboard), callback_(callback) {
   static const wl_keyboard_listener listener = {
       &WaylandKeyboard::Keymap,    &WaylandKeyboard::Enter,
       &WaylandKeyboard::Leave,     &WaylandKeyboard::Key,
@@ -80,12 +81,6 @@ void WaylandKeyboard::Leave(void* data,
                             wl_surface* surface) {
   if (surface)
     WaylandWindow::FromSurface(surface)->set_keyboard_focus(false);
-
-  WaylandKeyboard* keyboard = static_cast<WaylandKeyboard*>(data);
-
-  // Reset all modifiers once focus is lost. Otherwise, the modifiers may be
-  // left with old flags, which are no longer valid.
-  keyboard->modifiers_.ResetKeyboardModifiers();
 }
 
 void WaylandKeyboard::Key(void* data,
@@ -97,9 +92,26 @@ void WaylandKeyboard::Key(void* data,
   WaylandKeyboard* keyboard = static_cast<WaylandKeyboard*>(data);
   keyboard->connection_->set_serial(serial);
 
-  keyboard->evdev_keyboard_.OnKeyChange(
-      key, state == WL_KEYBOARD_KEY_STATE_PRESSED, false, EventTimeForNow(),
-      keyboard->obj_.id());
+  DomCode dom_code =
+      KeycodeConverter::NativeKeycodeToDomCode(key + kXkbKeycodeOffset);
+  if (dom_code == ui::DomCode::NONE)
+    return;
+
+  uint8_t flags = keyboard->modifiers_;
+  DomKey dom_key;
+  KeyboardCode key_code;
+  if (!KeyboardLayoutEngineManager::GetKeyboardLayoutEngine()->Lookup(
+          dom_code, flags, &dom_key, &key_code))
+    return;
+
+  // TODO(tonikitoo): handle repeat here.
+  bool down = state == WL_KEYBOARD_KEY_STATE_PRESSED;
+  ui::KeyEvent event(
+      down ? ET_KEY_PRESSED : ET_KEY_RELEASED, key_code, dom_code,
+      keyboard->modifiers_, dom_key,
+      base::TimeTicks() + base::TimeDelta::FromMilliseconds(time));
+  event.set_source_device_id(keyboard->obj_.id());
+  keyboard->callback_.Run(&event);
 }
 
 void WaylandKeyboard::Modifiers(void* data,
@@ -109,20 +121,23 @@ void WaylandKeyboard::Modifiers(void* data,
                                 uint32_t mods_latched,
                                 uint32_t mods_locked,
                                 uint32_t group) {
-  // KeyboardEvDev handles modifiers.
+#if BUILDFLAG(USE_XKBCOMMON)
+  WaylandKeyboard* keyboard = static_cast<WaylandKeyboard*>(data);
+  auto* engine = static_cast<WaylandXkbKeyboardLayoutEngine*>(
+      KeyboardLayoutEngineManager::GetKeyboardLayoutEngine());
+
+  keyboard->modifiers_ =
+      engine->UpdateModifiers(mods_depressed, mods_latched, mods_locked, group);
+
+#endif
 }
 
 void WaylandKeyboard::RepeatInfo(void* data,
                                  wl_keyboard* obj,
                                  int32_t rate,
                                  int32_t delay) {
-  WaylandKeyboard* keyboard = static_cast<WaylandKeyboard*>(data);
-  keyboard->evdev_keyboard_.SetAutoRepeatRate(
-      base::TimeDelta::FromMilliseconds(delay),
-      base::TimeDelta::FromMilliseconds(rate));
-
-  // Keyboard rate less than 0 means, wayland wants to disable autorepeat.
-  keyboard->evdev_keyboard_.SetAutoRepeatEnabled(rate > 0 ? true : false);
+  // TODO(tonikitoo): Implement proper repeat handling.
+  NOTIMPLEMENTED();
 }
 
 }  // namespace ui

--- a/ui/ozone/platform/wayland/wayland_keyboard.h
+++ b/ui/ozone/platform/wayland/wayland_keyboard.h
@@ -5,9 +5,7 @@
 #ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_KEYBOARD_H_
 #define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_KEYBOARD_H_
 
-#include "ui/events/event_modifiers.h"
 #include "ui/events/ozone/evdev/event_dispatch_callback.h"
-#include "ui/events/ozone/evdev/keyboard_evdev.h"
 #include "ui/ozone/platform/wayland/wayland_object.h"
 
 namespace ui {
@@ -23,7 +21,7 @@ class WaylandKeyboard {
     connection_ = connection;
   }
 
-  int modifiers() { return modifiers_.GetModifierFlags(); }
+  int modifiers() { return modifiers_; }
 
  private:
   // wl_keyboard_listener
@@ -62,9 +60,7 @@ class WaylandKeyboard {
   WaylandConnection* connection_ = nullptr;
   wl::Object<wl_keyboard> obj_;
   EventDispatchCallback callback_;
-
-  EventModifiers modifiers_;
-  KeyboardEvdev evdev_keyboard_;
+  int modifiers_ = 0;
 };
 
 }  // namespace ui

--- a/ui/ozone/platform/wayland/wayland_keyboard.h
+++ b/ui/ozone/platform/wayland/wayland_keyboard.h
@@ -58,6 +58,8 @@ class WaylandKeyboard {
                          int32_t rate,
                          int32_t delay);
 
+  void UpdateModifier(int modifier_flag, bool down);
+
   WaylandConnection* connection_ = nullptr;
   wl::Object<wl_keyboard> obj_;
   EventDispatchCallback callback_;

--- a/ui/ozone/platform/wayland/wayland_keyboard.h
+++ b/ui/ozone/platform/wayland/wayland_keyboard.h
@@ -5,6 +5,7 @@
 #ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_KEYBOARD_H_
 #define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_KEYBOARD_H_
 
+#include "ui/events/event_modifiers.h"
 #include "ui/events/ozone/evdev/event_dispatch_callback.h"
 #include "ui/ozone/platform/wayland/wayland_object.h"
 
@@ -21,7 +22,7 @@ class WaylandKeyboard {
     connection_ = connection;
   }
 
-  int modifiers() { return modifiers_; }
+  int modifiers() { return event_modifiers_.GetModifierFlags(); }
 
  private:
   // wl_keyboard_listener
@@ -60,7 +61,7 @@ class WaylandKeyboard {
   WaylandConnection* connection_ = nullptr;
   wl::Object<wl_keyboard> obj_;
   EventDispatchCallback callback_;
-  int modifiers_ = 0;
+  EventModifiers event_modifiers_;
 };
 
 }  // namespace ui

--- a/ui/ozone/platform/wayland/wayland_xkb_keyboard_layout_engine.cc
+++ b/ui/ozone/platform/wayland/wayland_xkb_keyboard_layout_engine.cc
@@ -5,6 +5,7 @@
 #include "ui/ozone/platform/wayland/wayland_xkb_keyboard_layout_engine.h"
 
 #include "ui/events/event_constants.h"
+#include "ui/events/event_modifiers.h"
 
 namespace ui {
 
@@ -21,27 +22,28 @@ void WaylandXkbKeyboardLayoutEngine::SetKeymap(xkb_keymap* keymap) {
   xkb_mod_indexes_.shift = xkb_keymap_mod_get_index(keymap, XKB_MOD_NAME_SHIFT);
 }
 
-int WaylandXkbKeyboardLayoutEngine::UpdateModifiers(uint32_t depressed_mods,
-                                                    uint32_t latched_mods,
-                                                    uint32_t locked_mods,
-                                                    uint32_t group) {
+void WaylandXkbKeyboardLayoutEngine::UpdateModifiers(uint32_t depressed_mods,
+                                                     uint32_t latched_mods,
+                                                     uint32_t locked_mods,
+                                                     uint32_t group) {
   xkb_state_update_mask(xkb_state_.get(), depressed_mods, latched_mods,
                         locked_mods, 0, 0, group);
 
-  int modifiers = 0;
+  event_modifiers_->ResetKeyboardModifiers();
+
   auto component = static_cast<xkb_state_component>(XKB_STATE_MODS_DEPRESSED |
                                                     XKB_STATE_MODS_LATCHED);
   if (xkb_state_mod_index_is_active(xkb_state_.get(), xkb_mod_indexes_.control,
                                     component))
-    modifiers |= EF_CONTROL_DOWN;
+    event_modifiers_->UpdateModifier(MODIFIER_CONTROL, true);
+
   if (xkb_state_mod_index_is_active(xkb_state_.get(), xkb_mod_indexes_.alt,
                                     component))
-    modifiers |= EF_ALT_DOWN;
+    event_modifiers_->UpdateModifier(MODIFIER_ALT, true);
+
   if (xkb_state_mod_index_is_active(xkb_state_.get(), xkb_mod_indexes_.shift,
                                     component))
-    modifiers |= EF_SHIFT_DOWN;
-
-  return modifiers;
+    event_modifiers_->UpdateModifier(MODIFIER_SHIFT, true);
 }
 
 }  // namespace ui

--- a/ui/ozone/platform/wayland/wayland_xkb_keyboard_layout_engine.h
+++ b/ui/ozone/platform/wayland/wayland_xkb_keyboard_layout_engine.h
@@ -11,16 +11,22 @@
 
 namespace ui {
 
+class EventModifiers;
+
 class WaylandXkbKeyboardLayoutEngine : public XkbKeyboardLayoutEngine {
  public:
   WaylandXkbKeyboardLayoutEngine(const XkbKeyCodeConverter& converter);
 
   // Used to sync up client side 'xkb_state' instance with modifiers status
   // update from the compositor.
-  int UpdateModifiers(uint32_t depressed_mods,
-                      uint32_t latched_mods,
-                      uint32_t locked_mods,
-                      uint32_t group);
+  void UpdateModifiers(uint32_t depressed_mods,
+                       uint32_t latched_mods,
+                       uint32_t locked_mods,
+                       uint32_t group);
+
+  void set_event_modifiers(EventModifiers* event_modifiers) {
+    event_modifiers_ = event_modifiers;
+  }
 
  private:
   void SetKeymap(xkb_keymap* keymap) override;
@@ -31,6 +37,8 @@ class WaylandXkbKeyboardLayoutEngine : public XkbKeyboardLayoutEngine {
     xkb_mod_index_t alt = 0;
     xkb_mod_index_t shift = 0;
   } xkb_mod_indexes_;
+
+  EventModifiers* event_modifiers_ = nullptr;  // Owned by WaylandKeyboard.
 };
 
 }  // namespace ui


### PR DESCRIPTION
This PR reverts the use of KeyboardEvDev from WaylandKeyboard, as per the discussion with spang@
in https://crrev.com/c/822871. Also reverts the follow up PR #334, which is now needed for now.

Instead, it switches WaylandKeyboard to using EventsModifiers class, rather than a raw integer, and 
also fixes the issue of KeyboardEvents being dispatched without the proper modifier flags, in case of a
modifier key (e.g. Alt) being pressed by itself.