### PR TITLE
[ozone/wayland] Add capslock support

### DIFF
--- a/ui/ozone/platform/wayland/wayland_keyboard.cc
+++ b/ui/ozone/platform/wayland/wayland_keyboard.cc
@@ -155,8 +155,17 @@ void WaylandKeyboard::UpdateModifier(int modifier_flag, bool down) {
   if (modifier == MODIFIER_NONE)
     return;
 
-  // TODO(tonikitoo,msisov) handle capslock here.
-  event_modifiers_.UpdateModifier(modifier, down);
+  // This mimics KeyboardEvDev, which matches chrome/x11.
+  // Currently EF_MOD3_DOWN means that the CapsLock key is currently down,
+  // and EF_CAPS_LOCK_ON means the caps lock state is enabled (and the
+  // key may or may not be down, but usually isn't). There does need to
+  // to be two different flags, since the physical CapsLock key is subject
+  // to remapping, but the caps lock state (which can be triggered in a
+  // variety of ways) is not.
+  if (modifier == MODIFIER_CAPS_LOCK)
+    event_modifiers_.UpdateModifier(MODIFIER_MOD3, down);
+  else
+    event_modifiers_.UpdateModifier(modifier, down);
 }
 
 }  // namespace ui

--- a/ui/ozone/platform/wayland/wayland_xkb_keyboard_layout_engine.cc
+++ b/ui/ozone/platform/wayland/wayland_xkb_keyboard_layout_engine.cc
@@ -20,6 +20,7 @@ void WaylandXkbKeyboardLayoutEngine::SetKeymap(xkb_keymap* keymap) {
       xkb_keymap_mod_get_index(keymap, XKB_MOD_NAME_CTRL);
   xkb_mod_indexes_.alt = xkb_keymap_mod_get_index(keymap, XKB_MOD_NAME_ALT);
   xkb_mod_indexes_.shift = xkb_keymap_mod_get_index(keymap, XKB_MOD_NAME_SHIFT);
+  xkb_mod_indexes_.caps = xkb_keymap_mod_get_index(keymap, XKB_MOD_NAME_CAPS);
 }
 
 void WaylandXkbKeyboardLayoutEngine::UpdateModifiers(uint32_t depressed_mods,
@@ -32,7 +33,8 @@ void WaylandXkbKeyboardLayoutEngine::UpdateModifiers(uint32_t depressed_mods,
   event_modifiers_->ResetKeyboardModifiers();
 
   auto component = static_cast<xkb_state_component>(XKB_STATE_MODS_DEPRESSED |
-                                                    XKB_STATE_MODS_LATCHED);
+                                                    XKB_STATE_MODS_LATCHED |
+                                                    XKB_STATE_MODS_LOCKED);
   if (xkb_state_mod_index_is_active(xkb_state_.get(), xkb_mod_indexes_.control,
                                     component))
     event_modifiers_->UpdateModifier(MODIFIER_CONTROL, true);
@@ -44,6 +46,12 @@ void WaylandXkbKeyboardLayoutEngine::UpdateModifiers(uint32_t depressed_mods,
   if (xkb_state_mod_index_is_active(xkb_state_.get(), xkb_mod_indexes_.shift,
                                     component))
     event_modifiers_->UpdateModifier(MODIFIER_SHIFT, true);
+
+  if (xkb_state_mod_index_is_active(xkb_state_.get(), xkb_mod_indexes_.caps,
+                                    component))
+    event_modifiers_->SetModifierLock(MODIFIER_CAPS_LOCK, true);
+  else
+    event_modifiers_->SetModifierLock(MODIFIER_CAPS_LOCK, false);
 }
 
 }  // namespace ui

--- a/ui/ozone/platform/wayland/wayland_xkb_keyboard_layout_engine.h
+++ b/ui/ozone/platform/wayland/wayland_xkb_keyboard_layout_engine.h
@@ -36,6 +36,7 @@ class WaylandXkbKeyboardLayoutEngine : public XkbKeyboardLayoutEngine {
     xkb_mod_index_t control = 0;
     xkb_mod_index_t alt = 0;
     xkb_mod_index_t shift = 0;
+    xkb_mod_index_t caps = 0;
   } xkb_mod_indexes_;
 
   EventModifiers* event_modifiers_ = nullptr;  // Owned by WaylandKeyboard.


### PR DESCRIPTION
CL adds capslock support by exteding the current modifiers
supported (shift, control, alt, et al).

Issue #346