### PR TITLE
fixup! Make content_browsertests and content_shell work with mus.

### DIFF
--- a/content/shell/app/shell_main.cc
+++ b/content/shell/app/shell_main.cc
@@ -60,8 +60,6 @@ int main(int argc, const char** argv) {
     base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
         switches::kMus, switches::kMusHostVizValue);
     params.env_mode = aura::Env::Mode::MUS;
-  } else {
-    LOG(FATAL) << "Ozone Linux builds can only be run with --mus flag.";
   }
 #endif
 


### PR DESCRIPTION
Remove LOG(FATAL) as long as second zygote process takes the same
path, but doesn't include mus flag, which triggers LOG(FATAL) and
content_shell crashes.

TBR=tonikitoo@igalia.com