### PR TITLE
Make CrossProcessFrameConnector wait until RenderWidgetHostView has v…

### DIFF
--- a/content/browser/frame_host/cross_process_frame_connector.h
+++ b/content/browser/frame_host/cross_process_frame_connector.h
@@ -105,6 +105,7 @@ class CONTENT_EXPORT CrossProcessFrameConnector
 #if defined(USE_AURA)
   void EmbedRendererWindowTreeClientInParent(
       ui::mojom::WindowTreeClientPtr window_tree_client) override;
+  void OnSetFrameSinkId() override;
 #endif
   void ResizeDueToAutoResize(const gfx::Size& new_size,
                              uint64_t sequence_number) override;
@@ -126,6 +127,8 @@ class CONTENT_EXPORT CrossProcessFrameConnector
   // Resets the rect and the viz::LocalSurfaceId of the connector to ensure the
   // unguessable surface ID is not reused after a cross-process navigation.
   void ResetFrameRect();
+
+  void ViewChanged();
 
   // Handlers for messages received from the parent frame.
   void OnUpdateResizeParams(const gfx::Rect& frame_rect,
@@ -152,6 +155,10 @@ class CONTENT_EXPORT CrossProcessFrameConnector
 
   bool is_throttled_ = false;
   bool subtree_throttled_ = false;
+
+  // Indicates whether |this| is in the process of setting a new view, and waiting
+  // before the |view_| receives a valid FrameSinkId.
+  bool is_setting_view_ = false;
 
   // Visibility state of the corresponding frame owner element in parent process
   // which is set through CSS.

--- a/content/browser/renderer_host/frame_connector_delegate.h
+++ b/content/browser/renderer_host/frame_connector_delegate.h
@@ -181,6 +181,9 @@ class CONTENT_EXPORT FrameConnectorDelegate {
   // creating a window in the ui server so that this can render to the screen.
   virtual void EmbedRendererWindowTreeClientInParent(
       ui::mojom::WindowTreeClientPtr window_tree_client) {}
+
+  // Tells the delegate FrameSinkId has been changed.
+  virtual void OnSetFrameSinkId() {}
 #endif
 
   // Called by RenderWidgetHostViewChildFrame when the child frame has resized

--- a/content/browser/renderer_host/render_widget_host_view_child_frame.cc
+++ b/content/browser/renderer_host/render_widget_host_view_child_frame.cc
@@ -185,8 +185,11 @@ void RenderWidgetHostViewChildFrame::SetFrameConnectorDelegate(
 #if defined(USE_AURA)
 void RenderWidgetHostViewChildFrame::SetFrameSinkId(
     const viz::FrameSinkId& frame_sink_id) {
-  if (switches::IsMusHostingViz())
+  if (switches::IsMusHostingViz()) {
     frame_sink_id_ = frame_sink_id;
+    DCHECK(frame_connector_);
+    frame_connector_->OnSetFrameSinkId();
+  }
 }
 #endif  // defined(USE_AURA)
 

--- a/testing/buildbot/filters/mash.browser_tests.filter
+++ b/testing/buildbot/filters/mash.browser_tests.filter
@@ -15,7 +15,7 @@ CrashRestoreComplexTest.*
 CrashRestoreSimpleTest.*
 DriveIntegrationServiceBrowserTest.*
 # crbug.com/796999
-#EnterpriseEnrollmentTest.*
+EnterpriseEnrollmentTest.*
 KioskAppManagerTest.*
 KioskAppUpdateServiceTest.*
 LoginPromptBrowserTest.*
@@ -26,15 +26,15 @@ PowerPolicyInSessionBrowserTest.*
 PowerPolicyLoginScreenBrowserTest.*
 QuirksBrowserTest.*
 # crbug.com/796999
-#ResetTest.*
+ResetTest.*
 SAMLEnrollmentTest.*
 ShutdownPolicyLockerTest.*
 UpdateScreenTest.*
 # crbug.com/796999
-#UserImageManagerTest.*
+UserImageManagerTest.*
 UserSelectionScreenTest.*
 # crbug.com/796999
-#WebviewLoginTest.*
+WebviewLoginTest.*
 
 # Tests from //chrome/browser/ui/ash.
 AcceleratorCommandsFullscreenBrowserTest.*
@@ -74,10 +74,10 @@ ScriptContextTest.*
 SiteEngagementUiBrowserTest.*
 
 # Sending invalid FrameSinkIds crbug.com/796999
--BrowserLoginTest.*BrowserActive
--LoginUtilsTest.MashLogin
--PowerPolicyLoginScreenBrowserTest.SetDevicePolicy
--SystemTrayClientClockTest.*TestMultiProfile24HourClock
--UserSelectionScreenTest.*ShowDircryptoMigrationBanner
+#-BrowserLoginTest.*BrowserActive
+#-LoginUtilsTest.MashLogin
+#-PowerPolicyLoginScreenBrowserTest.SetDevicePolicy
+#-SystemTrayClientClockTest.*TestMultiProfile24HourClock
+#-UserSelectionScreenTest.*ShowDircryptoMigrationBanner
 
 

--- a/testing/buildbot/filters/mojo.fyi.mash.browser_tests.filter
+++ b/testing/buildbot/filters/mojo.fyi.mash.browser_tests.filter
@@ -254,9 +254,3 @@
 
 # crbug.com/792641 - Disable tests on mash during Wallpaper re-factoring
 -WallPaperPrivateApiTest.*
-
-# Sending invalid FrameSinkIds crbug.com/796999
--WebviewLoginTest.AllowNewUser
--EnterpriseEnrollmentTest.TestAuthCodeGetsProperlyReceivedFromGaia
--PowerPolicyLoginScreenBrowserTest.SetDevicePolicy
--EnterpriseEnrollmentTest.TestActiveDirectoryEnrollment_Success


### PR DESCRIPTION
…alid FrameSinkId.

This cl fixes a problem, when creation of MusEmbeddedFrame is out
of sync with changing a view in CrossProcessFrameConnector. This leads to a problem when RenderFrameProxyHost had an invalid
FrameSinkId, because RenderWidgetHostView hasn't received it from
the RenderFrameProxy before calling to RenderFrameProxyHost.