### PR TITLE
[DoNotCarryForward] [ozone/wayland] Notify client about each state change from WM.

### DIFF
--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -77,7 +77,7 @@ WaylandWindow::WaylandWindow(PlatformWindowDelegate* delegate,
       connection_(connection),
       xdg_shell_objects_factory_(new XDGShellObjectFactory()),
       bounds_(bounds),
-      state_(ui::PlatformWindowState::PLATFORM_WINDOW_STATE_UNKNOWN) {}
+      state_(PlatformWindowState::PLATFORM_WINDOW_STATE_UNKNOWN) {}
 
 WaylandWindow::~WaylandWindow() {
   PlatformEventSource::GetInstance()->RemovePlatformEventDispatcher(this);
@@ -281,7 +281,6 @@ void WaylandWindow::ReleaseCapture() {
 
 void WaylandWindow::ToggleFullscreen() {
   DCHECK(xdg_surface_ && !xdg_popup_);
-  DCHECK(!IsMinimized());
 
   // TODO(msisov, tonikitoo): add multiscreen support. As the documentation says
   // if xdg_surface_set_fullscreen() is not provided with wl_output, it's up to
@@ -305,7 +304,6 @@ void WaylandWindow::ToggleFullscreen() {
 
 void WaylandWindow::Maximize() {
   DCHECK(xdg_surface_ && !xdg_popup_);
-  DCHECK(!IsMaximized());
 
   if (IsFullscreen())
     ToggleFullscreen();
@@ -321,7 +319,6 @@ void WaylandWindow::Maximize() {
 
 void WaylandWindow::Minimize() {
   DCHECK(xdg_surface_ && !xdg_popup_);
-  DCHECK(!IsMinimized());
 
   DCHECK(xdg_surface_);
   xdg_surface_->SetMinimized();
@@ -330,7 +327,7 @@ void WaylandWindow::Minimize() {
   // Wayland doesn't say if a window is minimized. Handle this case manually
   // here. We can track if the window was unminimized once wayland sends the
   // window is activated, and the previous state was minimized.
-  state_ = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MINIMIZED;
+  state_ = PlatformWindowState::PLATFORM_WINDOW_STATE_MINIMIZED;
 }
 
 void WaylandWindow::Restore() {
@@ -428,21 +425,19 @@ void WaylandWindow::HandleSurfaceConfigure(int32_t width,
                                            bool is_maximized,
                                            bool is_fullscreen,
                                            bool is_activated) {
-  // Change the window state only if the window is activated, because it's the
-  // only way to know if the window is not minimized.
-  if (is_activated) {
-    bool was_minimized = IsMinimized();
+  // Propagate the window state information to the client.
+  PlatformWindowState old_state = state_;
+  if (IsMinimized() && !is_activated)
+    state_ = PlatformWindowState::PLATFORM_WINDOW_STATE_MINIMIZED;
+  else if (is_fullscreen)
+    state_ = PlatformWindowState::PLATFORM_WINDOW_STATE_FULLSCREEN;
+  else if (is_maximized)
+    state_ = PlatformWindowState::PLATFORM_WINDOW_STATE_MAXIMIZED;
+  else
+    state_ = PlatformWindowState::PLATFORM_WINDOW_STATE_NORMAL;
 
-    state_ = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_NORMAL;
-    if (is_maximized && !is_fullscreen)
-      state_ = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MAXIMIZED;
-    else if (is_fullscreen)
-      state_ = ui::PlatformWindowState::PLATFORM_WINDOW_STATE_FULLSCREEN;
-
-    // Do not flood the WindowServer unless the previous state was minimized.
-    if (was_minimized)
-      delegate_->OnWindowStateChanged(state_);
-  }
+  if (old_state != state_)
+    delegate_->OnWindowStateChanged(state_);
 
   // Rather than call SetBounds here for every configure event, just save the
   // most recent bounds, and have WaylandConnection call ApplyPendingBounds
@@ -481,15 +476,15 @@ void WaylandWindow::OnCloseRequest() {
 }
 
 bool WaylandWindow::IsMinimized() const {
-  return state_ == ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MINIMIZED;
+  return state_ == PlatformWindowState::PLATFORM_WINDOW_STATE_MINIMIZED;
 }
 
 bool WaylandWindow::IsMaximized() const {
-  return state_ == ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MAXIMIZED;
+  return state_ == PlatformWindowState::PLATFORM_WINDOW_STATE_MAXIMIZED;
 }
 
 bool WaylandWindow::IsFullscreen() const {
-  return state_ == ui::PlatformWindowState::PLATFORM_WINDOW_STATE_FULLSCREEN;
+  return state_ == PlatformWindowState::PLATFORM_WINDOW_STATE_FULLSCREEN;
 }
 
 WaylandWindow* WaylandWindow::GetParentWindow() {

--- a/ui/ozone/platform/wayland/wayland_window_unittest.cc
+++ b/ui/ozone/platform/wayland/wayland_window_unittest.cc
@@ -94,24 +94,47 @@ TEST_P(WaylandWindowTest, SetTitle) {
 }
 
 TEST_P(WaylandWindowTest, MaximizeAndRestore) {
-  uint32_t serial = 12;
   wl_array states;
   InitializeWlArrayWithActivatedState(&states);
 
+  EXPECT_CALL(delegate,
+              OnWindowStateChanged(Eq(PLATFORM_WINDOW_STATE_MAXIMIZED)));
   SetWlArrayWithState(XDG_SURFACE_STATE_MAXIMIZED, &states);
 
   EXPECT_CALL(*GetXdgSurface(), SetMaximized());
-  EXPECT_CALL(*GetXdgSurface(), UnsetMaximized());
   window->Maximize();
-  SendConfigureEvent(0, 0, serial, &states);
+  SendConfigureEvent(0, 0, 1, &states);
   Sync();
 
+  EXPECT_CALL(delegate, OnWindowStateChanged(Eq(PLATFORM_WINDOW_STATE_NORMAL)));
+  EXPECT_CALL(*GetXdgSurface(), UnsetMaximized());
   window->Restore();
+  // Reinitialize wl_array, which removes previous old states.
+  InitializeWlArrayWithActivatedState(&states);
+  SendConfigureEvent(0, 0, 2, &states);
+  Sync();
 }
 
 TEST_P(WaylandWindowTest, Minimize) {
+  wl_array states;
+  wl_array_init(&states);
+
+  // Initialize to normal first.
+  EXPECT_CALL(delegate, OnWindowStateChanged(Eq(PLATFORM_WINDOW_STATE_NORMAL)));
+  SendConfigureEvent(0, 0, 1, &states);
+  Sync();
+
   EXPECT_CALL(*GetXdgSurface(), SetMinimized());
+  // The state of the window must retain minimized, which means we are not
+  // notified about the state, because 1) minimized state was set manually
+  // in WaylandWindow, and it has been confirmed in a back call from the server,
+  // which resulted in the same state as before.
+  EXPECT_CALL(delegate, OnWindowStateChanged(_)).Times(0);
   window->Minimize();
+  // Reinitialize wl_array, which removes previous old states.
+  wl_array_init(&states);
+  SendConfigureEvent(0, 0, 2, &states);
+  Sync();
 }
 
 TEST_P(WaylandWindowTest, SetFullscreenAndRestore) {
@@ -121,34 +144,49 @@ TEST_P(WaylandWindowTest, SetFullscreenAndRestore) {
   SetWlArrayWithState(XDG_SURFACE_STATE_FULLSCREEN, &states);
 
   EXPECT_CALL(*GetXdgSurface(), SetFullscreen());
-  EXPECT_CALL(*GetXdgSurface(), UnsetFullscreen());
+  EXPECT_CALL(delegate,
+              OnWindowStateChanged(Eq(PLATFORM_WINDOW_STATE_FULLSCREEN)));
   window->ToggleFullscreen();
   SendConfigureEvent(0, 0, 1, &states);
   Sync();
 
+  EXPECT_CALL(*GetXdgSurface(), UnsetFullscreen());
+  EXPECT_CALL(delegate, OnWindowStateChanged(Eq(PLATFORM_WINDOW_STATE_NORMAL)));
   window->Restore();
+  // Reinitialize wl_array, which removes previous old states.
+  InitializeWlArrayWithActivatedState(&states);
+  SendConfigureEvent(0, 0, 2, &states);
+  Sync();
 }
 
 TEST_P(WaylandWindowTest, SetMaximizedFullscreenAndRestore) {
   wl_array states;
   InitializeWlArrayWithActivatedState(&states);
 
-  EXPECT_CALL(*GetXdgSurface(), SetFullscreen());
-  EXPECT_CALL(*GetXdgSurface(), UnsetFullscreen());
   EXPECT_CALL(*GetXdgSurface(), SetMaximized());
-  EXPECT_CALL(*GetXdgSurface(), UnsetMaximized());
-
+  EXPECT_CALL(delegate,
+              OnWindowStateChanged(Eq(PLATFORM_WINDOW_STATE_MAXIMIZED)));
   window->Maximize();
   SetWlArrayWithState(XDG_SURFACE_STATE_MAXIMIZED, &states);
   SendConfigureEvent(0, 0, 2, &states);
   Sync();
 
+  EXPECT_CALL(*GetXdgSurface(), SetFullscreen());
+  EXPECT_CALL(delegate,
+              OnWindowStateChanged(Eq(PLATFORM_WINDOW_STATE_FULLSCREEN)));
   window->ToggleFullscreen();
   SetWlArrayWithState(XDG_SURFACE_STATE_FULLSCREEN, &states);
   SendConfigureEvent(0, 0, 3, &states);
   Sync();
 
+  EXPECT_CALL(*GetXdgSurface(), UnsetFullscreen());
+  EXPECT_CALL(*GetXdgSurface(), UnsetMaximized());
+  EXPECT_CALL(delegate, OnWindowStateChanged(Eq(PLATFORM_WINDOW_STATE_NORMAL)));
   window->Restore();
+  // Reinitialize wl_array, which removes previous old states.
+  InitializeWlArrayWithActivatedState(&states);
+  SendConfigureEvent(0, 0, 4, &states);
+  Sync();
 }
 
 TEST_P(WaylandWindowTest, CanDispatchMouseEventDefault) {


### PR DESCRIPTION
Notify the client about window state changes instantiated from a window
manager side. Those changes are results of shortcut keys
like ALT+F10 (maximize/unmaximize) or super+H (minimize).

Also remove the DCHECKs to avoid crashes due to theoretical races
between requests to change state of a window and a response back
from a WM.

Bug: 784836, 578890
Change-Id: Iaac5fdd971d89cef580197f00aeeeac64bf264b1