### PR TITLE
Standardize the path for WindowTree calls forwarded to ws::Display

### DIFF
--- a/services/ui/public/interfaces/window_tree.mojom
+++ b/services/ui/public/interfaces/window_tree.mojom
@@ -149,7 +149,7 @@ interface WindowTree {
                     uint32 window_id,
                     string name,
                     array<uint8>? value);
-                    
+
   // Sets the opacity of the specified window to |opacity|.
   SetWindowOpacity(uint32 change_id, uint32 window_id, float opacity);
 

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -221,6 +221,18 @@ void Display::SetBounds(const gfx::Rect& bounds) {
                                    allocator_.GenerateId());
 }
 
+void Display::SetProperty(const std::string& name, const std::vector<uint8_t>* value) {
+  DCHECK(window_server_->IsInExternalWindowMode());
+
+  if (name == mojom::WindowManager::kShowState_Property) {
+    const int64_t state = mojo::ConvertTo<int64_t>(*value);
+    platform_display_->SetNativeWindowState(static_cast<ui::mojom::ShowState>(state));
+  }
+
+  for (auto& pair : window_manager_display_root_map_)
+    pair.second->root()->SetProperty(name, value);
+}
+
 void Display::OnWillDestroyTree(WindowTree* tree) {
   for (auto it = window_manager_display_root_map_.begin();
        it != window_manager_display_root_map_.end(); ++it) {

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -233,6 +233,15 @@ void Display::SetProperty(const std::string& name, const std::vector<uint8_t>* v
     pair.second->root()->SetProperty(name, value);
 }
 
+void Display::SetVisible(bool value) {
+  DCHECK(window_server_->IsInExternalWindowMode());
+
+  platform_display_->SetWindowVisibility(value);
+
+  for (auto& pair : window_manager_display_root_map_)
+    pair.second->root()->SetVisible(value);
+}
+
 void Display::OnWillDestroyTree(WindowTree* tree) {
   for (auto it = window_manager_display_root_map_.begin();
        it != window_manager_display_root_map_.end(); ++it) {

--- a/services/ui/ws/display.h
+++ b/services/ui/ws/display.h
@@ -138,6 +138,7 @@ class Display : public PlatformDisplayDelegate,
                             const ui::TextInputState& state);
   void SetImeVisibility(ServerWindow* window, bool visible);
   void SetBounds(const gfx::Rect& bounds);
+  void SetProperty(const std::string& name, const std::vector<uint8_t>* value);
 
   // Called just before |tree| is destroyed.
   void OnWillDestroyTree(WindowTree* tree);

--- a/services/ui/ws/display.h
+++ b/services/ui/ws/display.h
@@ -139,6 +139,7 @@ class Display : public PlatformDisplayDelegate,
   void SetImeVisibility(ServerWindow* window, bool visible);
   void SetBounds(const gfx::Rect& bounds);
   void SetProperty(const std::string& name, const std::vector<uint8_t>* value);
+  void SetVisible(bool value);
 
   // Called just before |tree| is destroyed.
   void OnWillDestroyTree(WindowTree* tree);

--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -907,17 +907,6 @@ void WindowServer::SetNativeWindowVisibility(
   display->SetWindowVisibility(visible);
 }
 
-void WindowServer::SetNativeWindowState(ServerWindow* window,
-                                        ui::mojom::ShowState state) {
-  WindowManagerDisplayRoot* display_root =
-      display_manager_->GetWindowManagerDisplayRoot(window);
-  if (!display_root || display_root->GetClientVisibleRoot() != window)
-    return;
-  PlatformDisplay* display = display_root->display()->platform_display();
-  DCHECK(display);
-  display->SetNativeWindowState(state);
-}
-
 ServerWindow* WindowServer::GetRootWindowForDrawn(const ServerWindow* window) {
   Display* display = display_manager_->GetDisplayContaining(window);
   return display ? display->root_window() : nullptr;
@@ -1090,12 +1079,6 @@ void WindowServer::OnWindowSharedPropertyChanged(
     ServerWindow* window,
     const std::string& name,
     const std::vector<uint8_t>* new_data) {
-  if (IsInExternalWindowMode() &&
-      name == mojom::WindowManager::kShowState_Property) {
-    const int64_t state = mojo::ConvertTo<int64_t>(*new_data);
-    SetNativeWindowState(window, static_cast<ui::mojom::ShowState>(state));
-  }
-
   for (auto& pair : tree_map_) {
     pair.second->ProcessWindowPropertyChanged(window, name, new_data,
                                               IsOperationSource(pair.first));

--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -897,16 +897,6 @@ void WindowServer::CreateFrameSinkManager() {
       std::move(frame_sink_manager));
 }
 
-void WindowServer::SetNativeWindowVisibility(
-    WindowManagerDisplayRoot* display_root,
-    bool visible) {
-  if (!IsInExternalWindowMode())
-    return;
-  PlatformDisplay* display = display_root->display()->platform_display();
-  DCHECK(display);
-  display->SetWindowVisibility(visible);
-}
-
 ServerWindow* WindowServer::GetRootWindowForDrawn(const ServerWindow* window) {
   Display* display = display_manager_->GetDisplayContaining(window);
   return display ? display->root_window() : nullptr;
@@ -1051,8 +1041,6 @@ void WindowServer::OnWindowVisibilityChanged(ServerWindow* window) {
   if (display_root) {
     display_root->window_manager_state()
         ->ReleaseCaptureBlockedByAnyModalWindow();
-    if (display_root->GetClientVisibleRoot() == window)
-      SetNativeWindowVisibility(display_root, window->visible());
   }
 }
 

--- a/services/ui/ws/window_server.h
+++ b/services/ui/ws/window_server.h
@@ -333,10 +333,6 @@ class WindowServer : public ServerWindowDelegate,
   void SetNativeWindowVisibility(WindowManagerDisplayRoot* display_root,
                                  bool visible);
 
-  // Sets a state (minimize/maximize/restore) of a native window (only in
-  // external mode).
-  void SetNativeWindowState(ServerWindow* window, ui::mojom::ShowState state);
-
   // Overridden from ServerWindowDelegate:
   ServerWindow* GetRootWindowForDrawn(const ServerWindow* window) override;
 

--- a/services/ui/ws/window_server.h
+++ b/services/ui/ws/window_server.h
@@ -329,10 +329,6 @@ class WindowServer : public ServerWindowDelegate,
 
   void CreateFrameSinkManager();
 
-  // Hides or shows native window.
-  void SetNativeWindowVisibility(WindowManagerDisplayRoot* display_root,
-                                 bool visible);
-
   // Overridden from ServerWindowDelegate:
   ServerWindow* GetRootWindowForDrawn(const ServerWindow* window) override;
 

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -736,6 +736,19 @@ bool WindowTree::SetWindowVisibility(const ClientWindowId& window_id,
   }
   if (window->visible() == visible)
     return true;
+
+  if (window_server_->IsInExternalWindowMode()) {
+    WindowManagerDisplayRoot* display_root =
+        GetWindowManagerDisplayRoot(window);
+    if (display_root && display_root->GetClientVisibleRoot() == window) {
+      Operation op(this, window_server_, OperationType::SET_WINDOW_VISIBILITY);
+      Display* display = GetDisplay(window);
+      DCHECK(display);
+      display->SetVisible(visible);
+      return true;
+    }
+  }
+
   Operation op(this, window_server_, OperationType::SET_WINDOW_VISIBILITY);
   window->SetVisible(visible);
   return true;

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -1974,6 +1974,23 @@ void WindowTree::SetWindowProperty(
   }
   const bool success = window && access_policy_->CanSetWindowProperties(window);
   if (success) {
+    if (window_server_->IsInExternalWindowMode()) {
+      WindowManagerDisplayRoot* display_root =
+          GetWindowManagerDisplayRoot(window);
+      if (display_root && display_root->GetClientVisibleRoot() == window) {
+        Operation op(this, window_server_, OperationType::SET_WINDOW_PROPERTY);
+        Display* display = GetDisplay(window);
+        DCHECK(display);
+        if (!value.has_value()) {
+          display->SetProperty(name, nullptr);
+        } else {
+          display->SetProperty(name, &value.value());
+        }
+        client()->OnChangeCompleted(change_id, success);
+        return;
+      }
+    }
+
     Operation op(this, window_server_, OperationType::SET_WINDOW_PROPERTY);
     if (!value.has_value()) {
       window->SetProperty(name, nullptr);


### PR DESCRIPTION
Rather than calling PlatformDisplay from WindowServer, CL changes
the flow to WindowTree -> ws::Display -> PlatformDisplay.
This brings no functionality change, but standardize the path
for WindowTree calls forwarded to ws::Display.

Issue #266