### PR TITLE
First take to make mus run without viz.

### DIFF
--- a/chrome/app/chrome_main.cc
+++ b/chrome/app/chrome_main.cc
@@ -114,11 +114,6 @@ int ChromeMain(int argc, const char** argv) {
   if (command_line->HasSwitch(switches::kMus)) {
     params.create_discardable_memory = true;
     params.env_mode = aura::Env::Mode::MUS;
-    // TODO(786453): Remove when mus no longer needs to host viz.
-    base::CommandLine::ForCurrentProcess()->AppendSwitch(
-        switches::kMus);
-    base::CommandLine::ForCurrentProcess()->AppendSwitch(
-        switches::kMusHostingViz);
   }
 #if defined(OS_CHROMEOS)
   if (command_line->HasSwitch(switches::kMash)) {

--- a/content/browser/renderer_host/render_widget_host_view_child_frame_browsertest.cc
+++ b/content/browser/renderer_host/render_widget_host_view_child_frame_browsertest.cc
@@ -22,6 +22,7 @@
 #include "content/test/test_content_browser_client.h"
 #include "net/dns/mock_host_resolver.h"
 #include "net/test/embedded_test_server/embedded_test_server.h"
+#include "ui/base/ui_base_switches_util.h"
 #include "ui/gfx/geometry/size.h"
 
 namespace content {
@@ -154,8 +155,9 @@ IN_PROC_BROWSER_TEST_F(RenderWidgetHostViewChildFrameTest,
 // Tests that while in mus, the child frame receives an updated FrameSinkId
 // representing the frame sink used by the RenderFrameProxy.
 IN_PROC_BROWSER_TEST_F(RenderWidgetHostViewChildFrameTest, ChildFrameSinkId) {
-  // Only in mus do we expect a RenderFrameProxy to provide the FrameSinkId.
-  if (!IsUsingMus())
+  // Only when mus hosts viz do we expect a RenderFrameProxy to provide the
+  // FrameSinkId.
+  if (!switches::IsMusHostingViz())
     return;
 
   GURL main_url(embedded_test_server()->GetURL("/site_per_process_main.html"));

--- a/content/renderer/mus/renderer_window_tree_client.cc
+++ b/content/renderer/mus/renderer_window_tree_client.cc
@@ -168,6 +168,10 @@ void RendererWindowTreeClient::DestroyFrame(uint32_t frame_routing_id) {
   pending_frames_.erase(frame_routing_id);
 }
 
+void RendererWindowTreeClient::OnAcceleratedWidgetAvailable(
+    ui::Id window_id,
+    gpu::SurfaceHandle surface_handle) {}
+
 void RendererWindowTreeClient::OnEmbed(
     ui::mojom::WindowDataPtr root,
     ui::mojom::WindowTreePtr tree,

--- a/content/renderer/mus/renderer_window_tree_client.h
+++ b/content/renderer/mus/renderer_window_tree_client.h
@@ -110,6 +110,8 @@ class RendererWindowTreeClient : public ui::mojom::WindowTreeClient,
   // these will remain unimplemented in the long-term. Some of the
   // implementations would require some amount of refactoring out of
   // RenderWidget and related classes (e.g. resize, input, ime etc.).
+  void OnAcceleratedWidgetAvailable(ui::Id window_id,
+                                    gpu::SurfaceHandle surface_handle) override;
   void OnEmbed(
       ui::mojom::WindowDataPtr root,
       ui::mojom::WindowTreePtr tree,

--- a/content/test/content_test_launcher.cc
+++ b/content/test/content_test_launcher.cc
@@ -52,14 +52,6 @@ class ContentBrowserTestSuite : public ContentTestSuiteBase {
  public:
   ContentBrowserTestSuite(int argc, char** argv)
       : ContentTestSuiteBase(argc, argv) {
-#if BUILDFLAG(ENABLE_MUS)
-    // TODO(786453): This should be removed once mus can run without viz.
-    auto* cmd = base::CommandLine::ForCurrentProcess();
-    if (cmd->HasSwitch(switches::kMus)) {
-      base::CommandLine::ForCurrentProcess()->AppendSwitch(
-          switches::kMusHostingViz);
-    }
-#endif
   }
   ~ContentBrowserTestSuite() override {}
 

--- a/services/ui/public/interfaces/window_tree.mojom
+++ b/services/ui/public/interfaces/window_tree.mojom
@@ -4,6 +4,7 @@
 
 module ui.mojom;
 
+import "gpu/ipc/common/surface_handle.mojom";
 import "mojo/common/unguessable_token.mojom";
 import "services/ui/public/interfaces/cursor/cursor.mojom";
 import "services/ui/public/interfaces/event_matcher.mojom";
@@ -370,6 +371,12 @@ interface WindowTree {
 // calling SetWindowBounds(), connection 1 does not receive
 // OnWindowBoundsChanged().
 interface WindowTreeClient {
+  // Called to notify about the real AcceleratedWidget associated with a
+  // window. This is called only when mus is not hosting viz, and requires the
+  // browser to instead host viz.
+  OnAcceleratedWidgetAvailable(uint32 window_id,
+                               gpu.mojom.SurfaceHandle surface_handle);
+
   // Invoked when the client application has been embedded at |root|.
   // See Embed() on WindowTree for more details. |tree| will be a handle back to
   // the window manager service, unless the connection is to the root connection

--- a/services/ui/service.cc
+++ b/services/ui/service.cc
@@ -428,7 +428,11 @@ void Service::OnWillCreateTreeForWindowManager(
     screen_manager_ = display::ScreenManager::Create();
   }
   screen_manager_->AddInterfaces(&registry_with_source_info_);
-  if (is_gpu_ready_)
+  // We are calling SM::Init here, in case mus is not hosting viz, without
+  // awaiting for the GPU to be fully initialized.
+  // TODO(msisov, tonikitoo): check if there is any negative consequence of
+  // doing this.
+  if (is_gpu_ready_ || !should_host_viz_)
     screen_manager_->Init(window_server_->display_manager());
 }
 

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -355,12 +355,14 @@ EventSink* Display::GetEventSink() {
 }
 
 void Display::OnAcceleratedWidgetAvailable() {
-  display_manager()->OnDisplayAcceleratedWidgetAvailable(this);
-
+  // OnDisplayAcceleratedWidgetAvailable requires window manager state to be
+  // installed, otherwise the accelerated widget won't be propagated.
   if (window_server_->IsInExternalWindowMode())
     InitDisplayRoot();
   else
     InitWindowManagerDisplayRoots();
+
+  display_manager()->OnDisplayAcceleratedWidgetAvailable(this);
 }
 
 void Display::OnNativeCaptureLost() {

--- a/services/ui/ws/test_utils.cc
+++ b/services/ui/ws/test_utils.cc
@@ -310,6 +310,10 @@ void TestWindowTreeClient::Bind(
   binding_.Bind(std::move(request));
 }
 
+void TestWindowTreeClient::OnAcceleratedWidgetAvailable(
+    uint32_t window_id,
+    ::gpu::SurfaceHandle surface_handle) {}
+
 void TestWindowTreeClient::OnEmbed(
     mojom::WindowDataPtr root,
     ui::mojom::WindowTreePtr tree,

--- a/services/ui/ws/test_utils.h
+++ b/services/ui/ws/test_utils.h
@@ -485,6 +485,9 @@ class TestWindowTreeClient : public ui::mojom::WindowTreeClient {
 
  private:
   // WindowTreeClient:
+  void OnAcceleratedWidgetAvailable(
+      uint32_t window_id,
+      ::gpu::SurfaceHandle surface_handle) override;
   void OnEmbed(
       mojom::WindowDataPtr root,
       ui::mojom::WindowTreePtr tree,

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -217,6 +217,21 @@ void WindowTree::DoOnEmbed(mojom::WindowTreePtr tree,
 
 void WindowTree::OnAcceleratedWidgetAvailableForDisplay(Display* display) {
   DCHECK(window_manager_internal_);
+
+  if (window_server_->IsInExternalWindowMode()) {
+    // It's guaranteed this method is only calle once during initialization of
+    // ws::Display. Thus, |pending_client_window_id_| must always be a valid
+    // client id before ::AddRoot is called.
+    DCHECK(pending_client_window_id_ != kInvalidClientId);
+    ClientWindowId client_window_id =
+        MakeClientWindowId(pending_client_window_id_);
+
+    client()->OnAcceleratedWidgetAvailable(
+        ClientWindowIdToTransportId(client_window_id),
+        display->platform_display()->GetAcceleratedWidget());
+    return;
+  }
+
   // TODO(sad): Use GpuSurfaceTracker on platforms where a gpu::SurfaceHandle is
   // not the same as a gfx::AcceleratedWidget.
   window_manager_internal_->WmOnAcceleratedWidgetForDisplay(

--- a/services/ui/ws/window_tree_client_unittest.cc
+++ b/services/ui/ws/window_tree_client_unittest.cc
@@ -301,6 +301,9 @@ class TestWindowTreeClient : public mojom::WindowTreeClient,
   void OnActivationChanged(uint32_t window_id, bool is_active) override {}
 
   // WindowTreeClient:
+  void OnAcceleratedWidgetAvailable(
+        uint32_t window_id,
+        ::gpu::SurfaceHandle surface_handle) override {}
   void OnEmbed(
       WindowDataPtr root,
       mojom::WindowTreePtr tree,

--- a/ui/aura/mus/window_tree_client.cc
+++ b/ui/aura/mus/window_tree_client.cc
@@ -1192,6 +1192,18 @@ void WindowTreeClient::SetEventTargetingPolicy(
   tree_->SetEventTargetingPolicy(window->server_id(), policy);
 }
 
+void WindowTreeClient::OnAcceleratedWidgetAvailable(
+    Id window_id,
+    gpu::SurfaceHandle surface_handle) {
+  WindowMus* window = GetWindowByServerId(window_id);
+  if (!window)
+    return;
+
+  WindowTreeHostMus* host = GetWindowTreeHostMus(window);
+  DCHECK(host);
+  host->OverrideAcceleratedWidget(surface_handle);
+}
+
 void WindowTreeClient::OnEmbed(
     ui::mojom::WindowDataPtr root_data,
     ui::mojom::WindowTreePtr tree,

--- a/ui/aura/mus/window_tree_client.h
+++ b/ui/aura/mus/window_tree_client.h
@@ -369,6 +369,8 @@ class AURA_EXPORT WindowTreeClient
   void OnWmMoveLoopCompleted(uint32_t change_id, bool completed);
 
   // Overridden from WindowTreeClient:
+  void OnAcceleratedWidgetAvailable(Id window_id,
+                                    gpu::SurfaceHandle surface_handle) override;
   void OnEmbed(
       ui::mojom::WindowDataPtr root,
       ui::mojom::WindowTreePtr tree,


### PR DESCRIPTION
This patch is a first take to allow mus to run without viz. 

Firstly, in order to unblock ScreenMus during the waiting mojo call, we start initializing ScreenManager as soon as it's created not waiting until gpu is initialized (otherwise gpu won't be initialized, because ScreenMus blocks mojo initialization).

Secondly, we propagate accelerated widget from ozone to aura/mus WTHM object, and set a correct widget there, which is used further down the road initializing glx/gle furfaces. 

#337 