### PR TITLE
Introduce ExternalWindowDisplayRootWindow to forward calls to ws::Display

### DIFF
--- a/services/ui/ws/BUILD.gn
+++ b/services/ui/ws/BUILD.gn
@@ -55,6 +55,8 @@ static_library("lib") {
     "event_targeter_delegate.h",
     "external_window_access_policy.cc",
     "external_window_access_policy.h",
+    "external_window_display_root_window.cc",
+    "external_window_display_root_window.h",
     "external_window_tree_factory.cc",
     "external_window_tree_factory.h",
     "external_window_tree_host_factory.cc",

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -218,14 +218,10 @@ void Display::SetBounds(const gfx::Rect& bounds) {
 
 void Display::SetProperty(const std::string& name, const std::vector<uint8_t>* value) {
   DCHECK(window_server_->IsInExternalWindowMode());
+  DCHECK(name == mojom::WindowManager::kShowState_Property);
 
-  if (name == mojom::WindowManager::kShowState_Property) {
-    const int64_t state = mojo::ConvertTo<int64_t>(*value);
-    platform_display_->SetNativeWindowState(static_cast<ui::mojom::ShowState>(state));
-  }
-
-  for (auto& pair : window_manager_display_root_map_)
-    pair.second->root()->SetProperty(name, value);
+  const int64_t state = mojo::ConvertTo<int64_t>(*value);
+  platform_display_->SetNativeWindowState(static_cast<ui::mojom::ShowState>(state));
 }
 
 void Display::SetVisible(bool value) {

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -226,11 +226,7 @@ void Display::SetProperty(const std::string& name, const std::vector<uint8_t>* v
 
 void Display::SetVisible(bool value) {
   DCHECK(window_server_->IsInExternalWindowMode());
-
   platform_display_->SetWindowVisibility(value);
-
-  for (auto& pair : window_manager_display_root_map_)
-    pair.second->root()->SetVisible(value);
 }
 
 void Display::OnWillDestroyTree(WindowTree* tree) {

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -207,18 +207,13 @@ void Display::SetImeVisibility(ServerWindow* window, bool visible) {
 }
 
 void Display::SetBounds(const gfx::Rect& bounds) {
+  DCHECK(window_server_->IsInExternalWindowMode());
   platform_display_->SetViewportBounds(bounds);
 
   if (root_->bounds() == bounds)
     return;
 
   root_->SetBounds(bounds, allocator_.GenerateId());
-
-  // WindowManagerDisplayRoot::root_ needs to be at 0,0 position relative
-  // to its parent not to break mouse/touch events.
-  for (auto& pair : window_manager_display_root_map_)
-    pair.second->root()->SetBounds(gfx::Rect(bounds.size()),
-                                   allocator_.GenerateId());
 }
 
 void Display::SetProperty(const std::string& name, const std::vector<uint8_t>* value) {

--- a/services/ui/ws/external_window_display_root_window.cc
+++ b/services/ui/ws/external_window_display_root_window.cc
@@ -1,0 +1,36 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "services/ui/ws/external_window_display_root_window.h"
+
+#include "services/ui/ws/display.h"
+#include "services/ui/ws/display_manager.h"
+#include "services/ui/ws/window_server.h"
+
+namespace ui {
+namespace ws {
+
+ExternalWindowDisplayRootWindow::ExternalWindowDisplayRootWindow(
+    WindowServer* window_server,
+    const WindowId& id,
+    const viz::FrameSinkId& frame_sink_id,
+    const Properties& properties)
+    : ServerWindow(window_server, id, frame_sink_id, properties),
+      window_server_(window_server) {}
+
+void ExternalWindowDisplayRootWindow::SetBounds(
+    const gfx::Rect& bounds,
+    const base::Optional<viz::LocalSurfaceId>& local_surface_id) {
+  Display* display =
+      window_server_->display_manager()->GetDisplayContaining(this);
+  if (display)
+    display->SetBounds(bounds);
+
+  // WindowManagerDisplayRoot::root_ needs to be at 0,0 position relative
+  // to its parent not to break mouse/touch events.
+  ServerWindow::SetBounds(gfx::Rect(bounds.size()), local_surface_id);
+}
+
+}  // namespace ws
+}  // namespace ui

--- a/services/ui/ws/external_window_display_root_window.cc
+++ b/services/ui/ws/external_window_display_root_window.cc
@@ -32,5 +32,16 @@ void ExternalWindowDisplayRootWindow::SetBounds(
   ServerWindow::SetBounds(gfx::Rect(bounds.size()), local_surface_id);
 }
 
+void ExternalWindowDisplayRootWindow::SetProperty(
+    const std::string& name,
+    const std::vector<uint8_t>* value) {
+  Display* display =
+      window_server_->display_manager()->GetDisplayContaining(this);
+  if (display && name == mojom::WindowManager::kShowState_Property)
+    display->SetProperty(name, value);
+
+  ServerWindow::SetProperty(name, value);
+}
+
 }  // namespace ws
 }  // namespace ui

--- a/services/ui/ws/external_window_display_root_window.cc
+++ b/services/ui/ws/external_window_display_root_window.cc
@@ -43,5 +43,14 @@ void ExternalWindowDisplayRootWindow::SetProperty(
   ServerWindow::SetProperty(name, value);
 }
 
+void ExternalWindowDisplayRootWindow::SetVisible(bool value) {
+  Display* display =
+      window_server_->display_manager()->GetDisplayContaining(this);
+  if (display)
+    display->SetVisible(value);
+
+  ServerWindow::SetVisible(value);
+}
+
 }  // namespace ws
 }  // namespace ui

--- a/services/ui/ws/external_window_display_root_window.h
+++ b/services/ui/ws/external_window_display_root_window.h
@@ -1,0 +1,42 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SERVICES_UI_WS_EXTERNAL_WINDOW_DISPLAY_ROOT_WINDOW_H_
+#define SERVICES_UI_WS_EXTERNAL_WINDOW_DISPLAY_ROOT_WINDOW_H_
+
+#include "components/viz/common/surfaces/frame_sink_id.h"
+#include "services/ui/ws/server_window.h"
+#include "ui/gfx/geometry/rect.h"
+
+namespace ui {
+namespace ws {
+
+class WindowServer;
+
+// This class overrides specific methods of ws::ServerWindow
+// for external window mode. The methods forward calls to
+// ws::Display (and down to platform/ozone level) accordingly.
+class ExternalWindowDisplayRootWindow : public ServerWindow {
+ public:
+  ExternalWindowDisplayRootWindow(WindowServer* window_server,
+                                  const WindowId& id,
+                                  const viz::FrameSinkId& frame_sink_id,
+                                  const Properties& properties);
+  ~ExternalWindowDisplayRootWindow() override = default;
+
+  // ServerWindow
+  void SetBounds(const gfx::Rect& bounds,
+                 const base::Optional<viz::LocalSurfaceId>& local_surface_id =
+                     base::nullopt) override;
+
+ private:
+  WindowServer* window_server_ = nullptr;
+
+  DISALLOW_COPY_AND_ASSIGN(ExternalWindowDisplayRootWindow);
+};
+
+}  // namespace ws
+}  // namespace ui
+
+#endif  // SERVICES_UI_WS_EXTERNAL_WINDOW_DISPLAY_ROOT_WINDOW_H_

--- a/services/ui/ws/external_window_display_root_window.h
+++ b/services/ui/ws/external_window_display_root_window.h
@@ -29,6 +29,8 @@ class ExternalWindowDisplayRootWindow : public ServerWindow {
   void SetBounds(const gfx::Rect& bounds,
                  const base::Optional<viz::LocalSurfaceId>& local_surface_id =
                      base::nullopt) override;
+  void SetProperty(const std::string& name,
+                   const std::vector<uint8_t>* value) override;
 
  private:
   WindowServer* window_server_ = nullptr;

--- a/services/ui/ws/external_window_display_root_window.h
+++ b/services/ui/ws/external_window_display_root_window.h
@@ -31,6 +31,7 @@ class ExternalWindowDisplayRootWindow : public ServerWindow {
                      base::nullopt) override;
   void SetProperty(const std::string& name,
                    const std::vector<uint8_t>* value) override;
+  void SetVisible(bool value) override;
 
  private:
   WindowServer* window_server_ = nullptr;

--- a/services/ui/ws/server_window.h
+++ b/services/ui/ws/server_window.h
@@ -172,7 +172,7 @@ class ServerWindow : public viz::HostFrameSinkClient {
   // Returns the visibility requested by this window. IsDrawn() returns whether
   // the window is actually visible on screen.
   bool visible() const { return visible_; }
-  void SetVisible(bool value);
+  virtual void SetVisible(bool value);
 
   float opacity() const { return opacity_; }
   void SetOpacity(float value);

--- a/services/ui/ws/server_window.h
+++ b/services/ui/ws/server_window.h
@@ -186,7 +186,7 @@ class ServerWindow : public viz::HostFrameSinkClient {
   const std::map<std::string, std::vector<uint8_t>>& properties() const {
     return properties_;
   }
-  void SetProperty(const std::string& name, const std::vector<uint8_t>* value);
+  virtual void SetProperty(const std::string& name, const std::vector<uint8_t>* value);
 
   std::string GetName() const;
 

--- a/services/ui/ws/server_window.h
+++ b/services/ui/ws/server_window.h
@@ -103,7 +103,7 @@ class ServerWindow : public viz::HostFrameSinkClient {
   const gfx::Rect& bounds() const { return bounds_; }
   // Sets the bounds. If the size changes this implicitly resets the client
   // area to fill the whole bounds.
-  void SetBounds(const gfx::Rect& bounds,
+  virtual void SetBounds(const gfx::Rect& bounds,
                  const base::Optional<viz::LocalSurfaceId>& local_surface_id =
                      base::nullopt);
 

--- a/services/ui/ws/window_manager_display_root.cc
+++ b/services/ui/ws/window_manager_display_root.cc
@@ -10,6 +10,7 @@
 #include "services/ui/public/interfaces/window_manager.mojom.h"
 #include "services/ui/ws/display.h"
 #include "services/ui/ws/display_manager.h"
+#include "services/ui/ws/external_window_display_root_window.h"
 #include "services/ui/ws/server_window.h"
 #include "services/ui/ws/window_manager_state.h"
 #include "services/ui/ws/window_server.h"
@@ -17,6 +18,21 @@
 
 namespace ui {
 namespace ws {
+
+namespace {
+
+ServerWindow* CreateExternalWindowDisplayRootWindow(
+    WindowServer* window_server,
+    const WindowId& id,
+    const viz::FrameSinkId& frame_sink_id,
+    const std::map<std::string, std::vector<uint8_t>>& properties) {
+  ServerWindow* window =
+      new ExternalWindowDisplayRootWindow(window_server, id, frame_sink_id, properties);
+  window->AddObserver(window_server);
+  return window;
+}
+
+}  //  namespace
 
 WindowManagerDisplayRoot::WindowManagerDisplayRoot(Display* display)
     : display_(display) {
@@ -27,8 +43,11 @@ WindowManagerDisplayRoot::WindowManagerDisplayRoot(Display* display)
 
   WindowId id = window_server()->display_manager()->GetAndAdvanceNextRootId();
   ClientWindowId client_window_id(id.client_id, id.window_id);
-  root_.reset(
-      window_server()->CreateServerWindow(id, client_window_id, properties));
+  root_.reset(window_server()->IsInExternalWindowMode()
+                  ? CreateExternalWindowDisplayRootWindow(
+                        window_server(), id, client_window_id, properties)
+                  : window_server()->CreateServerWindow(id, client_window_id,
+                                                        properties));
   root_->set_event_targeting_policy(
       mojom::EventTargetingPolicy::DESCENDANTS_ONLY);
   // Our root is always a child of the Display's root. Do this

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -752,18 +752,6 @@ bool WindowTree::SetWindowVisibility(const ClientWindowId& window_id,
   if (window->visible() == visible)
     return true;
 
-  if (window_server_->IsInExternalWindowMode()) {
-    WindowManagerDisplayRoot* display_root =
-        GetWindowManagerDisplayRoot(window);
-    if (display_root && display_root->GetClientVisibleRoot() == window) {
-      Operation op(this, window_server_, OperationType::SET_WINDOW_VISIBILITY);
-      Display* display = GetDisplay(window);
-      DCHECK(display);
-      display->SetVisible(visible);
-      return true;
-    }
-  }
-
   Operation op(this, window_server_, OperationType::SET_WINDOW_VISIBILITY);
   window->SetVisible(visible);
   return true;

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -1989,23 +1989,6 @@ void WindowTree::SetWindowProperty(
   }
   const bool success = window && access_policy_->CanSetWindowProperties(window);
   if (success) {
-    if (window_server_->IsInExternalWindowMode()) {
-      WindowManagerDisplayRoot* display_root =
-          GetWindowManagerDisplayRoot(window);
-      if (display_root && display_root->GetClientVisibleRoot() == window) {
-        Operation op(this, window_server_, OperationType::SET_WINDOW_PROPERTY);
-        Display* display = GetDisplay(window);
-        DCHECK(display);
-        if (!value.has_value()) {
-          display->SetProperty(name, nullptr);
-        } else {
-          display->SetProperty(name, &value.value());
-        }
-        client()->OnChangeCompleted(change_id, success);
-        return;
-      }
-    }
-
     Operation op(this, window_server_, OperationType::SET_WINDOW_PROPERTY);
     if (!value.has_value()) {
       window->SetProperty(name, nullptr);

--- a/services/ui/ws/window_tree.cc
+++ b/services/ui/ws/window_tree.cc
@@ -1926,19 +1926,6 @@ void WindowTree::SetWindowBounds(
   // Only the owner of the window can change the bounds.
   bool success = access_policy_->CanSetWindowBounds(window);
   if (success) {
-    if (window_server_->IsInExternalWindowMode()) {
-      WindowManagerDisplayRoot* display_root =
-          GetWindowManagerDisplayRoot(window);
-      if (display_root && display_root->GetClientVisibleRoot() == window) {
-        Operation op(this, window_server_, OperationType::SET_WINDOW_BOUNDS);
-        Display* display = GetDisplay(window);
-        DCHECK(display);
-        display->SetBounds(bounds);
-        client()->OnChangeCompleted(change_id, success);
-        return;
-      }
-    }
-
     Operation op(this, window_server_, OperationType::SET_WINDOW_BOUNDS);
     window->SetBounds(bounds, local_surface_id);
   } else {


### PR DESCRIPTION
PR introduces a ExternalWindowDisplayRootWindow, which specializes ws::ServerWindow. This overrides particularly ::SetBounds, SetVisible, SetProperty methods and calls out to Display accordingly.
    
Issue #266
    
