### PR TITLE
fixup! Override WTHM with accelerated widget to make viz work without mus

### DIFF
--- a/chrome/app/chrome_main.cc
+++ b/chrome/app/chrome_main.cc
@@ -114,6 +114,11 @@ int ChromeMain(int argc, const char** argv) {
   if (command_line->HasSwitch(switches::kMus)) {
     params.create_discardable_memory = true;
     params.env_mode = aura::Env::Mode::MUS;
+    // TODO(786453): Remove when mus no longer needs to host viz.
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(
+        switches::kMus);
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(
+        switches::kMusHostingViz);
   }
 #if defined(OS_CHROMEOS)
   if (command_line->HasSwitch(switches::kMash)) {

--- a/content/browser/renderer_host/render_widget_host_view_child_frame_browsertest.cc
+++ b/content/browser/renderer_host/render_widget_host_view_child_frame_browsertest.cc
@@ -22,7 +22,6 @@
 #include "content/test/test_content_browser_client.h"
 #include "net/dns/mock_host_resolver.h"
 #include "net/test/embedded_test_server/embedded_test_server.h"
-#include "ui/base/ui_base_switches_util.h"
 #include "ui/gfx/geometry/size.h"
 
 namespace content {
@@ -155,9 +154,8 @@ IN_PROC_BROWSER_TEST_F(RenderWidgetHostViewChildFrameTest,
 // Tests that while in mus, the child frame receives an updated FrameSinkId
 // representing the frame sink used by the RenderFrameProxy.
 IN_PROC_BROWSER_TEST_F(RenderWidgetHostViewChildFrameTest, ChildFrameSinkId) {
-  // Only when mus hosts viz do we expect a RenderFrameProxy to provide the
-  // FrameSinkId.
-  if (!switches::IsMusHostingViz())
+  // Only in mus do we expect a RenderFrameProxy to provide the FrameSinkId.
+  if (!IsUsingMus())
     return;
 
   GURL main_url(embedded_test_server()->GetURL("/site_per_process_main.html"));

--- a/content/test/content_test_launcher.cc
+++ b/content/test/content_test_launcher.cc
@@ -52,6 +52,14 @@ class ContentBrowserTestSuite : public ContentTestSuiteBase {
  public:
   ContentBrowserTestSuite(int argc, char** argv)
       : ContentTestSuiteBase(argc, argv) {
+#if BUILDFLAG(ENABLE_MUS)
+    // TODO(786453): This should be removed once mus can run without viz.
+    auto* cmd = base::CommandLine::ForCurrentProcess();
+    if (cmd->HasSwitch(switches::kMus)) {
+      base::CommandLine::ForCurrentProcess()->AppendSwitch(
+          switches::kMusHostingViz);
+    }
+#endif
   }
   ~ContentBrowserTestSuite() override {}
 

--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -376,14 +376,12 @@ EventSink* Display::GetEventSink() {
 }
 
 void Display::OnAcceleratedWidgetAvailable() {
-  // OnDisplayAcceleratedWidgetAvailable requires window manager state to be
-  // installed, otherwise the accelerated widget won't be propagated.
+  display_manager()->OnDisplayAcceleratedWidgetAvailable(this);
+
   if (window_server_->IsInExternalWindowMode())
     InitDisplayRoot();
   else
     InitWindowManagerDisplayRoots();
-
-  display_manager()->OnDisplayAcceleratedWidgetAvailable(this);
 }
 
 void Display::OnNativeCaptureLost() {

--- a/services/ui/ws/window_server.cc
+++ b/services/ui/ws/window_server.cc
@@ -689,6 +689,12 @@ void WindowServer::OnDisplayReady(Display* display, bool is_first) {
     delegate_->OnFirstDisplayReady();
   bool wm_is_hosting_viz = !gpu_host_;
   if (wm_is_hosting_viz) {
+    // Notify client about the AcceleratedWidget if it is hosting viz.
+    if (IsInExternalWindowMode()) {
+      GetTreeForExternalWindowMode()->OnAcceleratedWidgetAvailableForDisplay(
+          display);
+      return;
+    }
     // Notify WM about the AcceleratedWidget if it is hosting viz.
     for (auto& pair : tree_map_) {
       if (pair.second->window_manager_state()) {


### PR DESCRIPTION
Don't rely on window manager state, but instead notify a tree
for external window mode about available widget.

And revert the revert to host viz by default

#337 