### PR TITLE
Make Display::OnBoundsChanged() deliver bounds without modification

### DIFF
--- a/services/ui/ws/display.cc
+++ b/services/ui/ws/display.cc
@@ -393,10 +393,8 @@ void Display::OnBoundsChanged(const gfx::Rect& new_bounds) {
 
   root_->SetBounds(new_bounds, allocator_.GenerateId());
 
-  // WindowManagerDisplayRoot::root_ needs to be at 0,0 position relative
-  // to its parent not to break mouse/touch events.
   for (auto& pair : window_manager_display_root_map_)
-    pair.second->root()->SetBounds(gfx::Rect(new_bounds.size()),
+    pair.second->root()->SetBounds(new_bounds,
                                    allocator_.GenerateId());
 }
 


### PR DESCRIPTION
This CL delivers bounds without resetting position to
WindowManagerDisplayRoot::root_ in order to handle the real
position with ws::Display::root_ in
ExternalWindowDisplayRootWindow::SetBounds(). For the relative
position, it's already handled with ServerWindow::SetBounds().

Issue #382