### PR TITLE
fixup! [TEMP] Revert "mus: Do not host viz by default.

### DIFF
--- a/services/ui/demo/mus_demo_external.cc
+++ b/services/ui/demo/mus_demo_external.cc
@@ -15,6 +15,7 @@
 #include "ui/aura/mus/window_tree_client.h"
 #include "ui/aura/mus/window_tree_host_mus.h"
 #include "ui/aura/mus/window_tree_host_mus_init_params.h"
+#include "ui/base/ui_base_switches.h"
 #include "ui/display/display.h"
 
 namespace ui {
@@ -57,6 +58,10 @@ MusDemoExternal::~MusDemoExternal() {}
 
 std::unique_ptr<aura::WindowTreeClient>
 MusDemoExternal::CreateWindowTreeClient() {
+  base::CommandLine* command_line =
+      base::CommandLine::ForCurrentProcess();
+  command_line->AppendSwitch(switches::kMusHostingViz);
+
   return std::make_unique<aura::WindowTreeClient>(context()->connector(), this);
 }
 


### PR DESCRIPTION
This allows mus demo to be launched without specifying
--mus-hosting-viz, similar to chrome and content_shell.

TBR=msisov

Issue #387