### PR TITLE
Added stopped_propagation condition before inserting character

### DIFF
--- a/ui/base/ime/input_method_minimal.cc
+++ b/ui/base/ime/input_method_minimal.cc
@@ -35,7 +35,8 @@ ui::EventDispatchDetails InputMethodMinimal::DispatchKeyEvent(
 
   // Insert the character.
   ui::EventDispatchDetails dispatch_details = DispatchKeyEventPostIME(event);
-  if (!dispatch_details.dispatcher_destroyed &&
+  if (!event->stopped_propagation() &&
+      !dispatch_details.dispatcher_destroyed &&
       event->type() == ET_KEY_PRESSED && GetTextInputClient()) {
     const uint16_t ch = event->GetCharacter();
     if (ch) {


### PR DESCRIPTION
It added event->stopped_propagation() to avoid inserting character
when stopped_propagation is set while DispatchKeyEventPostIME is
working.

Issue #389