### PR TITLE
[ozone/wayland] Add missing algorithm declaration in WaylandDataOffer

### DIFF
--- a/ui/ozone/platform/wayland/wayland_data_offer.cc
+++ b/ui/ozone/platform/wayland/wayland_data_offer.cc
@@ -4,6 +4,7 @@
 
 #include "ui/ozone/platform/wayland/wayland_data_offer.h"
 
+#include <algorithm>
 #include <fcntl.h>
 
 #include "base/logging.h"


### PR DESCRIPTION
WaylandDataOffer is using the algorithms std::find and std::any_of,
both declared in #include <algorithm>. But the include was missing.

This should be squashed against "[ozone/wayland] Add clipboard support"