### PR TITLE
Implement wayland nested compositor

### DIFF
--- a/ui/ozone/platform/wayland/BUILD.gn
+++ b/ui/ozone/platform/wayland/BUILD.gn
@@ -70,6 +70,7 @@ source_set("wayland") {
   }
 
   deps = [
+    ":wayland_nested_compositor",
     "//base",
     "//services/ui/public/interfaces/ime",
     "//skia",
@@ -97,6 +98,28 @@ source_set("wayland") {
   configs += [
     ":wayland-egl",
     "//third_party/khronos:khronos_headers",
+  ]
+}
+
+source_set("wayland_nested_compositor") {
+  sources = [
+    "wayland_nested_compositor.cc",
+    "wayland_nested_compositor.h",
+    "wayland_nested_compositor_client.cc",
+    "wayland_nested_compositor_client.h",
+    "wayland_nested_compositor_watcher.cc",
+    "wayland_nested_compositor_watcher.h",
+    "wayland_nested_surface.cc",
+    "wayland_nested_surface.h",
+  ]
+
+  deps = [
+    "//base",
+    "//skia",
+    "//third_party/angle:libEGL",
+    "//third_party/angle:libGLESv2",
+    "//third_party/wayland:wayland_server",
+    "//ui/gl",
   ]
 }
 

--- a/ui/ozone/platform/wayland/gl_surface_wayland.cc
+++ b/ui/ozone/platform/wayland/gl_surface_wayland.cc
@@ -19,10 +19,12 @@ void EGLWindowDeleter::operator()(wl_egl_window* egl_window) {
 }
 
 std::unique_ptr<wl_egl_window, EGLWindowDeleter> CreateWaylandEglWindow(
-    WaylandWindow* window) {
-  gfx::Size size = window->GetBounds().size();
+    wl_surface* surface) {
+  // TODO(msisov, tonikitoo): provide proper surface size. It's ok to set 1x1
+  // here as long as ::Resize fixes the size of the surface right after this
+  // call.
   return std::unique_ptr<wl_egl_window, EGLWindowDeleter>(
-      wl_egl_window_create(window->surface(), size.width(), size.height()));
+      wl_egl_window_create(surface, 1, 1));
 }
 
 GLSurfaceWayland::GLSurfaceWayland(WaylandEglWindowPtr egl_window)

--- a/ui/ozone/platform/wayland/gl_surface_wayland.h
+++ b/ui/ozone/platform/wayland/gl_surface_wayland.h
@@ -12,17 +12,16 @@
 #include "ui/gl/gl_surface_egl.h"
 
 struct wl_egl_window;
+struct wl_surface;
 
 namespace ui {
-
-class WaylandWindow;
 
 struct EGLWindowDeleter {
   void operator()(wl_egl_window* egl_window);
 };
 
 std::unique_ptr<wl_egl_window, EGLWindowDeleter> CreateWaylandEglWindow(
-    WaylandWindow* window);
+    wl_surface* surface);
 
 // GLSurface class implementation for wayland.
 class GLSurfaceWayland : public gl::NativeViewGLSurfaceEGL {

--- a/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+++ b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
@@ -14,6 +14,9 @@
 #include "ui/ozone/common/stub_overlay_manager.h"
 #include "ui/ozone/platform/wayland/wayland_connection.h"
 #include "ui/ozone/platform/wayland/wayland_input_method_context.h"
+#include "ui/ozone/platform/wayland/wayland_nested_compositor.h"
+#include "ui/ozone/platform/wayland/wayland_nested_compositor_client.h"
+#include "ui/ozone/platform/wayland/wayland_nested_compositor_watcher.h"
 #include "ui/ozone/platform/wayland/wayland_surface_factory.h"
 #include "ui/ozone/platform/wayland/wayland_window.h"
 #include "ui/ozone/public/clipboard_data_bridge.h"
@@ -111,23 +114,30 @@ class OzonePlatformWayland : public OzonePlatform {
     cursor_factory_.reset(new BitmapCursorFactoryOzone);
     overlay_manager_.reset(new StubOverlayManager);
     input_controller_ = CreateStubInputController();
-    surface_factory_.reset(new WaylandSurfaceFactory(connection_.get()));
+
+    if (!args.single_process) {
+      nested_compositor_.reset(new WaylandNestedCompositor(connection_.get()));
+      if (!nested_compositor_->Initialize())
+        CHECK(false) << "Wayland nested compositor failure.";
+
+      nested_compositor_watcher_.reset(
+          new WaylandNestedCompositorWatcher(nested_compositor_.get()));
+    } else {
+      surface_factory_.reset(new WaylandSurfaceFactory(connection_.get()));
+    }
+
     gpu_platform_support_host_.reset(CreateStubGpuPlatformSupportHost());
   }
 
   void InitializeGPU(const InitParams& args) override {
-    // TODO(fwang): args.single_process parameter should be checked here; make
-    // sure callers pass in the proper value. Once it happens, the check whether
-    // surface factory was set in the same process by a previous InitializeUI
-    // call becomes unneeded.
-    if (!surface_factory_) {
-      // TODO(fwang): Separate processes can not share a Wayland connection
-      // and so the current implementations of GLOzoneEGLWayland and
-      // WaylandCanvasSurface may only work when UI and GPU live in the same
-      // process. GetSurfaceFactoryOzone() must be non-null so a dummy instance
-      // of WaylandSurfaceFactory is needed to make the GPU initialization
-      // gracefully fail.
-      surface_factory_.reset(new WaylandSurfaceFactory(nullptr));
+    if (!args.single_process) {
+      DCHECK(!surface_factory_);
+      nested_compositor_client_.reset(new WaylandNestedCompositorClient);
+      if (!nested_compositor_client_->Initialize())
+        CHECK(false) << "Wayland nested compositor client failure.";
+
+      surface_factory_.reset(
+          new WaylandSurfaceFactory(nested_compositor_client_.get()));
     }
   }
 
@@ -148,12 +158,21 @@ class OzonePlatformWayland : public OzonePlatform {
   }
 
  private:
+  // Belong to browser process.
   std::unique_ptr<WaylandConnection> connection_;
-  std::unique_ptr<WaylandSurfaceFactory> surface_factory_;
   std::unique_ptr<BitmapCursorFactoryOzone> cursor_factory_;
   std::unique_ptr<StubOverlayManager> overlay_manager_;
   std::unique_ptr<InputController> input_controller_;
+  std::unique_ptr<WaylandNestedCompositor> nested_compositor_;
+  std::unique_ptr<WaylandNestedCompositorWatcher> nested_compositor_watcher_;
   std::unique_ptr<GpuPlatformSupportHost> gpu_platform_support_host_;
+
+  // Can belong to either browser or gpu process depending on
+  // |args.single_process| value.
+  std::unique_ptr<WaylandSurfaceFactory> surface_factory_;
+
+  // Belong to gpu process if exists.
+  std::unique_ptr<WaylandNestedCompositorClient> nested_compositor_client_;
 
 #if BUILDFLAG(USE_XKBCOMMON)
   XkbEvdevCodes xkb_evdev_code_converter_;

--- a/ui/ozone/platform/wayland/wayland_connection.cc
+++ b/ui/ozone/platform/wayland/wayland_connection.cc
@@ -106,6 +106,11 @@ WaylandWindow* WaylandConnection::GetWindow(gfx::AcceleratedWidget widget) {
   return it == window_map_.end() ? nullptr : it->second;
 }
 
+WaylandWindow* WaylandConnection::GetLastWindow() {
+  DCHECK(!window_map_.empty());
+  return window_map_.rbegin()->second;
+}
+
 WaylandWindow* WaylandConnection::GetCurrentFocusedWindow() {
   for (auto entry : window_map_) {
     WaylandWindow* window = entry.second;

--- a/ui/ozone/platform/wayland/wayland_connection.h
+++ b/ui/ozone/platform/wayland/wayland_connection.h
@@ -49,6 +49,7 @@ class WaylandConnection : public PlatformEventSource,
   wl_data_device* data_device() { return data_device_->data_device(); }
 
   WaylandWindow* GetWindow(gfx::AcceleratedWidget widget);
+  WaylandWindow* GetLastWindow();
   WaylandWindow* GetCurrentFocusedWindow();
   WaylandWindow* GetCurrentKeyboardFocusedWindow();
   void AddWindow(gfx::AcceleratedWidget widget, WaylandWindow* window);

--- a/ui/ozone/platform/wayland/wayland_nested_compositor.cc
+++ b/ui/ozone/platform/wayland/wayland_nested_compositor.cc
@@ -1,0 +1,365 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/ozone/platform/wayland/wayland_nested_compositor.h"
+
+#include <wayland-client-protocol.h>
+#include <wayland-server-core.h>
+
+#include "base/files/file_path.h"
+#include "base/memory/ptr_util.h"
+#include "ui/gl/gl_context_egl.h"
+#include "ui/gl/gl_egl_api_implementation.h"
+#include "ui/gl/gl_gl_api_implementation.h"
+#include "ui/gl/gl_surface_egl.h"
+#include "ui/ozone/common/egl_util.h"
+#include "ui/ozone/platform/wayland/wayland_connection.h"
+#include "ui/ozone/platform/wayland/wayland_nested_surface.h"
+#include "ui/ozone/platform/wayland/wayland_window.h"
+
+namespace ui {
+
+namespace {
+
+// Default wayland socket name.
+constexpr base::FilePath::CharType kSocketName[] =
+    FILE_PATH_LITERAL("chromium-wayland-nested-compositor");
+
+#if !defined(PFNEGLBINDWAYLANDDISPLAYWL)
+typedef EGLBoolean (*PFNEGLBINDWAYLANDDISPLAYWL)(EGLDisplay,
+                                                 struct wl_display*);
+#endif
+
+#if !defined(PFNEGLUNBINDWAYLANDDISPLAYWL)
+typedef EGLBoolean (*PFNEGLUNBINDWAYLANDDISPLAYWL)(EGLDisplay,
+                                                   struct wl_display*);
+#endif
+
+#if !defined(PFNEGLQUERYWAYLANDBUFFERWL)
+typedef EGLBoolean (*PFNEGLQUERYWAYLANDBUFFERWL)(EGLDisplay,
+                                                 struct wl_resource*,
+                                                 EGLint attribute,
+                                                 EGLint* value);
+#endif
+
+#if !defined(PFNEGLCREATEIMAGEKHRPROC)
+typedef EGLImageKHR (*PFNEGLCREATEIMAGEKHRPROC)(EGLDisplay,
+                                                EGLContext,
+                                                EGLenum target,
+                                                EGLClientBuffer,
+                                                const EGLint* attribList);
+#endif
+
+#if !defined(PFNEGLDESTROYIMAGEKHRPROC)
+typedef EGLBoolean (*PFNEGLDESTROYIMAGEKHRPROC)(EGLDisplay, EGLImageKHR);
+#endif
+
+#if !defined(PFNGLEGLIMAGETARGETTEXTURE2DOESPROC)
+typedef void (*PFNGLEGLIMAGETARGETTEXTURE2DOESPROC)(GLenum target,
+                                                    GLeglImageOES);
+#endif
+
+#if !defined(PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWL)
+typedef struct wl_buffer*(EGLAPIENTRYP PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWL)(
+    EGLDisplay dpy,
+    EGLImageKHR image);
+#endif
+
+#ifndef EGL_WAYLAND_BUFFER_WL
+#define EGL_WAYLAND_BUFFER_WL 0x31D5 /* eglCreateImageKHR target */
+#endif
+
+static PFNEGLBINDWAYLANDDISPLAYWL bind_display;
+static PFNEGLUNBINDWAYLANDDISPLAYWL unbind_display;
+static PFNEGLQUERYWAYLANDBUFFERWL query_buffer;
+static PFNEGLCREATEIMAGEKHRPROC create_image;
+static PFNEGLDESTROYIMAGEKHRPROC destroy_image;
+static PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWL create_wayland_buffer_from_image;
+
+// TODO(msisov, tonikitoo, jkim): share these with exo server.
+template <class T>
+T* GetUserDataAs(struct wl_resource* resource) {
+  return static_cast<T*>(wl_resource_get_user_data(resource));
+}
+
+template <class T>
+std::unique_ptr<T> TakeUserDataAs(wl_resource* resource) {
+  std::unique_ptr<T> user_data = base::WrapUnique(GetUserDataAs<T>(resource));
+  wl_resource_set_user_data(resource, nullptr);
+  return user_data;
+}
+
+template <class T>
+void DestroyUserData(wl_resource* resource) {
+  TakeUserDataAs<T>(resource);
+}
+
+template <class T>
+void SetImplementation(wl_resource* resource,
+                       const void* implementation,
+                       std::unique_ptr<T> user_data) {
+  wl_resource_set_implementation(resource, implementation, user_data.release(),
+                                 DestroyUserData<T>);
+}
+
+// ----------------------------------------------------------------------------
+// wl_surface_interface
+
+void surface_destroy(wl_client* client, wl_resource* resource) {
+  wl_resource_destroy(resource);
+}
+
+void surface_attach(wl_client* client,
+                    wl_resource* resource,
+                    wl_resource* buffer,
+                    int32_t x,
+                    int32_t y) {
+  GetUserDataAs<WaylandNestedSurface>(resource)->AttachBuffer(buffer);
+}
+
+void surface_damage(wl_client* client,
+                    wl_resource* resource,
+                    int32_t x,
+                    int32_t y,
+                    int32_t width,
+                    int32_t height) {}
+
+uint32_t TimeTicksToMilliseconds(base::TimeTicks ticks) {
+  return (ticks - base::TimeTicks()).InMilliseconds();
+}
+
+void HandleSurfaceFrameCallback(wl_resource* resource,
+                                base::TimeTicks frame_time) {
+  if (!frame_time.is_null()) {
+    wl_callback_send_done(resource, TimeTicksToMilliseconds(frame_time));
+    // TODO(msisov, reveman, tonikitoo): Remove this potentially blocking flush
+    // and instead watch the file descriptor to be ready for write without
+    // blocking.
+    wl_client_flush(wl_resource_get_client(resource));
+  }
+  wl_resource_destroy(resource);
+}
+
+void surface_frame(wl_client* client,
+                   wl_resource* resource,
+                   uint32_t callback) {
+  wl_resource* callback_resource =
+      wl_resource_create(client, &wl_callback_interface, 1, callback);
+
+  // base::Unretained is safe as the resource owns the callback.
+  auto cancelable_callback =
+      std::make_unique<base::CancelableCallback<void(base::TimeTicks)>>(
+          base::Bind(&HandleSurfaceFrameCallback,
+                     base::Unretained(callback_resource)));
+
+  GetUserDataAs<WaylandNestedSurface>(resource)->RequestFrameCallback(
+      cancelable_callback->callback());
+
+  SetImplementation(callback_resource, nullptr, std::move(cancelable_callback));
+}
+
+void surface_set_opaque_region(wl_client* client,
+                               wl_resource* resource,
+                               wl_resource* region_resource) {}
+
+void surface_set_input_region(wl_client* client,
+                              wl_resource* resource,
+                              wl_resource* region_resource) {}
+
+void surface_commit(wl_client* client, wl_resource* resource) {
+  GetUserDataAs<WaylandNestedSurface>(resource)->Commit();
+}
+
+const struct wl_surface_interface surface_implementation = {
+    surface_destroy,
+    surface_attach,
+    surface_damage,
+    surface_frame,
+    surface_set_opaque_region,
+    surface_set_input_region,
+    surface_commit,
+};
+
+// ----------------------------------------------------------------------------
+// wl_compositor_interface
+
+void compositor_create_surface(wl_client* client,
+                               wl_resource* resource,
+                               uint32_t id) {
+  WaylandNestedCompositor* compositor =
+      GetUserDataAs<WaylandNestedCompositor>(resource);
+
+  WaylandConnection* connection = compositor->connection();
+  WaylandWindow* window = connection->GetLastWindow();
+  CHECK(window);
+
+  std::unique_ptr<WaylandNestedSurface> nested_surface =
+      std::make_unique<WaylandNestedSurface>(compositor, window->surface());
+
+  wl_resource* surface_resource = wl_resource_create(
+      client, &wl_surface_interface, 1 /*TODO fix version */, id);
+
+  SetImplementation(surface_resource, &surface_implementation,
+                    std::move(nested_surface));
+}
+
+void compositor_create_region(wl_client* client,
+                              wl_resource* resource,
+                              uint32_t id) {}
+
+const struct wl_compositor_interface compositor_implementation = {
+    compositor_create_surface, compositor_create_region};
+
+constexpr uint32_t kMaxCompositorVersion = 3;
+
+void bind_compositor(wl_client* client,
+                     void* data,
+                     uint32_t version,
+                     uint32_t id) {
+  wl_resource* resource =
+      wl_resource_create(client, &wl_compositor_interface,
+                         std::min(version, kMaxCompositorVersion), id);
+
+  wl_resource_set_implementation(resource, &compositor_implementation, data,
+                                 nullptr);
+}
+
+}  // namespace
+
+WaylandNestedCompositor::WaylandNestedCompositor(WaylandConnection* connection)
+    : connection_(connection) {
+  CHECK(connection_);
+}
+
+WaylandNestedCompositor::~WaylandNestedCompositor() {
+  wl_display_destroy(wl_display_);
+}
+
+bool WaylandNestedCompositor::Initialize() {
+  wl_display_ = wl_display_create();
+  if (!wl_display_) {
+    LOG(ERROR) << "Failed to create Wayland display";
+    return false;
+  }
+
+  const std::string socket_name(kSocketName);
+  if (!AddSocket(socket_name.c_str())) {
+    LOG(ERROR) << "Failed to create Wayland socket";
+    return false;
+  }
+
+  wl_global_create(wl_display_, &wl_compositor_interface, kMaxCompositorVersion,
+                   this, bind_compositor);
+
+  if (InitializeEGL()) {
+    bind_display(egl_display_, wl_display_);
+    return true;
+  }
+  LOG(ERROR) << "Failed to initialize EGL.";
+
+  return false;
+}
+
+int WaylandNestedCompositor::GetFileDescriptor() const {
+  wl_event_loop* event_loop = wl_display_get_event_loop(wl_display_);
+  DCHECK(event_loop);
+  return wl_event_loop_get_fd(event_loop);
+}
+
+void WaylandNestedCompositor::Dispatch(base::TimeDelta timeout) {
+  wl_event_loop* event_loop = wl_display_get_event_loop(wl_display_);
+  DCHECK(event_loop);
+  wl_event_loop_dispatch(event_loop, timeout.InMilliseconds());
+}
+
+void WaylandNestedCompositor::Flush() {
+  wl_display_flush_clients(wl_display_);
+}
+
+wl_buffer* WaylandNestedCompositor::CreateWaylandBufferFromImage(
+    EGLImageKHR image) {
+  DCHECK(image);
+  return create_wayland_buffer_from_image(egl_display_, image);
+}
+
+void WaylandNestedCompositor::DestroyImage(EGLImageKHR image) {
+  DCHECK(image);
+  destroy_image(egl_display_, image);
+}
+
+EGLImageKHR WaylandNestedCompositor::CreateEGLImageKHRFromResource(
+    struct wl_resource* resource) {
+  DCHECK(resource);
+  return static_cast<EGLImageKHR*>(create_image(
+      egl_display_, EGL_NO_CONTEXT, EGL_WAYLAND_BUFFER_WL, resource, nullptr));
+}
+
+bool WaylandNestedCompositor::InitializeEGL() {
+  InitializeEGLBindings();
+  InitializeEGLDisplay();
+
+  gl_surface_ = gl::InitializeGLSurface(new gl::SurfacelessEGL(gfx::Size()));
+  gl_context_ = gl::InitializeGLContext(
+      new gl::GLContextEGL(nullptr), gl_surface_.get(), gl::GLContextAttribs());
+  CHECK(gl_context_);
+  make_current_.reset(
+      new ui::ScopedMakeCurrent(gl_context_.get(), gl_surface_.get()));
+
+  // TODO(msisov, tonikitoo): use extensions.
+  // const char* extensions = eglQueryString(egl_display_, EGL_EXTENSIONS);
+
+  // TODO: move these.
+  create_image = reinterpret_cast<PFNEGLCREATEIMAGEKHRPROC>(
+      eglGetProcAddress("eglCreateImage"));
+  destroy_image = reinterpret_cast<PFNEGLDESTROYIMAGEKHRPROC>(
+      eglGetProcAddress("eglDestroyImage"));
+
+  if (!create_image || !destroy_image) {
+    CHECK(false) << "Failed to image make interfaces";
+  }
+
+  bind_display = reinterpret_cast<PFNEGLBINDWAYLANDDISPLAYWL>(
+      eglGetProcAddress("eglBindWaylandDisplayWL"));
+  unbind_display = reinterpret_cast<PFNEGLUNBINDWAYLANDDISPLAYWL>(
+      eglGetProcAddress("eglUnbindWaylandDisplayWL"));
+  query_buffer = reinterpret_cast<PFNEGLQUERYWAYLANDBUFFERWL>(
+      eglGetProcAddress("eglQueryWaylandBufferWL"));
+
+  if (!bind_display || !unbind_display || !query_buffer) {
+    CHECK(false) << "Failed to make display and buffer interfaces";
+  }
+
+  create_wayland_buffer_from_image =
+      reinterpret_cast<PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWL>(
+          eglGetProcAddress("eglCreateWaylandBufferFromImageWL"));
+  CHECK(create_wayland_buffer_from_image);
+
+  return true;
+}
+
+void WaylandNestedCompositor::InitializeEGLBindings() {
+  setenv("EGL_PLATFORM", "wayland", 0);
+  LoadDefaultEGLGLES2Bindings(gl::kGLImplementationEGLGLES2);
+  gl::SetGLImplementation(gl::kGLImplementationEGLGLES2);
+  gl::InitializeStaticGLBindingsGL();
+  gl::InitializeStaticGLBindingsEGL();
+}
+
+void WaylandNestedCompositor::InitializeEGLDisplay() {
+  if (egl_display_ != EGL_NO_DISPLAY)
+    return;
+
+  EGLNativeDisplayType native_display =
+      reinterpret_cast<intptr_t>(connection_->display());
+  egl_display_ = gl::GLSurfaceEGL::InitializeDisplay(native_display);
+  if (egl_display_ == EGL_NO_DISPLAY)
+    CHECK(false) << "Cannot get default EGL display";
+}
+
+bool WaylandNestedCompositor::AddSocket(const std::string socket_name) {
+  DCHECK(!socket_name.empty());
+  return !wl_display_add_socket(wl_display_, socket_name.c_str());
+}
+
+}  // namespace ui

--- a/ui/ozone/platform/wayland/wayland_nested_compositor.h
+++ b/ui/ozone/platform/wayland/wayland_nested_compositor.h
@@ -1,0 +1,60 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/macros.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/time/time.h"
+#include "ui/gl/gl_bindings.h"
+#include "ui/gl/scoped_make_current.h"
+
+struct wl_buffer;
+struct wl_display;
+struct wl_resource;
+
+namespace ui {
+
+class WaylandConnection;
+
+class WaylandNestedCompositor {
+ public:
+  WaylandNestedCompositor(WaylandConnection* connection);
+  ~WaylandNestedCompositor();
+
+  bool Initialize();
+
+  int GetFileDescriptor() const;
+
+  void Dispatch(base::TimeDelta timeout);
+
+  void Flush();
+
+  wl_display* display() const { return wl_display_; }
+  EGLDisplay egl_display() const { return egl_display_; }
+  WaylandConnection* connection() const { return connection_; }
+
+  wl_buffer* CreateWaylandBufferFromImage(EGLImageKHR image);
+  void DestroyImage(EGLImageKHR image);
+  EGLImageKHR CreateEGLImageKHRFromResource(struct wl_resource* resource);
+
+ private:
+  // EGL initialization helper methods.
+  bool InitializeEGL();
+  void InitializeEGLBindings();
+  void InitializeEGLDisplay();
+
+  bool AddSocket(const std::string socket_name);
+
+  wl_display* wl_display_ = nullptr;
+
+  WaylandConnection* connection_;  // non-owned primary client connection.
+
+  EGLDisplay egl_display_ = EGL_NO_DISPLAY;
+  scoped_refptr<gl::GLSurface> gl_surface_;
+  scoped_refptr<gl::GLContext> gl_context_;
+  std::unique_ptr<ui::ScopedMakeCurrent> make_current_;
+
+  DISALLOW_COPY_AND_ASSIGN(WaylandNestedCompositor);
+};
+
+}  // namespace ui

--- a/ui/ozone/platform/wayland/wayland_nested_compositor_client.cc
+++ b/ui/ozone/platform/wayland/wayland_nested_compositor_client.cc
@@ -1,0 +1,98 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/ozone/platform/wayland/wayland_nested_compositor_client.h"
+
+#include <wayland-client.h>
+
+#include "base/files/file_path.h"
+
+namespace ui {
+
+namespace {
+
+constexpr uint32_t kMaxCompositorVersion = 3;
+
+// Default wayland socket name.
+constexpr base::FilePath::CharType kSocketName[] =
+    FILE_PATH_LITERAL("chromium-wayland-nested-compositor");
+
+}  // namespace
+
+WaylandNestedCompositorClient::WaylandNestedCompositorClient() = default;
+
+WaylandNestedCompositorClient::~WaylandNestedCompositorClient() = default;
+
+bool WaylandNestedCompositorClient::Initialize() {
+  static const wl_registry_listener registry_listener = {
+      &WaylandNestedCompositorClient::Global,
+      &WaylandNestedCompositorClient::GlobalRemove};
+
+  const std::string socket_name(kSocketName);
+  wl_display_.reset(wl_display_connect(socket_name.c_str()));
+
+  if (!wl_display_) {
+    LOG(ERROR) << "Failed to connect to Wayland display on " << socket_name
+               << " socket.";
+    return false;
+  }
+
+  registry_.reset(wl_display_get_registry(wl_display_.get()));
+  if (!registry_) {
+    LOG(ERROR) << "Failed to get Wayland registry.";
+    return false;
+  }
+
+  wl_registry_add_listener(registry_.get(), &registry_listener, this);
+  wl_display_roundtrip(wl_display_.get());
+
+  if (!compositor_) {
+    LOG(ERROR) << "Failed to get wl_compositor object.";
+    return false;
+  }
+
+  return true;
+}
+
+wl_surface* WaylandNestedCompositorClient::CreateOrGetSurface() {
+  if (!wl_surface_) {
+    wl_surface_.reset(wl_compositor_create_surface(compositor_.get()));
+    if (!wl_surface_)
+      CHECK(false) << "Failed to create wl_surface";
+  }
+
+  Flush();
+
+  return wl_surface_.get();
+}
+
+void WaylandNestedCompositorClient::Flush() {
+  // TODO: maybe use message pump instead.
+  wl_display_flush(wl_display_.get());
+}
+
+// static
+void WaylandNestedCompositorClient::Global(void* data,
+                                           wl_registry* registry,
+                                           uint32_t name,
+                                           const char* interface,
+                                           uint32_t version) {
+  WaylandNestedCompositorClient* client =
+      static_cast<WaylandNestedCompositorClient*>(data);
+  if (!client->compositor_ && strcmp(interface, "wl_compositor") == 0) {
+    client->compositor_ = wl::Bind<wl_compositor>(
+        registry, name, std::min(version, kMaxCompositorVersion));
+    if (!client->compositor_)
+      LOG(ERROR) << "Failed to bind to wl_compositor global.";
+  }
+}
+
+// static
+void WaylandNestedCompositorClient::GlobalRemove(void* data,
+                                                 wl_registry* registry,
+                                                 uint32_t name) {
+  NOTIMPLEMENTED();
+}
+
+}  // namespace ui

--- a/ui/ozone/platform/wayland/wayland_nested_compositor_client.cc
+++ b/ui/ozone/platform/wayland/wayland_nested_compositor_client.cc
@@ -56,15 +56,18 @@ bool WaylandNestedCompositorClient::Initialize() {
 }
 
 wl_surface* WaylandNestedCompositorClient::CreateOrGetSurface() {
-  if (!wl_surface_) {
-    wl_surface_.reset(wl_compositor_create_surface(compositor_.get()));
-    if (!wl_surface_)
-      CHECK(false) << "Failed to create wl_surface";
-  }
+  wl::Object<wl_surface> wl_surface;
+  wl_surface.reset(wl_compositor_create_surface(compositor_.get()));
+  if (!wl_surface)
+    CHECK(false) << "Failed to create wl_surface";
 
   Flush();
 
-  return wl_surface_.get();
+  struct wl_surface* surface = wl_surface.get();
+  // TODO(msisov, tonikitoo): check for a listener, which is capabale of
+  // listening
+  surfaces_.push_back(std::move(wl_surface));
+  return surface;
 }
 
 void WaylandNestedCompositorClient::Flush() {

--- a/ui/ozone/platform/wayland/wayland_nested_compositor_client.h
+++ b/ui/ozone/platform/wayland/wayland_nested_compositor_client.h
@@ -1,0 +1,42 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/macros.h"
+#include "ui/gfx/native_widget_types.h"
+#include "ui/ozone/platform/wayland/wayland_object.h"
+
+namespace ui {
+
+class WaylandNestedCompositorClient {
+ public:
+  WaylandNestedCompositorClient();
+  ~WaylandNestedCompositorClient();
+
+  wl_display* display() { return wl_display_.get(); }
+
+  bool Initialize();
+
+  // Returns new surface. This cannot be called twice.
+  wl_surface* CreateOrGetSurface();
+
+ private:
+  void Flush();
+
+  static void Global(void* data,
+                     wl_registry* registry,
+                     uint32_t name,
+                     const char* interface,
+                     uint32_t version);
+  static void GlobalRemove(void* data, wl_registry* registry, uint32_t name);
+
+  wl::Object<wl_display> wl_display_;
+  wl::Object<wl_registry> registry_;
+  wl::Object<wl_compositor> compositor_;
+
+  wl::Object<wl_surface> wl_surface_;
+
+  DISALLOW_COPY_AND_ASSIGN(WaylandNestedCompositorClient);
+};
+
+}  // namespace ui

--- a/ui/ozone/platform/wayland/wayland_nested_compositor_client.h
+++ b/ui/ozone/platform/wayland/wayland_nested_compositor_client.h
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <vector>
+
 #include "base/macros.h"
 #include "ui/gfx/native_widget_types.h"
 #include "ui/ozone/platform/wayland/wayland_object.h"
@@ -34,7 +36,7 @@ class WaylandNestedCompositorClient {
   wl::Object<wl_registry> registry_;
   wl::Object<wl_compositor> compositor_;
 
-  wl::Object<wl_surface> wl_surface_;
+  std::vector<wl::Object<wl_surface>> surfaces_;
 
   DISALLOW_COPY_AND_ASSIGN(WaylandNestedCompositorClient);
 };

--- a/ui/ozone/platform/wayland/wayland_nested_compositor_watcher.cc
+++ b/ui/ozone/platform/wayland/wayland_nested_compositor_watcher.cc
@@ -1,0 +1,31 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/ozone/platform/wayland/wayland_nested_compositor_watcher.h"
+
+#include "ui/ozone/platform/wayland/wayland_nested_compositor.h"
+
+namespace ui {
+
+WaylandNestedCompositorWatcher::WaylandNestedCompositorWatcher(
+    WaylandNestedCompositor* nested_compositor)
+    : controller_(FROM_HERE), nested_compositor_(nested_compositor) {
+  base::MessageLoopForUI::current()->WatchFileDescriptor(
+      nested_compositor_->GetFileDescriptor(),
+      true,  // persistent
+      base::MessagePumpLibevent::WATCH_READ, &controller_, this);
+}
+
+WaylandNestedCompositorWatcher::~WaylandNestedCompositorWatcher() = default;
+
+void WaylandNestedCompositorWatcher::OnFileCanReadWithoutBlocking(int fd) {
+  nested_compositor_->Dispatch(base::TimeDelta());
+  nested_compositor_->Flush();
+}
+
+void WaylandNestedCompositorWatcher::OnFileCanWriteWithoutBlocking(int fd) {
+  NOTREACHED();
+}
+
+}  // namespace ui

--- a/ui/ozone/platform/wayland/wayland_nested_compositor_watcher.h
+++ b/ui/ozone/platform/wayland/wayland_nested_compositor_watcher.h
@@ -1,0 +1,35 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_NESTED_COMPOSITOR_WATCHER_H_
+#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_NESTED_COMPOSITOR_WATCHER_H_
+
+#include "base/macros.h"
+#include "base/message_loop/message_loop.h"
+
+namespace ui {
+
+class WaylandNestedCompositor;
+
+class WaylandNestedCompositorWatcher
+    : public base::MessagePumpLibevent::Watcher {
+ public:
+  explicit WaylandNestedCompositorWatcher(
+      WaylandNestedCompositor* nested_compositor);
+  ~WaylandNestedCompositorWatcher() override;
+
+  // base::MessagePumpLibevent::Watcher:
+  void OnFileCanReadWithoutBlocking(int fd) override;
+  void OnFileCanWriteWithoutBlocking(int fd) override;
+
+ private:
+  base::MessagePumpLibevent::FileDescriptorWatcher controller_;
+  WaylandNestedCompositor* nested_compositor_;  // non-owned.
+
+  DISALLOW_COPY_AND_ASSIGN(WaylandNestedCompositorWatcher);
+};
+
+}  // namespace ui
+
+#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_NESTED_COMPOSITOR_WATCHER_H_

--- a/ui/ozone/platform/wayland/wayland_nested_surface.cc
+++ b/ui/ozone/platform/wayland/wayland_nested_surface.cc
@@ -1,0 +1,178 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/ozone/platform/wayland/wayland_nested_surface.h"
+
+#include "ui/ozone/platform/wayland/wayland_connection.h"
+#include "ui/ozone/platform/wayland/wayland_nested_compositor.h"
+
+namespace ui {
+
+namespace {
+
+template <class T>
+T* GetUserDataAs(struct wl_resource* resource) {
+  return static_cast<T*>(wl_resource_get_user_data(resource));
+}
+
+}  // namespace
+
+WaylandNestedSurface::Buffer::Buffer(struct wl_resource* resource)
+    : resource_(resource) {
+  wl_list_init(&destroy_listener_.link);
+  destroy_listener_.notify = DestroyListenerCallback;
+  wl_resource_add_destroy_listener(resource_, &destroy_listener_);
+}
+
+WaylandNestedSurface::Buffer::~Buffer() {
+  wl_list_remove(&destroy_listener_.link);
+}
+
+// static
+WaylandNestedSurface::Buffer* WaylandNestedSurface::Buffer::GetBuffer(
+    struct wl_resource* resource) {
+  if (struct wl_listener* listener =
+          wl_resource_get_destroy_listener(resource, DestroyListenerCallback)) {
+    Buffer* buffer;
+    return wl_container_of(listener, buffer, destroy_listener_);
+  }
+  return new Buffer(resource);
+}
+
+void WaylandNestedSurface::Buffer::OnBufferAttach() {
+  ++attach_count_;
+}
+
+void WaylandNestedSurface::Buffer::OnBufferDetach() {
+  --attach_count_;
+  if (!attach_count_)
+    wl_resource_queue_event(resource_, WL_BUFFER_RELEASE);
+}
+
+// static
+void WaylandNestedSurface::Buffer::DestroyListenerCallback(
+    struct wl_listener* listener,
+    void* data) {
+  Buffer* buffer = wl_container_of(listener, buffer, destroy_listener_);
+  if (buffer)
+    delete buffer;
+}
+
+// WaylandNestedSurface --------------------------------------------------------
+
+WaylandNestedSurface::WaylandNestedSurface(WaylandNestedCompositor* compositor,
+                                           struct wl_surface* surface)
+    : compositor_(compositor),
+      image_(EGL_NO_IMAGE_KHR),
+      nested_surface_(surface) {
+  glGenTextures(1, &texture_);
+  glBindTexture(GL_TEXTURE_2D, texture_);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+}
+
+WaylandNestedSurface::~WaylandNestedSurface() {}
+
+void WaylandNestedSurface::AttachBuffer(struct wl_resource* buffer) {
+  if (buffer)
+    pending_buffer_ = Buffer::GetBuffer(buffer);
+}
+
+void WaylandNestedSurface::RequestFrameCallback(const FrameCallback& callback) {
+  pending_frame_callbacks_.push_back(callback);
+}
+
+void WaylandNestedSurface::Commit() {
+  static struct wl_callback_listener frame_listener = {
+      WaylandNestedSurface::OnFrameCallback};
+
+  static struct wl_buffer_listener buffer_listener = {
+      WaylandNestedSurface::OnBufferRelease};
+
+  if (!nested_surface_) {
+    LOG(ERROR) << "Nested surface is not available.";
+    return;
+  }
+
+  if (image_ != EGL_NO_IMAGE_KHR)
+    compositor_->DestroyImage(image_);
+
+  image_ = compositor_->CreateEGLImageKHRFromResource(
+      pending_buffer_->wl_resource());
+
+  MakePendingBufferCurrent();
+  MakePendingFrameCallbacksCurrent();
+
+  if (image_ == EGL_NO_IMAGE_KHR) {
+    FlushFrameCallbacks(base::TimeTicks().Now());
+    return;
+  }
+
+  // TODO(msisov, tonikitoo): instead of allocation thousands of buffers, reuse
+  // a released one. Check OnBufferRelease.
+  wl_buffer_ = compositor_->CreateWaylandBufferFromImage(image_);
+  DCHECK(wl_buffer_);
+  wl_surface_attach(nested_surface_, wl_buffer_, 0, 0);
+
+  wl_buffer_add_listener(wl_buffer_, &buffer_listener, this);
+
+  if (frame_callback_)
+    wl_callback_destroy(frame_callback_);
+  frame_callback_ = wl_surface_frame(nested_surface_);
+  wl_callback_add_listener(frame_callback_, &frame_listener, this);
+
+  wl_surface_commit(nested_surface_);
+
+  compositor_->connection()->ScheduleFlush();
+}
+
+void WaylandNestedSurface::MakePendingBufferCurrent() {
+  if (pending_buffer_ == buffer_)
+    return;
+
+  if (buffer_)
+    buffer_->OnBufferDetach();
+
+  if (pending_buffer_)
+    pending_buffer_->OnBufferAttach();
+
+  buffer_ = pending_buffer_;
+}
+
+void WaylandNestedSurface::FlushFrameCallbacks(base::TimeTicks time) {
+  std::list<FrameCallback> frame_callbacks;
+  frame_callbacks.splice(frame_callbacks.end(), frame_callbacks_);
+  frame_callbacks_.clear();
+  for (const auto& cb : frame_callbacks) {
+    cb.Run(time);
+  }
+}
+
+void WaylandNestedSurface::MakePendingFrameCallbacksCurrent() {
+  frame_callbacks_.splice(frame_callbacks_.end(), pending_frame_callbacks_);
+  pending_frame_callbacks_.clear();
+}
+
+// static
+void WaylandNestedSurface::OnFrameCallback(void* data,
+                                           struct wl_callback* callback,
+                                           uint32_t time) {
+  WaylandNestedSurface* surface = static_cast<WaylandNestedSurface*>(data);
+  surface->FlushFrameCallbacks(base::TimeTicks().Now());
+  if (callback)
+    wl_callback_destroy(callback);
+  surface->frame_callback_ = nullptr;
+}
+
+// static
+void WaylandNestedSurface::OnBufferRelease(void* data,
+                                           struct wl_buffer* wl_buffer) {
+  // TODO(msisov, tonikitoo): reuse buffer instead. See wl_buffer_listener
+  // documentation.
+  wl_buffer_destroy(wl_buffer);
+}
+
+}  // namespace ui

--- a/ui/ozone/platform/wayland/wayland_nested_surface.h
+++ b/ui/ozone/platform/wayland/wayland_nested_surface.h
@@ -1,0 +1,110 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_NESTED_SURFACE_H_
+#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_NESTED_SURFACE_H_
+
+#include <list>
+
+#include <wayland-server-protocol-core.h>
+
+#include "base/callback.h"
+#include "base/macros.h"
+#include "ui/gl/gl_bindings.h"
+
+namespace ui {
+
+class WaylandNestedCompositor;
+
+// This is a representation of wayland surface, which nested compositor creates.
+// The WaylandNestedSurface is mapped to certain wl_surface created by
+// WaylandWindow, and a buffer is attached to it. Once new contents are
+// committed from gpu, this surface signals host compositor about new contents
+// to be drawn.
+class WaylandNestedSurface {
+ public:
+  WaylandNestedSurface(WaylandNestedCompositor* compositor,
+                       struct wl_surface* surface);
+  ~WaylandNestedSurface();
+
+  // Attaches a new WaylandNestedSurface::Buffer linked to |buffer| to this
+  // surface.
+  void AttachBuffer(struct wl_resource* buffer);
+
+  // Sets |callback| to |pending_frame_callbacks_|.
+  using FrameCallback = base::Callback<void(base::TimeTicks frame_time)>;
+  void RequestFrameCallback(const FrameCallback& callback);
+
+  // Creates an EGLImageKHR out of the wl_resource buffer contents and commits
+  // the data to host compositor, which draws pixels.
+  void Commit();
+
+  void MakePendingBufferCurrent();
+
+  void FlushFrameCallbacks(base::TimeTicks time);
+
+  void MakePendingFrameCallbacksCurrent();
+
+ private:
+  // A buffer abstraction, which represents clients' buffer contents via
+  // wl_resource.
+  class Buffer {
+   public:
+    Buffer(struct wl_resource* resource);
+    ~Buffer();
+
+    // Gets already created buffer or creates a new one based on |resource|.
+    static Buffer* GetBuffer(struct wl_resource* resource);
+
+    void OnBufferAttach();
+
+    void OnBufferDetach();
+
+    struct wl_resource* wl_resource() { return resource_; }
+
+   private:
+    static void DestroyListenerCallback(struct wl_listener* listener,
+                                        void* data);
+
+    // A pointer to a buffer resource, which clients holds and renders to. It's
+    // used to create an EGL image and commit the contents to host compositor.
+    struct wl_resource* resource_ = nullptr;
+    struct wl_listener destroy_listener_;
+
+    uint32_t attach_count_ = 0;
+
+    DISALLOW_COPY_AND_ASSIGN(Buffer);
+  };
+
+  static void OnFrameCallback(void* data,
+                              struct wl_callback* callback,
+                              uint32_t time);
+
+  static void OnBufferRelease(void* data, struct wl_buffer* wl_buffer);
+
+  WaylandNestedCompositor* compositor_ = nullptr;
+
+  unsigned texture_;
+  EGLImageKHR image_;
+
+  // Hold client's frame callbacks.
+  std::list<FrameCallback> pending_frame_callbacks_;
+  std::list<FrameCallback> frame_callbacks_;
+
+  Buffer* buffer_ = nullptr;
+  Buffer* pending_buffer_ = nullptr;
+
+  struct wl_buffer* wl_buffer_ = nullptr;
+  struct wl_callback* frame_callback_ = nullptr;
+
+  // This wl_surface represents a real wayland surface this nested surface is
+  // mapped to. wl_buffer is attached to this surface.
+  struct wl_surface* nested_surface_ = nullptr;
+
+  DISALLOW_COPY_AND_ASSIGN(WaylandNestedSurface);
+};
+
+}  // namespace ui
+
+#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_NESTED_SURFACE_H_

--- a/ui/ozone/platform/wayland/wayland_surface_factory.cc
+++ b/ui/ozone/platform/wayland/wayland_surface_factory.cc
@@ -21,6 +21,10 @@
 #include "ui/ozone/platform/wayland/wayland_window.h"
 #include "ui/ozone/public/surface_ozone_canvas.h"
 
+#include "ui/gl/gl_bindings.h"
+
+#include "ui/ozone/platform/wayland/wayland_nested_compositor_client.h"
+
 namespace ui {
 
 static void DeleteSharedMemory(void* pixels, void* context) {
@@ -131,6 +135,8 @@ class GLOzoneEGLWayland : public GLOzoneEGL {
  public:
   explicit GLOzoneEGLWayland(WaylandConnection* connection)
       : connection_(connection) {}
+  explicit GLOzoneEGLWayland(WaylandNestedCompositorClient* client)
+      : client_(client) {}
   ~GLOzoneEGLWayland() override {}
 
   scoped_refptr<gl::GLSurface> CreateViewGLSurface(
@@ -144,21 +150,18 @@ class GLOzoneEGLWayland : public GLOzoneEGL {
   bool LoadGLES2Bindings(gl::GLImplementation impl) override;
 
  private:
-  WaylandConnection* connection_;
+  WaylandNestedCompositorClient* client_ = nullptr;
+  WaylandConnection* connection_ = nullptr;
 
   DISALLOW_COPY_AND_ASSIGN(GLOzoneEGLWayland);
 };
 
 scoped_refptr<gl::GLSurface> GLOzoneEGLWayland::CreateViewGLSurface(
     gfx::AcceleratedWidget widget) {
-  DCHECK(connection_);
-  WaylandWindow* window = connection_->GetWindow(widget);
-  DCHECK(window);
-  // The wl_egl_window needs to be created before the GLSurface so it can be
-  // used in the GLSurface constructor.
-  auto egl_window = CreateWaylandEglWindow(window);
-  if (!egl_window)
-    return nullptr;
+  wl_surface* surface = client_ ? client_->CreateOrGetSurface()
+                                : connection_->GetWindow(widget)->surface();
+  DCHECK(surface);
+  auto egl_window = CreateWaylandEglWindow(surface);
   return gl::InitializeGLSurface(new GLSurfaceWayland(std::move(egl_window)));
 }
 
@@ -173,7 +176,8 @@ scoped_refptr<gl::GLSurface> GLOzoneEGLWayland::CreateOffscreenGLSurface(
 }
 
 intptr_t GLOzoneEGLWayland::GetNativeDisplay() {
-  return reinterpret_cast<intptr_t>(connection_->display());
+  return client_ ? reinterpret_cast<intptr_t>(client_->display())
+                 : reinterpret_cast<intptr_t>(connection_->display());
 }
 
 bool GLOzoneEGLWayland::LoadGLES2Bindings(gl::GLImplementation impl) {
@@ -192,10 +196,19 @@ WaylandSurfaceFactory::WaylandSurfaceFactory(WaylandConnection* connection)
     egl_implementation_ = std::make_unique<GLOzoneEGLWayland>(connection_);
 }
 
+WaylandSurfaceFactory::WaylandSurfaceFactory(
+    WaylandNestedCompositorClient* client)
+    : client_(client),
+      osmesa_implementation_(std::make_unique<GLOzoneOSMesa>()) {
+  if (client_)
+    egl_implementation_ = std::make_unique<GLOzoneEGLWayland>(client_);
+}
+
 WaylandSurfaceFactory::~WaylandSurfaceFactory() {}
 
 std::unique_ptr<SurfaceOzoneCanvas>
 WaylandSurfaceFactory::CreateCanvasForWidget(gfx::AcceleratedWidget widget) {
+  CHECK(false);
   if (!connection_)
     return nullptr;
   WaylandWindow* window = connection_->GetWindow(widget);

--- a/ui/ozone/platform/wayland/wayland_surface_factory.h
+++ b/ui/ozone/platform/wayland/wayland_surface_factory.h
@@ -13,10 +13,12 @@
 namespace ui {
 
 class WaylandConnection;
+class WaylandNestedCompositorClient;
 
 class WaylandSurfaceFactory : public SurfaceFactoryOzone {
  public:
   explicit WaylandSurfaceFactory(WaylandConnection* connection);
+  explicit WaylandSurfaceFactory(WaylandNestedCompositorClient* client);
   ~WaylandSurfaceFactory() override;
 
   // SurfaceFactoryOzone:
@@ -36,6 +38,8 @@ class WaylandSurfaceFactory : public SurfaceFactoryOzone {
       const gfx::NativePixmapHandle& handle) override;
 
  private:
+  WaylandNestedCompositorClient* client_;
+
   WaylandConnection* connection_;
   std::unique_ptr<GLOzone> egl_implementation_;
   std::unique_ptr<GLOzone> osmesa_implementation_;


### PR DESCRIPTION
This PR implements a nested compositor, which makes it possible to have a gpu service in a separate gpu process different from browser process, which holds original wayland connection.

WaylandNestedCompositor and WaylandNestedCompositorClient are implemented.
WaylandNestedCompositor implements wl_surface interface to serve WaylandNestedCompositorClient
with wl_surfaces, which internally mapped to WaylandWindow's wl_surfaces. Wayland EGL, which resides on gpu process, uses that wl_surface to create wayland egl surface and writes rendered contents to that surface buffer. Buffers are swapped on eglSwapBuffer call.

How WaylandNestedCompositor works internally for each frame: basically, it's a mini wayland surface with wl_surface interface. The core methods are wl_surface_frame, wl_surface_attach and wl_surface_commit.

On wl_surface_frame, a client asks compositor to notify it about next possibility when it can send a new frame. Internally, the compositor stores a callback into a list of callbacks, which is used later.

On wl_surface_attach, the compositor uses a buffer resource to allocate a new buffer instance if it doesn't exist. That is, the wl_resource buffer is mapped to internal buffer representation, which is used on wl_surface_commit method.

On wl_surface_commit, the compositor checks if there is a pending buffer and creates an EGLImageKHR from it (this logic can be improved by subscribing to wl_buffer_release callback from the host compositor, which will allow to reuse a buffer). Then, it gets a wl_buffer from that image and attaches it to the real wl_surface taken from WaylandWindow. Once it's attached, frame callback is requested and surface is committed.
Once a host compositor is done with a frame, it calls a frame callback, which the nested surface is subscribed to. On that call, it calls own frame callbacks and notifies a client on gpu side about possibility to handle a new frame.
