### PR TITLE
Deploy ozone-wayland-dev-r545691 rebase

### DIFF
--- a/services/ui/ws/display.h
+++ b/services/ui/ws/display.h
@@ -70,15 +70,15 @@ class Display : public PlatformDisplayDelegate,
   // Initialize the display's root window to host window manager content.
   void InitWindowManagerDisplayRoots();
 
-  // Returns the ID for this display. In internal mode this is the
-  // display::Display ID. In external mode this hasn't been defined yet.
-  int64_t GetId() const;
-
   // Sets the display::Display corresponding to this ws::Display.
   void SetDisplay(const display::Display& display);
 
   // PlatformDisplayDelegate:
   const display::Display& GetDisplay() override;
+
+  // Returns the ID for this display. In internal mode this is the
+  // display::Display ID. In external mode this hasn't been defined yet.
+  int64_t GetId() const override;
 
   const display::ViewportMetrics& GetViewportMetrics() const;
 

--- a/services/ui/ws/platform_display_default.cc
+++ b/services/ui/ws/platform_display_default.cc
@@ -67,10 +67,10 @@ void PlatformDisplayDefault::Init(PlatformDisplayDelegate* delegate) {
   const gfx::Rect& bounds = metrics_.bounds_in_pixels;
   DCHECK(!bounds.size().IsEmpty());
 
-  if (delegate_->GetDisplay().id() == display::kUnifiedDisplayId) {
+  if (delegate_->GetId() == display::kUnifiedDisplayId) {
     // Virtual unified displays use a StubWindow; see AshWindowTreeHostUnified.
     platform_window_ = std::make_unique<ui::StubWindow>(this, true, bounds);
-  } else if (delegate_->GetDisplay().id() == display::kInvalidDisplayId) {
+  } else if (delegate_->GetId() == display::kInvalidDisplayId) {
     // Unit tests may use kInvalidDisplayId to request a StubWindow for testing.
     platform_window_ = std::make_unique<ui::StubWindow>(this, false);
   } else {

--- a/services/ui/ws/platform_display_default_unittest.cc
+++ b/services/ui/ws/platform_display_default_unittest.cc
@@ -53,6 +53,7 @@ class TestPlatformDisplayDelegate : public PlatformDisplayDelegate {
 
   // PlatformDisplayDelegate:
   const display::Display& GetDisplay() override { return stub_display_; }
+  int64_t GetId() const override { return stub_display_.id(); }
   ServerWindow* GetRootWindow() override { return nullptr; }
   EventSink* GetEventSink() override { return sink_; }
   void OnAcceleratedWidgetAvailable() override {}

--- a/services/ui/ws/platform_display_delegate.h
+++ b/services/ui/ws/platform_display_delegate.h
@@ -25,6 +25,9 @@ class PlatformDisplayDelegate {
   // Returns a display::Display for this display.
   virtual const display::Display& GetDisplay() = 0;
 
+  // Returns a display::Display for this display.
+  virtual int64_t GetId() const = 0;
+
   // Returns the root window of this display.
   virtual ServerWindow* GetRootWindow() = 0;
 


### PR DESCRIPTION
fixup! Implement an unique identifier to be returned for ws::Display::GetId

CL makes it possible to query the ws::Display Id through the
PlatformDisplayDelegate interface. This allows PlatformDisplayDefault::Init
to take the "external window mode" ws::Display Id, rather than the "internal
window mode" display::Display Id. See [1] for details.

[1] https://github.com/Igalia/chromium/pull/297 (Implement an unique
identifier to be returned for ws::Display::GetId)