### PR TITLE
Even moar clipboard fixup's.

### DIFF
--- a/ui/ozone/platform/wayland/fake_server.cc
+++ b/ui/ozone/platform/wayland/fake_server.cc
@@ -715,7 +715,7 @@ void MockDataSource::DataReadCb(ReadDataCallback callback,
   std::move(callback).Run(data);
 }
 
-void MockDataSource::OnCancel() {
+void MockDataSource::OnCancelled() {
   wl_data_source_send_cancelled(resource());
 }
 

--- a/ui/ozone/platform/wayland/fake_server.h
+++ b/ui/ozone/platform/wayland/fake_server.h
@@ -174,7 +174,7 @@ class MockDataSource : public ServerObject {
       base::OnceCallback<void(const std::vector<uint8_t>&)>;
   void ReadData(ReadDataCallback);
 
-  void OnCancel();
+  void OnCancelled();
 
  private:
   void DataReadCb(ReadDataCallback callback, const std::vector<uint8_t>& data);

--- a/ui/ozone/platform/wayland/wayland_data_device.cc
+++ b/ui/ozone/platform/wayland/wayland_data_device.cc
@@ -30,9 +30,9 @@ WaylandDataDevice::WaylandDataDevice(WaylandConnection* connection,
 WaylandDataDevice::~WaylandDataDevice() {}
 
 void WaylandDataDevice::RequestSelectionData(const std::string& mime_type) {
-  int fd = selection_offer_->Receive(mime_type);
-  if (fd == -1) {
-    LOG(ERROR) << "Failed to open file descriptor";
+  base::ScopedFD fd = selection_offer_->Receive(mime_type);
+  if (!fd.is_valid()) {
+    LOG(ERROR) << "Failed to open file descriptor.";
     return;
   }
 
@@ -40,20 +40,19 @@ void WaylandDataDevice::RequestSelectionData(const std::string& mime_type) {
   // other read(..) can block awaiting data to be sent to pipe.
   read_from_fd_closure_ =
       base::BindOnce(&WaylandDataDevice::ReadClipboardDataFromFD,
-                     base::Unretained(this), fd, mime_type);
+                     base::Unretained(this), std::move(fd), mime_type);
   sync_callback_.reset(wl_display_sync(connection_->display()));
   wl_callback_add_listener(sync_callback_.get(), &callback_listener_, this);
   wl_display_flush(connection_->display());
 }
 
-void WaylandDataDevice::ReadClipboardDataFromFD(int fd,
+void WaylandDataDevice::ReadClipboardDataFromFD(base::ScopedFD fd,
                                                 const std::string& mime_type) {
   std::string contents;
   char buffer[1 << 10];  // 1 kB in bytes.
   ssize_t length;
-  while ((length = read(fd, buffer, sizeof(buffer))) > 0)
+  while ((length = read(fd.get(), buffer, sizeof(buffer))) > 0)
     contents.append(buffer, length);
-  close(fd);
 
   connection_->SetClipboardData(contents, mime_type);
 }

--- a/ui/ozone/platform/wayland/wayland_data_device.h
+++ b/ui/ozone/platform/wayland/wayland_data_device.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "base/callback.h"
+#include "base/files/scoped_file.h"
 #include "base/macros.h"
 #include "ui/ozone/platform/wayland/wayland_data_offer.h"
 #include "ui/ozone/platform/wayland/wayland_object.h"
@@ -31,7 +32,7 @@ class WaylandDataDevice {
   std::vector<std::string> GetAvailableMimeTypes();
 
  private:
-  void ReadClipboardDataFromFD(int fd, const std::string& mime_type);
+  void ReadClipboardDataFromFD(base::ScopedFD fd, const std::string& mime_type);
 
   // wl_data_device_listener callbacks
   static void OnDataOffer(void* data,

--- a/ui/ozone/platform/wayland/wayland_data_device_unittest.cc
+++ b/ui/ozone/platform/wayland/wayland_data_device_unittest.cc
@@ -11,12 +11,15 @@
 
 namespace ui {
 
+// This class mocks how a real clipboard/ozone client would
+// hook to ClipboardDelegate, with one difference: real clients
+// have no access to the WaylandConnection instance like this
+// MockClipboardClient impl does. Instead, clients and ozone gets
+// plumbbed up by calling the appropriated Ozone API,
+// OzonePlatform::GetClipboardDelegate.
 class MockClipboardClient {
  public:
   MockClipboardClient(WaylandConnection* connection) {
-    // Real clients have no access to the WaylandConnection instance like
-    // this MockClipboardClient impl does. Instead clients and ozone gets
-    // plumbbed up by calling the appropriated Ozone API.
     DCHECK(connection);
     delegate_ = connection->GetClipboardDelegate();
 
@@ -100,7 +103,7 @@ TEST_P(WaylandDataDeviceManagerTest, ReadFromClibpard) {
   data_device_manager_->data_device()->OnSelection(*data_offer);
   Sync();
 
-  // The client requests to read clipboard data from the server.
+  // The client requests to reading clipboard data from the server.
   // The Server writes in some sample data, and we check it matches
   // expectation.
   auto callback =
@@ -122,7 +125,7 @@ TEST_P(WaylandDataDeviceManagerTest, IsSelectionOwner) {
   // The compositor sends OnCancelled whenever another application
   // on the system sets a new selection. It means we are not the application
   // that owns the current selection data.
-  data_device_manager_->data_source()->OnCancel();
+  data_device_manager_->data_source()->OnCancelled();
   Sync();
 
   ASSERT_FALSE(clipboard_client_->IsSelectionOwner());

--- a/ui/ozone/platform/wayland/wayland_data_offer.cc
+++ b/ui/ozone/platform/wayland/wayland_data_offer.cc
@@ -19,6 +19,13 @@ const char kTextPlain[] = "text/plain";
 const char kTextPlainUtf8[] = "text/plain;charset=utf-8";
 const char kUtf8String[] = "UTF8_STRING";
 
+void CreatePipe(base::ScopedFD* read_pipe, base::ScopedFD* write_pipe) {
+  int raw_pipe[2];
+  PCHECK(0 == pipe(raw_pipe));
+  read_pipe->reset(raw_pipe[0]);
+  write_pipe->reset(raw_pipe[1]);
+}
+
 }  // namespace
 
 WaylandDataOffer::WaylandDataOffer(wl_data_offer* data_offer)
@@ -48,16 +55,14 @@ void WaylandDataOffer::EnsureTextMimeTypeIfNeeded() {
   }
 }
 
-int WaylandDataOffer::Receive(const std::string& mime_type) {
+base::ScopedFD WaylandDataOffer::Receive(const std::string& mime_type) {
   if (std::find(mime_types_.begin(), mime_types_.end(), mime_type) ==
       mime_types_.end())
-    return -1;
+    return base::ScopedFD();
 
-  int pipefd[2];
-  if (pipe2(pipefd, O_CLOEXEC) == -1) {
-    LOG(ERROR) << "Failed to create pipe: " << strerror(errno);
-    return -1;
-  }
+  base::ScopedFD read_fd;
+  base::ScopedFD write_fd;
+  CreatePipe(&read_fd, &write_fd);
 
   // If we needed to forcibly write "text/plain" as an available
   // mimetype, then it is safer to "read" the clipboard data with
@@ -68,10 +73,8 @@ int WaylandDataOffer::Receive(const std::string& mime_type) {
   }
 
   wl_data_offer_receive(data_offer_.get(), effective_mime_type.data(),
-                        pipefd[1]);
-  close(pipefd[1]);
-
-  return pipefd[0];
+                        write_fd.get());
+  return read_fd;
 }
 
 // static

--- a/ui/ozone/platform/wayland/wayland_data_offer.h
+++ b/ui/ozone/platform/wayland/wayland_data_offer.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "base/files/scoped_file.h"
 #include "base/macros.h"
 #include "ui/ozone/platform/wayland/wayland_object.h"
 
@@ -35,7 +36,7 @@ class WaylandDataOffer {
 
   // Receive data of type mime_type from another Wayland client. Returns
   // an open file descriptor to read the data from, or -1 on failure.
-  int Receive(const std::string& mime_type);
+  base::ScopedFD Receive(const std::string& mime_type);
 
  private:
   // wl_data_offer_listener callbacks.

--- a/ui/ozone/platform/wayland/wayland_data_source.cc
+++ b/ui/ozone/platform/wayland/wayland_data_source.cc
@@ -4,6 +4,7 @@
 
 #include "ui/ozone/platform/wayland/wayland_data_source.h"
 
+#include "base/files/file_util.h"
 #include "ui/ozone/platform/wayland/wayland_connection.h"
 
 namespace ui {
@@ -55,10 +56,8 @@ void WaylandDataSource::OnSend(void* data,
       strcmp(mime_type, "text/plain;charset=utf-8") == 0)
     self->GetClipboardData("text/plain", &mime_data);
 
-  std::string str(mime_data->begin(), mime_data->end());
-  if (write(fd, str.data(), str.length()) < 0)
-    LOG(ERROR) << "write failed: " << fd;
-
+  std::string contents(mime_data->begin(), mime_data->end());
+  DCHECK(base::WriteFileDescriptor(fd, contents.data(), contents.length()));
   close(fd);
 }
 


### PR DESCRIPTION
fixup! [ozone/wayland] Add clipboard support

Some more code improvements, in preparation for "primary selection"
support:

- raw fd -> base::ScopedFD
- raw calls to write() -> base::WriteFileDescriptor
- better comments on tests

This aligns the local code with the review from Rob (https://crrev.com/c/976461)

Issue #369