### PR TITLE
avoid 'declaration shadows a variable' warnings

### DIFF
--- a/content/browser/dom_storage/session_storage_data_map.cc
+++ b/content/browser/dom_storage/session_storage_data_map.cc
@@ -93,14 +93,11 @@ LevelDBWrapperImpl::Options SessionStorageDataMap::GetOptions() {
 
   // To avoid excessive IO we apply limits to the amount of data being
   // written and the frequency of writes.
-  const int kMaxBytesPerHour = kPerStorageAreaQuota;
-  const int kMaxCommitsPerHour = 60;
-
   LevelDBWrapperImpl::Options options;
   options.max_size = kPerStorageAreaQuota + kPerStorageAreaOverQuotaAllowance;
   options.default_commit_delay = kCommitDefaultDelaySecs;
-  options.max_bytes_per_hour = kMaxBytesPerHour;
-  options.max_commits_per_hour = kMaxCommitsPerHour;
+  options.max_bytes_per_hour = kPerStorageAreaQuota;
+  options.max_commits_per_hour = 60;
   options.cache_mode = LevelDBWrapperImpl::CacheMode::KEYS_ONLY_WHEN_POSSIBLE;
   return options;
 }


### PR DESCRIPTION
CL https://chromium-review.googlesource.com/c/chromium/src/+/1008824 added
two consts inside SessionStorageDataMap::GetOptions() that shadow existing
consts and generate warnigs in jumbo builds.  These consts were only
used once each, so we may as well just use the values directly.

TBR=dmurph@chromium.org

Bug: 716490
Change-Id: I09505a9df50ef6d3cc2bc002254027cd791cdcdf
Reviewed-on: https://chromium-review.googlesource.com/1013458
Reviewed-by: Daniel Bratell <bratell@opera.com>
Commit-Queue: Daniel Bratell <bratell@opera.com>
Cr-Commit-Position: refs/heads/master@{#551005}