### PR TITLE
[ozone/wayland] Fix minimize/maximize/fullscreen/restore support

### DIFF
--- a/chrome/browser/fullscreen_ozone.cc
+++ b/chrome/browser/fullscreen_ozone.cc
@@ -13,6 +13,7 @@ bool IsFullScreenMode() {
     return false;
   }
 
-  NOTREACHED() << "For Ozone builds, only mash launch is supported for now.";
+  // TODO(msisov, jkim): figure out why it is needed. We didn't
+  // implement it with mus/mash integration before.
   return false;
 }

--- a/ui/ozone/platform/drm/host/drm_window_host.cc
+++ b/ui/ozone/platform/drm/host/drm_window_host.cc
@@ -113,6 +113,18 @@ void DrmWindowHost::Minimize() {
 void DrmWindowHost::Restore() {
 }
 
+bool DrmWindowHost::IsFullscreen() const {
+  return false;
+}
+
+bool DrmWindowHost::IsMaximized() const {
+  return false;
+}
+
+bool DrmWindowHost::IsMinimized() const {
+  return false;
+}
+
 void DrmWindowHost::SetCursor(PlatformCursor cursor) {
   cursor_->SetCursor(widget_, cursor);
 }

--- a/ui/ozone/platform/drm/host/drm_window_host.h
+++ b/ui/ozone/platform/drm/host/drm_window_host.h
@@ -72,6 +72,9 @@ class DrmWindowHost : public PlatformWindow,
   void Maximize() override;
   void Minimize() override;
   void Restore() override;
+  bool IsFullscreen() const override;
+  bool IsMaximized() const override;
+  bool IsMinimized() const override;
   void SetCursor(PlatformCursor cursor) override;
   void MoveCursorTo(const gfx::Point& location) override;
   void ConfineCursorToBounds(const gfx::Rect& bounds) override;

--- a/ui/ozone/platform/headless/headless_window.cc
+++ b/ui/ozone/platform/headless/headless_window.cc
@@ -68,6 +68,18 @@ void HeadlessWindow::Minimize() {}
 
 void HeadlessWindow::Restore() {}
 
+bool HeadlessWindow::IsFullscreen() const {
+  return false;
+}
+
+bool HeadlessWindow::IsMaximized() const {
+  return false;
+}
+
+bool HeadlessWindow::IsMinimized() const {
+  return false;
+}
+
 void HeadlessWindow::SetCursor(PlatformCursor cursor) {}
 
 void HeadlessWindow::MoveCursorTo(const gfx::Point& location) {}

--- a/ui/ozone/platform/headless/headless_window.h
+++ b/ui/ozone/platform/headless/headless_window.h
@@ -37,6 +37,9 @@ class HeadlessWindow : public PlatformWindow {
   void Maximize() override;
   void Minimize() override;
   void Restore() override;
+  bool IsFullscreen() const override;
+  bool IsMaximized() const override;
+  bool IsMinimized() const override;
   void SetCursor(PlatformCursor cursor) override;
   void MoveCursorTo(const gfx::Point& location) override;
   void ConfineCursorToBounds(const gfx::Rect& bounds) override;

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -194,8 +194,6 @@ void WaylandWindow::Maximize() {
 
 void WaylandWindow::Minimize() {
   DCHECK(xdg_surface_);
-
-  DCHECK(xdg_surface_);
   xdg_surface_->SetMinimized();
   connection_->ScheduleFlush();
 
@@ -203,6 +201,7 @@ void WaylandWindow::Minimize() {
   // here. We can track if the window was unminimized once wayland sends the
   // window is activated, and the previous state was minimized.
   state_ = PlatformWindowState::PLATFORM_WINDOW_STATE_MINIMIZED;
+  delegate_->OnWindowStateChanged(state_);
 }
 
 void WaylandWindow::Restore() {

--- a/ui/ozone/platform/wayland/wayland_window.h
+++ b/ui/ozone/platform/wayland/wayland_window.h
@@ -73,6 +73,9 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
   void Maximize() override;
   void Minimize() override;
   void Restore() override;
+  bool IsMinimized() const override;
+  bool IsMaximized() const override;
+  bool IsFullscreen() const override;
   void SetCursor(PlatformCursor cursor) override;
   void MoveCursorTo(const gfx::Point& location) override;
   void ConfineCursorToBounds(const gfx::Rect& bounds) override;
@@ -91,10 +94,6 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
   void OnCloseRequest();
 
  private:
-  bool IsMinimized() const;
-  bool IsMaximized() const;
-  bool IsFullscreen() const;
-
   void SetPendingBounds(int32_t width, int32_t height);
 
   // Creates a surface window, which is visible as a main window.

--- a/ui/platform_window/platform_window.h
+++ b/ui/platform_window/platform_window.h
@@ -51,6 +51,9 @@ class PlatformWindow {
   virtual void Maximize() = 0;
   virtual void Minimize() = 0;
   virtual void Restore() = 0;
+  virtual bool IsFullscreen() const = 0;
+  virtual bool IsMaximized() const = 0;
+  virtual bool IsMinimized() const = 0;
 
   virtual void SetCursor(PlatformCursor cursor) = 0;
 

--- a/ui/platform_window/stub/stub_window.cc
+++ b/ui/platform_window/stub/stub_window.cc
@@ -69,6 +69,18 @@ void StubWindow::Minimize() {
 void StubWindow::Restore() {
 }
 
+bool StubWindow::IsFullscreen() const {
+  return false;
+}
+
+bool StubWindow::IsMaximized() const {
+  return false;
+}
+
+bool StubWindow::IsMinimized() const {
+  return false;
+}
+
 void StubWindow::SetCursor(PlatformCursor cursor) {
 }
 

--- a/ui/platform_window/stub/stub_window.h
+++ b/ui/platform_window/stub/stub_window.h
@@ -41,6 +41,9 @@ class STUB_WINDOW_EXPORT StubWindow : public PlatformWindow {
   void Maximize() override;
   void Minimize() override;
   void Restore() override;
+  bool IsFullscreen() const override;
+  bool IsMaximized() const override;
+  bool IsMinimized() const override;
   void SetCursor(PlatformCursor cursor) override;
   void MoveCursorTo(const gfx::Point& location) override;
   void ConfineCursorToBounds(const gfx::Rect& bounds) override;

--- a/ui/platform_window/x11/x11_window_base.h
+++ b/ui/platform_window/x11/x11_window_base.h
@@ -44,6 +44,9 @@ class X11_WINDOW_EXPORT X11WindowBase : public PlatformWindow {
   void Maximize() override;
   void Minimize() override;
   void Restore() override;
+  bool IsMinimized() const override;
+  bool IsMaximized() const override;
+  bool IsFullscreen() const override;
   void MoveCursorTo(const gfx::Point& location) override;
   void ConfineCursorToBounds(const gfx::Rect& bounds) override;
   PlatformImeController* GetPlatformImeController() override;
@@ -69,10 +72,6 @@ class X11_WINDOW_EXPORT X11WindowBase : public PlatformWindow {
  private:
   // Called when WM_STATE property is changed.
   void OnWMStateUpdated();
-
-  bool IsMinimized() const;
-  bool IsMaximized() const;
-  bool IsFullscreen() const;
 
   PlatformWindowDelegate* const delegate_;
 

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
@@ -259,15 +259,11 @@ void DesktopWindowTreeHostPlatform::Restore() {
 }
 
 bool DesktopWindowTreeHostPlatform::IsMaximized() const {
-  // TODO: needs PlatformWindow support.
-  NOTIMPLEMENTED_LOG_ONCE();
-  return false;
+  return platform_window()->IsMaximized();
 }
 
 bool DesktopWindowTreeHostPlatform::IsMinimized() const {
-  // TODO: needs PlatformWindow support.
-  NOTIMPLEMENTED_LOG_ONCE();
-  return false;
+  return platform_window()->IsMinimized();
 }
 
 bool DesktopWindowTreeHostPlatform::HasCapture() const {
@@ -342,14 +338,12 @@ bool DesktopWindowTreeHostPlatform::ShouldWindowContentsBeTransparent() const {
 void DesktopWindowTreeHostPlatform::FrameTypeChanged() {}
 
 void DesktopWindowTreeHostPlatform::SetFullscreen(bool fullscreen) {
-  // TODO: needs PlatformWindow support.
-  NOTIMPLEMENTED_LOG_ONCE();
+  if (IsFullscreen() != fullscreen)
+    platform_window()->ToggleFullscreen();
 }
 
 bool DesktopWindowTreeHostPlatform::IsFullscreen() const {
-  // TODO: needs PlatformWindow support.
-  NOTIMPLEMENTED_LOG_ONCE();
-  return false;
+  return platform_window()->IsFullscreen();
 }
 
 void DesktopWindowTreeHostPlatform::SetOpacity(float opacity) {
@@ -411,6 +405,23 @@ void DesktopWindowTreeHostPlatform::OnClosed() {
   desktop_native_widget_aura_->OnHostClosed();
 }
 
+void DesktopWindowTreeHostPlatform::OnWindowStateChanged(
+    ui::PlatformWindowState new_state) {
+  // Propagate minimization/restore to compositor to avoid drawing 'blank'
+  // frames that could be treated as previews, which show content even if a
+  // window is minimized.
+  bool visible =
+      new_state != ui::PlatformWindowState::PLATFORM_WINDOW_STATE_MINIMIZED;
+  if (visible != compositor()->IsVisible()) {
+    compositor()->SetVisible(visible);
+    native_widget_delegate_->OnNativeWidgetVisibilityChanged(visible);
+  }
+
+  // It might require relayouting when state property has been changed.
+  if (visible)
+    Relayout();
+}
+
 void DesktopWindowTreeHostPlatform::OnCloseRequest() {
   GetWidget()->Close();
 }
@@ -419,6 +430,17 @@ void DesktopWindowTreeHostPlatform::OnActivationChanged(bool active) {
   is_active_ = active;
   aura::WindowTreeHostPlatform::OnActivationChanged(active);
   desktop_native_widget_aura_->HandleActivationChanged(active);
+}
+
+void DesktopWindowTreeHostPlatform::Relayout() {
+  Widget* widget = native_widget_delegate_->AsWidget();
+  NonClientView* non_client_view = widget->non_client_view();
+  // non_client_view may be NULL, especially during creation.
+  if (non_client_view) {
+    non_client_view->client_view()->InvalidateLayout();
+    non_client_view->InvalidateLayout();
+  }
+  widget->GetRootView()->Layout();
 }
 
 Widget* DesktopWindowTreeHostPlatform::GetWidget() {

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.h
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.h
@@ -90,10 +90,13 @@ class VIEWS_EXPORT DesktopWindowTreeHostPlatform
 
   // WindowTreeHostPlatform:
   void OnClosed() override;
+  void OnWindowStateChanged(ui::PlatformWindowState new_state) override;
   void OnCloseRequest() override;
   void OnActivationChanged(bool active) override;
 
  private:
+  void Relayout();
+
   Widget* GetWidget();
 
   internal::NativeWidgetDelegate* const native_widget_delegate_;


### PR DESCRIPTION
This commit adds IsMinimized/IsMaximized/IsFullscreen to
PlatformWindow and makes DesktopWindowTreeHostPlatform use it.

What is more, DesktopWindowTreeHostPlatform also updates
compositor's visibility based on OnWindowStateChanged's
ui::PlatformWindowState, and does relayouting to update
OpaqueBrowserFrameView's buttons.

Issue: #420