### PR TITLE
[ozone/wayland/x11] Make window interactions (move, resize, double click and etc) working

### DIFF
--- a/ui/ozone/platform/drm/host/drm_window_host.cc
+++ b/ui/ozone/platform/drm/host/drm_window_host.cc
@@ -145,6 +145,9 @@ PlatformImeController* DrmWindowHost::GetPlatformImeController() {
   return nullptr;
 }
 
+void DrmWindowHost::StartWindowMoveOrResize(int hittest,
+                                            gfx::Point pointer_location) {}
+
 bool DrmWindowHost::CanDispatchEvent(const PlatformEvent& event) {
   DCHECK(event);
 

--- a/ui/ozone/platform/drm/host/drm_window_host.h
+++ b/ui/ozone/platform/drm/host/drm_window_host.h
@@ -79,6 +79,8 @@ class DrmWindowHost : public PlatformWindow,
   void MoveCursorTo(const gfx::Point& location) override;
   void ConfineCursorToBounds(const gfx::Rect& bounds) override;
   PlatformImeController* GetPlatformImeController() override;
+  void StartWindowMoveOrResize(int hittest,
+                               gfx::Point pointer_location) override;
 
   // PlatformEventDispatcher:
   bool CanDispatchEvent(const PlatformEvent& event) override;

--- a/ui/ozone/platform/headless/headless_window.cc
+++ b/ui/ozone/platform/headless/headless_window.cc
@@ -90,4 +90,7 @@ PlatformImeController* HeadlessWindow::GetPlatformImeController() {
   return nullptr;
 }
 
+void HeadlessWindow::StartWindowMoveOrResize(int hittest,
+                                             gfx::Point pointer_location) {}
+
 }  // namespace ui

--- a/ui/ozone/platform/headless/headless_window.h
+++ b/ui/ozone/platform/headless/headless_window.h
@@ -44,6 +44,8 @@ class HeadlessWindow : public PlatformWindow {
   void MoveCursorTo(const gfx::Point& location) override;
   void ConfineCursorToBounds(const gfx::Rect& bounds) override;
   PlatformImeController* GetPlatformImeController() override;
+  void StartWindowMoveOrResize(int hittest,
+                               gfx::Point pointer_location) override;
 
  private:
   PlatformWindowDelegate* delegate_;

--- a/ui/ozone/platform/wayland/wayland_connection.cc
+++ b/ui/ozone/platform/wayland/wayland_connection.cc
@@ -168,6 +168,11 @@ bool WaylandConnection::IsSelectionOwner() {
   return !!data_source_;
 }
 
+void WaylandConnection::ResetPointerFlags() {
+  if (pointer_)
+    pointer_->ResetFlags();
+}
+
 void WaylandConnection::GetAvailableMimeTypes(
     ClipboardDelegate::GetMimeTypesClosure callback) {
   std::move(callback).Run(data_device_->GetAvailableMimeTypes());

--- a/ui/ozone/platform/wayland/wayland_connection.h
+++ b/ui/ozone/platform/wayland/wayland_connection.h
@@ -82,6 +82,13 @@ class WaylandConnection : public PlatformEventSource,
       ClipboardDelegate::GetMimeTypesClosure callback) override;
   bool IsSelectionOwner() override;
 
+  // Resets flags and keyboard modifiers.
+  //
+  // This method is specially handy for cases when the WaylandPointer state is
+  // modified by a POINTER_DOWN event, but the respective POINTER_UP event is
+  // not delivered.
+  void ResetPointerFlags();
+
  private:
   void Flush();
   void DispatchUiEvent(Event* event);

--- a/ui/ozone/platform/wayland/wayland_pointer.cc
+++ b/ui/ozone/platform/wayland/wayland_pointer.cc
@@ -204,4 +204,9 @@ int WaylandPointer::GetFlagsWithKeyboardModifiers() {
   return flags_;
 }
 
+void WaylandPointer::ResetFlags() {
+  flags_ = 0;
+  keyboard_modifiers_ = 0;
+}
+
 }  // namespace ui

--- a/ui/ozone/platform/wayland/wayland_pointer.h
+++ b/ui/ozone/platform/wayland/wayland_pointer.h
@@ -26,6 +26,7 @@ class WaylandPointer {
   }
 
   int GetFlagsWithKeyboardModifiers();
+  void ResetFlags();
 
   WaylandCursor* cursor() { return cursor_.get(); }
 

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -8,6 +8,7 @@
 
 #include "base/bind.h"
 #include "ui/base/cursor/ozone/bitmap_cursor_factory_ozone.h"
+#include "ui/base/hit_test.h"
 #include "ui/events/event.h"
 #include "ui/events/ozone/events_ozone.h"
 #include "ui/ozone/platform/wayland/wayland_connection.h"
@@ -241,6 +242,18 @@ void WaylandWindow::ConfineCursorToBounds(const gfx::Rect& bounds) {
 PlatformImeController* WaylandWindow::GetPlatformImeController() {
   NOTIMPLEMENTED();
   return nullptr;
+}
+
+void WaylandWindow::StartWindowMoveOrResize(int hittest,
+                                            gfx::Point pointer_location) {
+  DCHECK(xdg_surface_);
+
+  connection_->ResetPointerFlags();
+
+  if (hittest == HTCAPTION)
+    xdg_surface_->SurfaceMove(connection_);
+  else
+    xdg_surface_->SurfaceResize(connection_, hittest);
 }
 
 bool WaylandWindow::CanDispatchEvent(const PlatformEvent& event) {

--- a/ui/ozone/platform/wayland/wayland_window.h
+++ b/ui/ozone/platform/wayland/wayland_window.h
@@ -80,6 +80,8 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
   void MoveCursorTo(const gfx::Point& location) override;
   void ConfineCursorToBounds(const gfx::Rect& bounds) override;
   PlatformImeController* GetPlatformImeController() override;
+  void StartWindowMoveOrResize(int hittest,
+                               gfx::Point pointer_location) override;
 
   // PlatformEventDispatcher
   bool CanDispatchEvent(const PlatformEvent& event) override;

--- a/ui/ozone/platform/wayland/xdg_surface_wrapper_v5.cc
+++ b/ui/ozone/platform/wayland/xdg_surface_wrapper_v5.cc
@@ -7,10 +7,51 @@
 #include <xdg-shell-unstable-v5-client-protocol.h>
 
 #include "base/strings/utf_string_conversions.h"
+#include "ui/base/hit_test.h"
 #include "ui/ozone/platform/wayland/wayland_connection.h"
 #include "ui/ozone/platform/wayland/wayland_window.h"
 
 namespace ui {
+
+namespace {
+
+// Identifies the direction of the "hittest" for Wayland.
+bool IdentifyDirection(int hittest, int* direction) {
+  DCHECK(direction);
+  *direction = -1;
+  switch (hittest) {
+    case HTBOTTOM:
+      *direction = xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_BOTTOM;
+      break;
+    case HTBOTTOMLEFT:
+      *direction = xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_BOTTOM_LEFT;
+      break;
+    case HTBOTTOMRIGHT:
+      *direction =
+          xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_BOTTOM_RIGHT;
+      break;
+    case HTLEFT:
+      *direction = xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_LEFT;
+      break;
+    case HTRIGHT:
+      *direction = xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_RIGHT;
+      break;
+    case HTTOP:
+      *direction = xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_TOP;
+      break;
+    case HTTOPLEFT:
+      *direction = xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_TOP_LEFT;
+      break;
+    case HTTOPRIGHT:
+      *direction = xdg_surface_resize_edge::XDG_SURFACE_RESIZE_EDGE_TOP_RIGHT;
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
+
+}  // namespace
 
 XDGSurfaceWrapperV5::XDGSurfaceWrapperV5(WaylandWindow* wayland_window)
     : wayland_window_(wayland_window) {}
@@ -52,20 +93,17 @@ void XDGSurfaceWrapperV5::SetMinimized() {
 }
 
 void XDGSurfaceWrapperV5::SurfaceMove(WaylandConnection* connection) {
-  NOTIMPLEMENTED();
+  xdg_surface_move(xdg_surface_.get(), connection->seat(),
+                   connection->serial());
 }
 
 void XDGSurfaceWrapperV5::SurfaceResize(WaylandConnection* connection,
                                         uint32_t hittest) {
-  // TODO(msisov): implement resizing.
-  /*
-   * int direction;
-   * if (!IdentifyDirection(hittest, &direction))
-   *   return;
-   * xdg_surface_resize(xdg_surface_.get(), connection->seat(),
-   *                    connection->serial(), direction);
-   */
-  NOTIMPLEMENTED();
+  int direction;
+  if (!IdentifyDirection(hittest, &direction))
+    return;
+  xdg_surface_resize(xdg_surface_.get(), connection->seat(),
+                     connection->serial(), direction);
 }
 
 void XDGSurfaceWrapperV5::SetTitle(const base::string16& title) {

--- a/ui/ozone/platform/wayland/xdg_surface_wrapper_v6.cc
+++ b/ui/ozone/platform/wayland/xdg_surface_wrapper_v6.cc
@@ -7,10 +7,58 @@
 #include <xdg-shell-unstable-v6-client-protocol.h>
 
 #include "base/strings/utf_string_conversions.h"
+#include "ui/base/hit_test.h"
 #include "ui/ozone/platform/wayland/wayland_connection.h"
 #include "ui/ozone/platform/wayland/wayland_window.h"
 
 namespace ui {
+
+namespace {
+
+// Identifies the direction of the "hittest" for Wayland.
+bool IdentifyDirection(int hittest, int* direction) {
+  DCHECK(direction);
+  *direction = -1;
+  switch (hittest) {
+    case HTBOTTOM:
+      *direction =
+          zxdg_toplevel_v6_resize_edge::ZXDG_TOPLEVEL_V6_RESIZE_EDGE_BOTTOM;
+      break;
+    case HTBOTTOMLEFT:
+      *direction = zxdg_toplevel_v6_resize_edge::
+          ZXDG_TOPLEVEL_V6_RESIZE_EDGE_BOTTOM_LEFT;
+      break;
+    case HTBOTTOMRIGHT:
+      *direction = zxdg_toplevel_v6_resize_edge::
+          ZXDG_TOPLEVEL_V6_RESIZE_EDGE_BOTTOM_RIGHT;
+      break;
+    case HTLEFT:
+      *direction =
+          zxdg_toplevel_v6_resize_edge::ZXDG_TOPLEVEL_V6_RESIZE_EDGE_LEFT;
+      break;
+    case HTRIGHT:
+      *direction =
+          zxdg_toplevel_v6_resize_edge::ZXDG_TOPLEVEL_V6_RESIZE_EDGE_RIGHT;
+      break;
+    case HTTOP:
+      *direction =
+          zxdg_toplevel_v6_resize_edge::ZXDG_TOPLEVEL_V6_RESIZE_EDGE_TOP;
+      break;
+    case HTTOPLEFT:
+      *direction =
+          zxdg_toplevel_v6_resize_edge::ZXDG_TOPLEVEL_V6_RESIZE_EDGE_TOP_LEFT;
+      break;
+    case HTTOPRIGHT:
+      *direction =
+          zxdg_toplevel_v6_resize_edge::ZXDG_TOPLEVEL_V6_RESIZE_EDGE_TOP_RIGHT;
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
+
+}  // namespace
 
 XDGSurfaceWrapperV6::XDGSurfaceWrapperV6(WaylandWindow* wayland_window)
     : wayland_window_(wayland_window) {}
@@ -73,20 +121,19 @@ void XDGSurfaceWrapperV6::SetMinimized() {
 }
 
 void XDGSurfaceWrapperV6::SurfaceMove(WaylandConnection* connection) {
-  NOTIMPLEMENTED();
+  DCHECK(zxdg_toplevel_v6_);
+  zxdg_toplevel_v6_move(zxdg_toplevel_v6_.get(), connection->seat(),
+                        connection->serial());
 }
 
 void XDGSurfaceWrapperV6::SurfaceResize(WaylandConnection* connection,
                                         uint32_t hittest) {
-  // TODO(msisov): implement resizing.
-  /*
-   * int direction;
-   * if (!IdentifyDirection(hittest, &direction))
-   *   return;
-   * xdg_surface_resize(xdg_surface_.get(), connection->seat(),
-   *                    connection->serial(), direction);
-   */
-  NOTIMPLEMENTED();
+  int direction;
+  if (!IdentifyDirection(hittest, &direction))
+    return;
+  DCHECK(zxdg_toplevel_v6_);
+  zxdg_toplevel_v6_resize(zxdg_toplevel_v6_.get(), connection->seat(),
+                          connection->serial(), direction);
 }
 
 void XDGSurfaceWrapperV6::SetTitle(const base::string16& title) {

--- a/ui/platform_window/platform_window.h
+++ b/ui/platform_window/platform_window.h
@@ -67,6 +67,11 @@ class PlatformWindow {
   // The PlatformImeController is owned by the PlatformWindow, the ownership is
   // not transferred.
   virtual PlatformImeController* GetPlatformImeController() = 0;
+
+  // The window manager starts interactive drag or resize of a window based on
+  // the |hittest|.
+  virtual void StartWindowMoveOrResize(int hittest,
+                                       gfx::Point pointer_location) = 0;
 };
 
 }  // namespace ui

--- a/ui/platform_window/stub/stub_window.cc
+++ b/ui/platform_window/stub/stub_window.cc
@@ -94,4 +94,7 @@ PlatformImeController* StubWindow::GetPlatformImeController() {
   return nullptr;
 }
 
+void StubWindow::StartWindowMoveOrResize(int hittest,
+                                         gfx::Point pointer_location) {}
+
 }  // namespace ui

--- a/ui/platform_window/stub/stub_window.h
+++ b/ui/platform_window/stub/stub_window.h
@@ -48,6 +48,8 @@ class STUB_WINDOW_EXPORT StubWindow : public PlatformWindow {
   void MoveCursorTo(const gfx::Point& location) override;
   void ConfineCursorToBounds(const gfx::Rect& bounds) override;
   PlatformImeController* GetPlatformImeController() override;
+  void StartWindowMoveOrResize(int hittest,
+                               gfx::Point pointer_location) override;
 
   PlatformWindowDelegate* delegate_;
   gfx::Rect bounds_;

--- a/ui/platform_window/x11/x11_window_base.cc
+++ b/ui/platform_window/x11/x11_window_base.cc
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "base/strings/utf_string_conversions.h"
+#include "ui/base/hit_test.h"
 #include "ui/base/platform_window_defaults.h"
 #include "ui/base/x/x11_util.h"
 #include "ui/base/x/x11_window_event_manager.h"
@@ -22,6 +23,56 @@
 namespace ui {
 
 namespace {
+
+// These constants are defined in the Extended Window Manager Hints
+// standard...and aren't in any header that I can find.
+const int k_NET_WM_MOVERESIZE_SIZE_TOPLEFT = 0;
+const int k_NET_WM_MOVERESIZE_SIZE_TOP = 1;
+const int k_NET_WM_MOVERESIZE_SIZE_TOPRIGHT = 2;
+const int k_NET_WM_MOVERESIZE_SIZE_RIGHT = 3;
+const int k_NET_WM_MOVERESIZE_SIZE_BOTTOMRIGHT = 4;
+const int k_NET_WM_MOVERESIZE_SIZE_BOTTOM = 5;
+const int k_NET_WM_MOVERESIZE_SIZE_BOTTOMLEFT = 6;
+const int k_NET_WM_MOVERESIZE_SIZE_LEFT = 7;
+const int k_NET_WM_MOVERESIZE_MOVE = 8;
+
+// Identifies the direction of the "hittest" for X11.
+bool IdentifyDirection(int hittest, int* direction) {
+  DCHECK(direction);
+  *direction = -1;
+  switch (hittest) {
+    case HTBOTTOM:
+      *direction = k_NET_WM_MOVERESIZE_SIZE_BOTTOM;
+      break;
+    case HTBOTTOMLEFT:
+      *direction = k_NET_WM_MOVERESIZE_SIZE_BOTTOMLEFT;
+      break;
+    case HTBOTTOMRIGHT:
+      *direction = k_NET_WM_MOVERESIZE_SIZE_BOTTOMRIGHT;
+      break;
+    case HTCAPTION:
+      *direction = k_NET_WM_MOVERESIZE_MOVE;
+      break;
+    case HTLEFT:
+      *direction = k_NET_WM_MOVERESIZE_SIZE_LEFT;
+      break;
+    case HTRIGHT:
+      *direction = k_NET_WM_MOVERESIZE_SIZE_RIGHT;
+      break;
+    case HTTOP:
+      *direction = k_NET_WM_MOVERESIZE_SIZE_TOP;
+      break;
+    case HTTOPLEFT:
+      *direction = k_NET_WM_MOVERESIZE_SIZE_TOPLEFT;
+      break;
+    case HTTOPRIGHT:
+      *direction = k_NET_WM_MOVERESIZE_SIZE_TOPRIGHT;
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
 
 XID FindXEventTarget(const XEvent& xev) {
   XID target = xev.xany.window;
@@ -82,10 +133,10 @@ void X11WindowBase::Create() {
 
   // Setup XInput event mask.
   long event_mask = ButtonPressMask | ButtonReleaseMask | FocusChangeMask |
-                    KeyPressMask | KeyReleaseMask | EnterWindowMask |
-                    LeaveWindowMask | ExposureMask | VisibilityChangeMask |
-                    StructureNotifyMask | PropertyChangeMask |
-                    PointerMotionMask;
+                    KeyPressMask | KeyReleaseMask | ExposureMask |
+                    VisibilityChangeMask | StructureNotifyMask |
+                    PropertyChangeMask | PointerMotionMask;
+
   xwindow_events_.reset(new ui::XScopedEventSelector(xwindow_, event_mask));
 
   // Setup XInput2 event mask.
@@ -292,6 +343,35 @@ void X11WindowBase::ConfineCursorToBounds(const gfx::Rect& bounds) {
 
 PlatformImeController* X11WindowBase::GetPlatformImeController() {
   return nullptr;
+}
+
+void X11WindowBase::StartWindowMoveOrResize(int hittest,
+                                            gfx::Point pointer_location) {
+  int direction;
+  if (!IdentifyDirection(hittest, &direction))
+    return;
+
+  // We most likely have an implicit grab right here. We need to dump it
+  // because what we're about to do is tell the window manager
+  // that it's now responsible for moving the window around; it immediately
+  // grabs when it receives the event below.
+  XUngrabPointer(xdisplay_, x11::CurrentTime);
+
+  XEvent event;
+  memset(&event, 0, sizeof(event));
+  event.xclient.type = ClientMessage;
+  event.xclient.display = xdisplay_;
+  event.xclient.window = xwindow_;
+  event.xclient.message_type = gfx::GetAtom("_NET_WM_MOVERESIZE");
+  event.xclient.format = 32;
+  event.xclient.data.l[0] = pointer_location.x();
+  event.xclient.data.l[1] = pointer_location.y();
+  event.xclient.data.l[2] = direction;
+  event.xclient.data.l[3] = 0;
+  event.xclient.data.l[4] = 0;
+
+  XSendEvent(xdisplay_, xroot_window_, x11::False,
+             SubstructureRedirectMask | SubstructureNotifyMask, &event);
 }
 
 void X11WindowBase::UnConfineCursor() {

--- a/ui/platform_window/x11/x11_window_base.h
+++ b/ui/platform_window/x11/x11_window_base.h
@@ -50,6 +50,8 @@ class X11_WINDOW_EXPORT X11WindowBase : public PlatformWindow {
   void MoveCursorTo(const gfx::Point& location) override;
   void ConfineCursorToBounds(const gfx::Rect& bounds) override;
   PlatformImeController* GetPlatformImeController() override;
+  void StartWindowMoveOrResize(int hittest,
+                               gfx::Point pointer_location) override;
 
  protected:
   // Creates new underlying XWindow. Does not map XWindow.

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host.h
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host.h
@@ -169,6 +169,11 @@ class VIEWS_EXPORT DesktopWindowTreeHost {
 
   // Returns whether a VisibilityController should be created.
   virtual bool ShouldCreateVisibilityController() const = 0;
+
+  // TODO(msisov, jkim): make this pure virtual when upstreaming.
+  // Starts moving or resizing native window based on hittests.
+  virtual void StartWindowMoveOrResize(int hittest,
+                                       gfx::Point pointer_location) {}
 };
 
 }  // namespace views

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
@@ -54,6 +54,16 @@ void DesktopWindowTreeHostPlatform::Init(const Widget::InitParams& params) {
 void DesktopWindowTreeHostPlatform::OnNativeWidgetCreated(
     const Widget::InitParams& params) {
   native_widget_delegate_->OnNativeWidgetCreated(true);
+
+  // Setup a non_client_window_event_filter, which handles resize/move, double
+  // click and other events.
+  std::unique_ptr<ui::EventHandler> handler(new WindowEventFilter(this));
+  wm::CompoundEventFilter* compound_event_filter =
+      desktop_native_widget_aura_->root_window_event_filter();
+  if (non_client_window_event_filter_)
+    compound_event_filter->RemoveHandler(handler.get());
+  compound_event_filter->AddHandler(handler.get());
+  non_client_window_event_filter_ = std::move(handler);
 }
 
 void DesktopWindowTreeHostPlatform::OnWidgetInitDone() {}
@@ -93,6 +103,12 @@ void DesktopWindowTreeHostPlatform::CloseNow() {
   SetPlatformWindow(nullptr);
   if (!weak_ref || got_on_closed_)
     return;
+
+  // Remove the event listeners we've installed. We need to remove these
+  // because otherwise we get assert during ~WindowEventDispatcher().
+  desktop_native_widget_aura_->root_window_event_filter()->RemoveHandler(
+      non_client_window_event_filter_.get());
+  non_client_window_event_filter_.reset();
 
   got_on_closed_ = true;
   desktop_native_widget_aura_->OnHostClosed();
@@ -398,6 +414,35 @@ bool DesktopWindowTreeHostPlatform::ShouldUseDesktopNativeCursorManager()
 
 bool DesktopWindowTreeHostPlatform::ShouldCreateVisibilityController() const {
   return true;
+}
+
+void DesktopWindowTreeHostPlatform::StartWindowMoveOrResize(
+    int hittest,
+    gfx::Point pointer_location) {
+  platform_window()->StartWindowMoveOrResize(hittest, pointer_location);
+}
+
+void DesktopWindowTreeHostPlatform::DispatchEvent(ui::Event* event) {
+  // We need to make sure it is appropriately marked as non-client if it's in
+  // the non client area, or otherwise, we can get into a state where the a
+  // window is set as the |mouse_pressed_handler_| in window_event_dispatcher.cc
+  // despite the mouse button being released. X11 also does the same.
+  //
+  // See comment in DesktopWindowTreeHostX11::DispatchMouseEvent for details.
+  aura::Window* content_window = desktop_native_widget_aura_->content_window();
+  if (content_window && content_window->delegate()) {
+    if (event->IsMouseEvent()) {
+      ui::MouseEvent* mouse_event = event->AsMouseEvent();
+      int flags = mouse_event->flags();
+      int hit_test_code = content_window->delegate()->GetNonClientComponent(
+          mouse_event->location());
+      if (hit_test_code != HTCLIENT && hit_test_code != HTNOWHERE)
+        flags |= ui::EF_IS_NON_CLIENT;
+      mouse_event->set_flags(flags);
+    }
+  }
+
+  WindowTreeHostPlatform::DispatchEvent(event);
 }
 
 void DesktopWindowTreeHostPlatform::OnClosed() {

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.h
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.h
@@ -87,8 +87,11 @@ class VIEWS_EXPORT DesktopWindowTreeHostPlatform
   bool ShouldUpdateWindowTransparency() const override;
   bool ShouldUseDesktopNativeCursorManager() const override;
   bool ShouldCreateVisibilityController() const override;
+  void StartWindowMoveOrResize(int hittest,
+                               gfx::Point pointer_location) override;
 
   // WindowTreeHostPlatform:
+  void DispatchEvent(ui::Event* event) override;
   void OnClosed() override;
   void OnWindowStateChanged(ui::PlatformWindowState new_state) override;
   void OnCloseRequest() override;
@@ -108,6 +111,9 @@ class VIEWS_EXPORT DesktopWindowTreeHostPlatform
   bool got_on_closed_ = false;
 
   bool is_active_ = false;
+
+  // A handler for events inteded for non client area.
+  std::unique_ptr<ui::EventHandler> non_client_window_event_filter_;
 
   base::WeakPtrFactory<DesktopWindowTreeHostPlatform> weak_factory_{this};
 

--- a/ui/views/widget/desktop_aura/window_event_filter.cc
+++ b/ui/views/widget/desktop_aura/window_event_filter.cc
@@ -21,6 +21,28 @@
 
 namespace views {
 
+namespace {
+
+bool CanPerformDragOrResize(int hittest) {
+  switch (hittest) {
+    case HTBOTTOM:
+    case HTBOTTOMLEFT:
+    case HTBOTTOMRIGHT:
+    case HTCAPTION:
+    case HTLEFT:
+    case HTRIGHT:
+    case HTTOP:
+    case HTTOPLEFT:
+    case HTTOPRIGHT:
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
+
+}  // namespace
+
 WindowEventFilter::WindowEventFilter(DesktopWindowTreeHost* window_tree_host)
     : window_tree_host_(window_tree_host), click_component_(HTNOWHERE) {}
 
@@ -149,6 +171,14 @@ void WindowEventFilter::LowerWindow() {}
 
 void WindowEventFilter::MaybeDispatchHostWindowDragMovement(
     int hittest,
-    ui::MouseEvent* event) {}
+    ui::MouseEvent* event) {
+  auto* target = static_cast<aura::Window*>(event->target());
+  if (!event->IsLeftMouseButton() ||
+      target->GetHost() != window_tree_host_->AsWindowTreeHost() ||
+      !CanPerformDragOrResize(hittest))
+    return;
+  window_tree_host_->StartWindowMoveOrResize(hittest, event->location());
+  event->StopPropagation();
+}
 
 }  // namespace views


### PR DESCRIPTION
This cl fixes interactions with window's non client area.

WindowEventFilter is now set in DesktopWindowTreeHostPlatform,
and events are properly marked as non client to avoid mouse pressed
handler be kept until release event is sent (which isn't sent at all.
See wayland/x11 protocol documentation).

Basically, it's almost the same as we had with mus.

Issue: #419