### PR TITLE
Add inital support for a tab drag window.

### DIFF
--- a/chrome/browser/ui/views/tabs/window_finder_ozone.cc
+++ b/chrome/browser/ui/views/tabs/window_finder_ozone.cc
@@ -2,8 +2,37 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "chrome/browser/ui/browser_list.h"
+#include "chrome/browser/ui/browser_window.h"
 #include "chrome/browser/ui/views/tabs/window_finder.h"
 #include "chrome/browser/ui/views/tabs/window_finder_mus.h"
+#include "ui/views/widget/widget.h"
+
+namespace {
+
+gfx::NativeWindow GetLocalProcessWindowAtPointOzone(
+    const gfx::Point& screen_point,
+    const std::set<gfx::NativeWindow>& ignore) {
+  std::set<aura::Window*> root_windows;
+  for (auto* browser : *BrowserList::GetInstance())
+    root_windows.insert(browser->window()->GetNativeWindow());
+
+  for (aura::Window* root : root_windows) {
+    views::Widget* widget = views::Widget::GetWidgetForNativeView(root);
+    if (widget && widget->GetWindowBoundsInScreen().Contains(screen_point)) {
+      aura::Window* content_window = widget->GetNativeWindow();
+
+      // If we were instructed to ignore this window, ignore it.
+      if (base::ContainsKey(ignore, content_window))
+        continue;
+
+      return content_window;
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace
 
 gfx::NativeWindow WindowFinder::GetLocalProcessWindowAtPoint(
     const gfx::Point& screen_point,
@@ -12,6 +41,5 @@ gfx::NativeWindow WindowFinder::GetLocalProcessWindowAtPoint(
   if (GetLocalProcessWindowAtPointMus(screen_point, ignore, &mus_result))
     return mus_result;
 
-  NOTREACHED() << "For Ozone builds, only mash launch is supported for now.";
-  return nullptr;
+  return GetLocalProcessWindowAtPointOzone(screen_point, ignore);
 }

--- a/ui/ozone/platform/cast/platform_window_cast.cc
+++ b/ui/ozone/platform/cast/platform_window_cast.cc
@@ -47,6 +47,12 @@ PlatformImeController* PlatformWindowCast::GetPlatformImeController() {
   return nullptr;
 }
 
+bool PlatformWindowCast::RunMoveLoop(const gfx::Vector2d& drag_offset) {
+  return false;
+}
+
+void PlatformWindowCast::StopMoveLoop() {}
+
 bool PlatformWindowCast::CanDispatchEvent(const PlatformEvent& ne) {
   return true;
 }

--- a/ui/ozone/platform/cast/platform_window_cast.h
+++ b/ui/ozone/platform/cast/platform_window_cast.h
@@ -40,6 +40,8 @@ class PlatformWindowCast : public PlatformWindow,
   void MoveCursorTo(const gfx::Point& location) override {}
   void ConfineCursorToBounds(const gfx::Rect& bounds) override {}
   PlatformImeController* GetPlatformImeController() override;
+  bool RunMoveLoop(const gfx::Vector2d& drag_offset) override;
+  void StopMoveLoop() override;
 
   // PlatformEventDispatcher implementation:
   bool CanDispatchEvent(const PlatformEvent& event) override;

--- a/ui/ozone/platform/drm/host/drm_window_host.cc
+++ b/ui/ozone/platform/drm/host/drm_window_host.cc
@@ -148,6 +148,12 @@ PlatformImeController* DrmWindowHost::GetPlatformImeController() {
 void DrmWindowHost::StartWindowMoveOrResize(int hittest,
                                             gfx::Point pointer_location) {}
 
+bool DrmWindowHost::RunMoveLoop(const gfx::Vector2d& drag_offset) {
+  return false;
+}
+
+void DrmWindowHost::StopMoveLoop() {}
+
 bool DrmWindowHost::CanDispatchEvent(const PlatformEvent& event) {
   DCHECK(event);
 

--- a/ui/ozone/platform/drm/host/drm_window_host.h
+++ b/ui/ozone/platform/drm/host/drm_window_host.h
@@ -81,6 +81,8 @@ class DrmWindowHost : public PlatformWindow,
   PlatformImeController* GetPlatformImeController() override;
   void StartWindowMoveOrResize(int hittest,
                                gfx::Point pointer_location) override;
+  bool RunMoveLoop(const gfx::Vector2d& drag_offset) override;
+  void StopMoveLoop() override;
 
   // PlatformEventDispatcher:
   bool CanDispatchEvent(const PlatformEvent& event) override;

--- a/ui/ozone/platform/headless/headless_window.cc
+++ b/ui/ozone/platform/headless/headless_window.cc
@@ -93,4 +93,10 @@ PlatformImeController* HeadlessWindow::GetPlatformImeController() {
 void HeadlessWindow::StartWindowMoveOrResize(int hittest,
                                              gfx::Point pointer_location) {}
 
+bool HeadlessWindow::RunMoveLoop(const gfx::Vector2d& drag_offset) {
+  return false;
+}
+
+void HeadlessWindow::StopMoveLoop() {}
+
 }  // namespace ui

--- a/ui/ozone/platform/headless/headless_window.h
+++ b/ui/ozone/platform/headless/headless_window.h
@@ -46,6 +46,8 @@ class HeadlessWindow : public PlatformWindow {
   PlatformImeController* GetPlatformImeController() override;
   void StartWindowMoveOrResize(int hittest,
                                gfx::Point pointer_location) override;
+  bool RunMoveLoop(const gfx::Vector2d& drag_offset) override;
+  void StopMoveLoop() override;
 
  private:
   PlatformWindowDelegate* delegate_;

--- a/ui/ozone/platform/wayland/wayland_window.cc
+++ b/ui/ozone/platform/wayland/wayland_window.cc
@@ -385,6 +385,12 @@ void WaylandWindow::StartWindowMoveOrResize(int hittest,
     xdg_surface_->SurfaceResize(connection_, hittest);
 }
 
+bool WaylandWindow::RunMoveLoop(const gfx::Vector2d& drag_offset) {
+  return true;
+}
+
+void WaylandWindow::StopMoveLoop() {}
+
 bool WaylandWindow::CanDispatchEvent(const PlatformEvent& event) {
   if (child_window_ && child_window_->is_popup())
     return is_popup();

--- a/ui/ozone/platform/wayland/wayland_window.h
+++ b/ui/ozone/platform/wayland/wayland_window.h
@@ -97,6 +97,8 @@ class WaylandWindow : public PlatformWindow, public PlatformEventDispatcher {
   PlatformImeController* GetPlatformImeController() override;
   void StartWindowMoveOrResize(int hittest,
                                gfx::Point pointer_location) override;
+  bool RunMoveLoop(const gfx::Vector2d& drag_offset) override;
+  void StopMoveLoop() override;
 
   // PlatformEventDispatcher
   bool CanDispatchEvent(const PlatformEvent& event) override;

--- a/ui/ozone/platform/x11/x11_window_ozone.cc
+++ b/ui/ozone/platform/x11/x11_window_ozone.cc
@@ -24,6 +24,11 @@ X11WindowOzone::X11WindowOzone(X11WindowManagerOzone* window_manager,
   auto* event_source = X11EventSourceLibevent::GetInstance();
   if (event_source)
     event_source->AddXEventDispatcher(this);
+
+// TODO(msisov, tonikitoo): Add a dummy implementation for chromeos.
+#if !defined(OS_CHROMEOS)
+  move_loop_client_.reset(new WindowMoveLoopClient());
+#endif
 }
 
 X11WindowOzone::~X11WindowOzone() {
@@ -49,6 +54,24 @@ void X11WindowOzone::SetCursor(PlatformCursor cursor) {
   XDefineCursor(xdisplay(), xwindow(), cursor_ozone->xcursor());
 }
 
+bool X11WindowOzone::RunMoveLoop(const gfx::Vector2d& drag_offset) {
+// TODO(msisov, tonikitoo): Add a dummy implementation for chromeos.
+#if !defined(OS_CHROMEOS)
+  DCHECK(move_loop_client_);
+  ReleaseCapture();
+  return move_loop_client_->RunMoveLoop(this, drag_offset);
+#endif
+  return true;
+}
+
+void X11WindowOzone::StopMoveLoop() {
+// TODO(msisov, tonikitoo): Add a dummy implementation for chromeos.
+#if !defined(OS_CHROMEOS)
+  ReleaseCapture();
+  move_loop_client_->EndMoveLoop();
+#endif
+}
+
 void X11WindowOzone::CheckCanDispatchNextPlatformEvent(XEvent* xev) {
   handle_next_event_ = xwindow() == x11::None ? false : IsEventForXWindow(*xev);
 }
@@ -69,8 +92,14 @@ bool X11WindowOzone::DispatchXEvent(XEvent* xev) {
   return true;
 }
 
-bool X11WindowOzone::CanDispatchEvent(const PlatformEvent& event) {
-  return handle_next_event_;
+bool X11WindowOzone::CanDispatchEvent(const PlatformEvent& platform_event) {
+  bool in_move_loop =
+#if !defined(OS_CHROMEOS)
+      move_loop_client_->IsInMoveLoop();
+#else
+      false;
+#endif
+  return handle_next_event_ || in_move_loop;
 }
 
 uint32_t X11WindowOzone::DispatchEvent(const PlatformEvent& event) {

--- a/ui/ozone/platform/x11/x11_window_ozone.h
+++ b/ui/ozone/platform/x11/x11_window_ozone.h
@@ -8,6 +8,7 @@
 #include "base/macros.h"
 #include "ui/events/platform/platform_event_dispatcher.h"
 #include "ui/events/platform/x11/x11_event_source_libevent.h"
+#include "ui/platform_window/x11/window_move_loop_client.h"
 #include "ui/platform_window/x11/x11_window_base.h"
 
 namespace ui {
@@ -30,8 +31,11 @@ class X11WindowOzone : public X11WindowBase,
   // PlatformWindow:
   void PrepareForShutdown() override;
   void SetCapture() override;
+
   void ReleaseCapture() override;
   void SetCursor(PlatformCursor cursor) override;
+  bool RunMoveLoop(const gfx::Vector2d& drag_offset) override;
+  void StopMoveLoop() override;
 
   // XEventDispatcher:
   void CheckCanDispatchNextPlatformEvent(XEvent* xev) override;
@@ -45,6 +49,11 @@ class X11WindowOzone : public X11WindowBase,
   uint32_t DispatchEvent(const PlatformEvent& event) override;
 
   X11WindowManagerOzone* window_manager_;
+
+// TODO(msisov, tonikitoo): Add a dummy implementation for chromeos.
+#if !defined(OS_CHROMEOS)
+  std::unique_ptr<WindowMoveLoopClient> move_loop_client_;
+#endif
 
   // Tells if this dispatcher can process next translated event based on a
   // previous check in ::CheckCanDispatchNextPlatformEvent based on a XID

--- a/ui/platform_window/platform_window.h
+++ b/ui/platform_window/platform_window.h
@@ -72,6 +72,11 @@ class PlatformWindow {
   // the |hittest|.
   virtual void StartWindowMoveOrResize(int hittest,
                                        gfx::Point pointer_location) = 0;
+
+  // Asks to window move client to start move loop.
+  virtual bool RunMoveLoop(const gfx::Vector2d& drag_offset) = 0;
+
+  virtual void StopMoveLoop() = 0;
 };
 
 }  // namespace ui

--- a/ui/platform_window/stub/stub_window.cc
+++ b/ui/platform_window/stub/stub_window.cc
@@ -97,4 +97,10 @@ PlatformImeController* StubWindow::GetPlatformImeController() {
 void StubWindow::StartWindowMoveOrResize(int hittest,
                                          gfx::Point pointer_location) {}
 
+bool StubWindow::RunMoveLoop(const gfx::Vector2d& drag_offset) {
+  return false;
+}
+
+void StubWindow::StopMoveLoop() {}
+
 }  // namespace ui

--- a/ui/platform_window/stub/stub_window.h
+++ b/ui/platform_window/stub/stub_window.h
@@ -50,6 +50,8 @@ class STUB_WINDOW_EXPORT StubWindow : public PlatformWindow {
   PlatformImeController* GetPlatformImeController() override;
   void StartWindowMoveOrResize(int hittest,
                                gfx::Point pointer_location) override;
+  bool RunMoveLoop(const gfx::Vector2d& drag_offset) override;
+  void StopMoveLoop() override;
 
   PlatformWindowDelegate* delegate_;
   gfx::Rect bounds_;

--- a/ui/platform_window/x11/BUILD.gn
+++ b/ui/platform_window/x11/BUILD.gn
@@ -34,7 +34,18 @@ jumbo_component("x11") {
     "x11_window_export.h",
   ]
 
-  if (use_x11) {
+  if (ozone_platform_x11) {
+    sources += [
+      "whole_screen_move_loop.cc",
+      "whole_screen_move_loop.h",
+      "window_move_loop_client.cc",
+      "window_move_loop_client.h",
+    ]
+    deps += [
+      "//ui/base",
+      "//ui/base/x",
+    ]
+  } else if (use_x11) {
     sources += [
       "x11_window.cc",
       "x11_window.h",

--- a/ui/platform_window/x11/whole_screen_move_loop.cc
+++ b/ui/platform_window/x11/whole_screen_move_loop.cc
@@ -1,0 +1,228 @@
+// Copyright (c) 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/platform_window/x11/whole_screen_move_loop.h"
+
+#include <stddef.h>
+#include <utility>
+
+#include "base/bind.h"
+#include "base/logging.h"
+#include "base/macros.h"
+#include "base/message_loop/message_loop.h"
+#include "base/run_loop.h"
+#include "base/single_thread_task_runner.h"
+#include "base/threading/thread_task_runner_handle.h"
+#include "ui/aura/client/capture_client.h"
+#include "ui/aura/env.h"
+#include "ui/aura/window.h"
+#include "ui/aura/window_event_dispatcher.h"
+#include "ui/aura/window_tree_host.h"
+#include "ui/base/x/x11_pointer_grab.h"
+#include "ui/base/x/x11_util.h"
+#include "ui/base/x/x11_window_event_manager.h"
+#include "ui/events/event.h"
+#include "ui/events/event_utils.h"
+#include "ui/events/keycodes/keyboard_code_conversion_x.h"
+#include "ui/events/ozone/events_ozone.h"
+#include "ui/events/platform/platform_event_source.h"
+#include "ui/events/platform/scoped_event_dispatcher.h"
+#include "ui/events/platform/x11/x11_event_source.h"
+#include "ui/events/platform/x11/x11_event_source_libevent.h"
+#include "ui/gfx/x/x11.h"
+#include "ui/platform_window/platform_window_delegate.h"
+
+namespace ui {
+
+// XGrabKey requires the modifier mask to explicitly be specified.
+const unsigned int kModifiersMasks[] = {0,         // No additional modifier.
+                                        Mod2Mask,  // Num lock
+                                        LockMask,  // Caps lock
+                                        Mod5Mask,  // Scroll lock
+                                        Mod2Mask | LockMask,
+                                        Mod2Mask | Mod5Mask,
+                                        LockMask | Mod5Mask,
+                                        Mod2Mask | LockMask | Mod5Mask};
+
+WholeScreenMoveLoop::WholeScreenMoveLoop(views::X11MoveLoopDelegate* delegate)
+    : delegate_(delegate),
+      in_move_loop_(false),
+      grab_input_window_(x11::None),
+      grabbed_pointer_(false),
+      canceled_(false),
+      weak_factory_(this) {}
+
+WholeScreenMoveLoop::~WholeScreenMoveLoop() {}
+
+void WholeScreenMoveLoop::DispatchMouseMovement() {
+  if (!last_motion_in_screen_ && !last_motion_in_screen_->IsLocatedEvent())
+    return;
+  delegate_->OnMouseMovement(
+      last_motion_in_screen_->AsLocatedEvent()->location(),
+      last_motion_in_screen_->flags(), last_motion_in_screen_->time_stamp());
+  last_motion_in_screen_.reset();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// DesktopWindowTreeHostLinux, ui::PlatformEventDispatcher implementation:
+
+bool WholeScreenMoveLoop::CanDispatchEvent(const ui::PlatformEvent& event) {
+  return in_move_loop_;
+}
+
+uint32_t WholeScreenMoveLoop::DispatchEvent(
+    const ui::PlatformEvent& platform_event) {
+  DCHECK(base::MessageLoopForUI::IsCurrent());
+
+  // This method processes all events while the move loop is active.
+  if (!in_move_loop_)
+    return ui::POST_DISPATCH_PERFORM_DEFAULT;
+
+  auto* event = static_cast<ui::Event*>(platform_event);
+  switch (event->type()) {
+    case ui::ET_MOUSE_MOVED:
+    case ui::ET_MOUSE_DRAGGED: {
+      bool can_send = !last_motion_in_screen_.get();
+
+      ui::MouseEvent* mouse_event = event->AsMouseEvent();
+      gfx::Point root_location = mouse_event->root_location();
+      mouse_event->set_location(root_location);
+
+      last_motion_in_screen_ = ui::Event::Clone(*event);
+      DCHECK(last_motion_in_screen_->IsMouseEvent());
+
+      if (can_send)
+        DispatchMouseMovement();
+      return ui::POST_DISPATCH_PERFORM_DEFAULT;
+    }
+    case ui::ET_MOUSE_RELEASED: {
+      ui::MouseEvent* mouse_event = event->AsMouseEvent();
+      gfx::Point root_location = mouse_event->root_location();
+      mouse_event->set_location(root_location);
+
+      last_motion_in_screen_ = ui::Event::Clone(*event);
+      DCHECK(last_motion_in_screen_->IsMouseEvent());
+
+      EndMoveLoop();
+      return ui::POST_DISPATCH_PERFORM_DEFAULT;
+    }
+    case ui::ET_KEY_PRESSED:
+      canceled_ = true;
+      EndMoveLoop();
+      return ui::POST_DISPATCH_NONE;
+    default:
+      break;
+  }
+  return ui::POST_DISPATCH_PERFORM_DEFAULT;
+}
+
+bool WholeScreenMoveLoop::RunMoveLoop() {
+  DCHECK(!in_move_loop_);  // Can only handle one nested loop at a time.
+
+  CreateDragInputWindow(gfx::GetXDisplay());
+
+  if (!GrabPointer()) {
+    XDestroyWindow(gfx::GetXDisplay(), grab_input_window_);
+    CHECK(false) << "failed to grab pointer";
+    return false;
+  }
+
+  GrabEscKey();
+
+  std::unique_ptr<ui::ScopedEventDispatcher> old_dispatcher =
+      std::move(nested_dispatcher_);
+  nested_dispatcher_ =
+      ui::PlatformEventSource::GetInstance()->OverrideDispatcher(this);
+
+  base::WeakPtr<WholeScreenMoveLoop> alive(weak_factory_.GetWeakPtr());
+
+  in_move_loop_ = true;
+  canceled_ = false;
+  base::MessageLoop::ScopedNestableTaskAllower allow_nested;
+  base::RunLoop run_loop;
+  quit_closure_ = run_loop.QuitClosure();
+  run_loop.Run();
+
+  if (!alive)
+    return false;
+
+  nested_dispatcher_ = std::move(old_dispatcher);
+  return !canceled_;
+}
+
+void WholeScreenMoveLoop::UpdateCursor() {}
+
+void WholeScreenMoveLoop::EndMoveLoop() {
+  if (!in_move_loop_)
+    return;
+
+  // Prevent DispatchMouseMovement from dispatching any posted motion event.
+  last_motion_in_screen_.reset();
+
+  // TODO(erg): Is this ungrab the cause of having to click to give input focus
+  // on drawn out windows? Not ungrabbing here screws the X server until I kill
+  // the chrome process.
+
+  // Ungrab before we let go of the window.
+  if (grabbed_pointer_)
+    ui::UngrabPointer();
+  else
+    UpdateCursor();
+
+  XDisplay* display = gfx::GetXDisplay();
+  unsigned int esc_keycode = XKeysymToKeycode(display, XK_Escape);
+  for (size_t i = 0; i < arraysize(kModifiersMasks); ++i) {
+    XUngrabKey(display, esc_keycode, kModifiersMasks[i], grab_input_window_);
+  }
+
+  // Restore the previous dispatcher.
+  nested_dispatcher_.reset();
+  grab_input_window_events_.reset();
+  XDestroyWindow(display, grab_input_window_);
+  grab_input_window_ = x11::None;
+  in_move_loop_ = false;
+  quit_closure_.Run();
+}
+
+bool WholeScreenMoveLoop::GrabPointer() {
+  XDisplay* display = gfx::GetXDisplay();
+
+  // Pass "owner_events" as false so that X sends all mouse events to
+  // |grab_input_window_|.
+  int ret = ui::GrabPointer(grab_input_window_, false, x11::None);
+  if (ret != GrabSuccess) {
+    DLOG(ERROR) << "Grabbing pointer for dragging failed: "
+                << ui::GetX11ErrorString(display, ret);
+  }
+  XFlush(display);
+  return ret == GrabSuccess;
+}
+
+void WholeScreenMoveLoop::GrabEscKey() {
+  XDisplay* display = gfx::GetXDisplay();
+  unsigned int esc_keycode = XKeysymToKeycode(display, XK_Escape);
+  for (size_t i = 0; i < arraysize(kModifiersMasks); ++i) {
+    XGrabKey(display, esc_keycode, kModifiersMasks[i], grab_input_window_,
+             x11::False, GrabModeAsync, GrabModeAsync);
+  }
+}
+
+void WholeScreenMoveLoop::CreateDragInputWindow(XDisplay* display) {
+  unsigned long attribute_mask = CWEventMask | CWOverrideRedirect;
+  XSetWindowAttributes swa;
+  memset(&swa, 0, sizeof(swa));
+  swa.override_redirect = x11::True;
+  grab_input_window_ = XCreateWindow(display, DefaultRootWindow(display), -100,
+                                     -100, 10, 10, 0, CopyFromParent, InputOnly,
+                                     CopyFromParent, attribute_mask, &swa);
+  uint32_t event_mask = ButtonPressMask | ButtonReleaseMask |
+                        PointerMotionMask | KeyPressMask | KeyReleaseMask |
+                        StructureNotifyMask;
+  grab_input_window_events_.reset(
+      new ui::XScopedEventSelector(grab_input_window_, event_mask));
+
+  XMapRaised(display, grab_input_window_);
+}
+
+}  // namespace ui

--- a/ui/platform_window/x11/whole_screen_move_loop.h
+++ b/ui/platform_window/x11/whole_screen_move_loop.h
@@ -1,0 +1,90 @@
+// Copyright (c) 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_PLATFORM_WINDOW_X11_WHOLE_SCREEN_MOVE_LOOP_H_
+#define UI_PLATFORM_WINDOW_X11_WHOLE_SCREEN_MOVE_LOOP_H_
+
+#include <stdint.h>
+
+#include "base/callback.h"
+#include "base/compiler_specific.h"
+#include "base/macros.h"
+#include "base/memory/weak_ptr.h"
+#include "ui/base/cursor/cursor.h"
+#include "ui/events/platform/platform_event_dispatcher.h"
+#include "ui/gfx/geometry/vector2d_f.h"
+#include "ui/gfx/image/image_skia.h"
+#include "ui/gfx/native_widget_types.h"
+#include "ui/gfx/x/x11_types.h"
+#include "ui/views/widget/desktop_aura/x11_move_loop.h"
+#include "ui/views/widget/desktop_aura/x11_move_loop_delegate.h"
+
+namespace ui {
+class MouseEvent;
+class ScopedEventDispatcher;
+class XScopedEventSelector;
+class PlatformWindowDelegate;
+
+// Runs a nested run loop and grabs the mouse. This is used to implement
+// dragging.
+class WholeScreenMoveLoop : public ui::PlatformEventDispatcher {
+ public:
+  explicit WholeScreenMoveLoop(views::X11MoveLoopDelegate* delegate);
+  ~WholeScreenMoveLoop() override;
+
+  // ui:::PlatformEventDispatcher:
+  bool CanDispatchEvent(const ui::PlatformEvent& event) override;
+  uint32_t DispatchEvent(const ui::PlatformEvent& platform_event) override;
+
+  // X11MoveLoop:
+  bool RunMoveLoop();
+  void UpdateCursor();
+  void EndMoveLoop();
+
+  bool in_move_loop() { return in_move_loop_; }
+
+ private:
+  // Grabs the pointer, setting the mouse cursor to |cursor|. Returns true if
+  // successful.
+  bool GrabPointer();
+
+  void GrabEscKey();
+
+  // Creates an input-only window to be used during the drag.
+  void CreateDragInputWindow(XDisplay* display);
+
+  // Dispatch mouse movement event to |delegate_| in a posted task.
+  void DispatchMouseMovement();
+
+  views::X11MoveLoopDelegate* delegate_;
+
+  // Are we running a nested run loop from RunMoveLoop()?
+  bool in_move_loop_;
+  std::unique_ptr<ui::ScopedEventDispatcher> nested_dispatcher_;
+
+  // An invisible InputOnly window. Keyboard grab and sometimes mouse grab
+  // are set on this window.
+  XID grab_input_window_;
+
+  // Events selected on |grab_input_window_|.
+  std::unique_ptr<ui::XScopedEventSelector> grab_input_window_events_;
+
+  // Whether the pointer was grabbed on |grab_input_window_|.
+  bool grabbed_pointer_;
+
+  base::Closure quit_closure_;
+
+  // Keeps track of whether the move-loop is cancled by the user (e.g. by
+  // pressing escape).
+  bool canceled_;
+
+  std::unique_ptr<ui::Event> last_motion_in_screen_;
+  base::WeakPtrFactory<WholeScreenMoveLoop> weak_factory_;
+
+  DISALLOW_COPY_AND_ASSIGN(WholeScreenMoveLoop);
+};
+
+}  // namespace ui
+
+#endif  // UI_PLATFORM_WINDOW_X11_WHOLE_SCREEN_MOVE_LOOP_H_

--- a/ui/platform_window/x11/window_move_loop_client.cc
+++ b/ui/platform_window/x11/window_move_loop_client.cc
@@ -1,0 +1,62 @@
+// Copyright (c) 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/platform_window/x11/window_move_loop_client.h"
+
+#include <X11/Xlib.h>
+
+#include "base/debug/stack_trace.h"
+#include "base/message_loop/message_loop.h"
+#include "base/run_loop.h"
+#include "ui/aura/env.h"
+#include "ui/aura/window.h"
+#include "ui/aura/window_tree_host.h"
+#include "ui/base/x/x11_util.h"
+#include "ui/events/event.h"
+
+#include "ui/platform_window/platform_window.h"
+
+namespace ui {
+
+WindowMoveLoopClient::WindowMoveLoopClient()
+    : move_loop_(this), window_(nullptr) {}
+
+WindowMoveLoopClient::~WindowMoveLoopClient() {}
+
+void WindowMoveLoopClient::OnMouseMovement(const gfx::Point& screen_point,
+                                           int flags,
+                                           base::TimeTicks event_time) {
+  gfx::Point system_loc = screen_point - window_offset_;
+  window_->SetBounds(gfx::Rect(system_loc, gfx::Size()));
+}
+
+void WindowMoveLoopClient::OnMouseReleased() {
+  EndMoveLoop();
+}
+
+void WindowMoveLoopClient::OnMoveLoopEnded() {
+  window_ = nullptr;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// DesktopWindowTreeHostLinux, wm::WindowMoveClient implementation:
+
+bool WindowMoveLoopClient::RunMoveLoop(PlatformWindow* window,
+                                       const gfx::Vector2d& drag_offset) {
+  window_offset_ = drag_offset;
+  window_ = window;
+  window_->SetCapture();
+  return move_loop_.RunMoveLoop();
+}
+
+void WindowMoveLoopClient::EndMoveLoop() {
+  window_->ReleaseCapture();
+  move_loop_.EndMoveLoop();
+}
+
+bool WindowMoveLoopClient::IsInMoveLoop() {
+  return move_loop_.in_move_loop();
+}
+
+}  // namespace ui

--- a/ui/platform_window/x11/window_move_loop_client.h
+++ b/ui/platform_window/x11/window_move_loop_client.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_PLATFORM_WINDOW_X11_WINDOW_MOVE_LOOP_CLIENT_H_
+#define UI_PLATFORM_WINDOW_X11_WINDOW_MOVE_LOOP_CLIENT_H_
+
+#include <X11/Xlib.h>
+
+#include "base/callback.h"
+#include "base/compiler_specific.h"
+#include "base/message_loop/message_loop.h"
+#include "ui/gfx/geometry/point.h"
+#include "ui/platform_window/x11/whole_screen_move_loop.h"
+#include "ui/platform_window/x11/x11_window_export.h"
+#include "ui/views/views_export.h"
+#include "ui/wm/public/window_move_client.h"
+
+namespace ui {
+
+class PlatformWindow;
+
+// When we're dragging tabs, we need to manually position our window.
+class X11_WINDOW_EXPORT WindowMoveLoopClient : public views::X11MoveLoopDelegate {
+ public:
+  WindowMoveLoopClient();
+  ~WindowMoveLoopClient() override;
+
+  // Overridden from X11MoveLoopDelegate:
+  void OnMouseMovement(const gfx::Point& screen_point,
+                       int flags,
+                       base::TimeTicks event_time) override;
+  void OnMouseReleased() override;
+  void OnMoveLoopEnded() override;
+
+  bool RunMoveLoop(PlatformWindow* window, const gfx::Vector2d& drag_offset);
+  void EndMoveLoop();
+
+  bool IsInMoveLoop();
+
+ private:
+  WholeScreenMoveLoop move_loop_;
+
+  // We need to keep track of this so we can actually move it when reacting to
+  // mouse events.
+  PlatformWindow* window_;
+
+  // Our cursor offset from the top left window origin when the drag
+  // started. Used to calculate the window's new bounds relative to the current
+  // location of the cursor.
+  gfx::Vector2d window_offset_;
+};
+
+}  // namespace ui
+
+#endif  // UI_PLATFORM_WINDOW_X11_WINDOW_MOVE_LOOP_CLIENT_H_

--- a/ui/platform_window/x11/x11_window_base.cc
+++ b/ui/platform_window/x11/x11_window_base.cc
@@ -258,7 +258,7 @@ void X11WindowBase::SetBounds(const gfx::Rect& bounds) {
     XWindowChanges changes = {0};
     unsigned value_mask = 0;
 
-    if (bounds_.size() != bounds.size()) {
+    if (!bounds.size().IsEmpty() && bounds_.size() != bounds.size()) {
       changes.width = bounds.width();
       changes.height = bounds.height();
       value_mask |= CWHeight | CWWidth;
@@ -278,8 +278,13 @@ void X11WindowBase::SetBounds(const gfx::Rect& bounds) {
   // case if we're running without a window manager.  If there's a window
   // manager, it can modify or ignore the request, but (per ICCCM) we'll get a
   // (possibly synthetic) ConfigureNotify about the actual size and correct
-  // |bounds_| later.
+  // |bounds_| later. If |bounds| came with zero size, use the previous size
+  // of |bounds_|.
+  gfx::Size size = bounds_.size();
+  if (!bounds.size().IsEmpty())
+    size = bounds_.size();
   bounds_ = bounds;
+  bounds_.set_size(size);
 
   // Even if the pixel bounds didn't change this call to the delegate should
   // still happen. The device scale factor may have changed which effectively
@@ -411,6 +416,12 @@ void X11WindowBase::StartWindowMoveOrResize(int hittest,
   XSendEvent(xdisplay_, xroot_window_, x11::False,
              SubstructureRedirectMask | SubstructureNotifyMask, &event);
 }
+
+bool X11WindowBase::RunMoveLoop(const gfx::Vector2d& drag_offset) {
+  return false;
+}
+
+void X11WindowBase::StopMoveLoop() {}
 
 void X11WindowBase::UnConfineCursor() {
   if (!has_pointer_barriers_)

--- a/ui/platform_window/x11/x11_window_base.h
+++ b/ui/platform_window/x11/x11_window_base.h
@@ -52,6 +52,8 @@ class X11_WINDOW_EXPORT X11WindowBase : public PlatformWindow {
   PlatformImeController* GetPlatformImeController() override;
   void StartWindowMoveOrResize(int hittest,
                                gfx::Point pointer_location) override;
+  bool RunMoveLoop(const gfx::Vector2d& drag_offset) override;
+  void StopMoveLoop() override;
 
  protected:
   // Creates new underlying XWindow. Does not map XWindow.
@@ -60,6 +62,7 @@ class X11_WINDOW_EXPORT X11WindowBase : public PlatformWindow {
   void Destroy();
 
   PlatformWindowDelegate* delegate() { return delegate_; }
+
   XDisplay* xdisplay() { return xdisplay_; }
   XID xwindow() const { return xwindow_; }
 

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
@@ -342,14 +342,13 @@ Widget::MoveLoopResult DesktopWindowTreeHostPlatform::RunMoveLoop(
     const gfx::Vector2d& drag_offset,
     Widget::MoveLoopSource source,
     Widget::MoveLoopEscapeBehavior escape_behavior) {
-  // TODO: needs PlatformWindow support.
-  NOTIMPLEMENTED_LOG_ONCE();
+  if (platform_window()->RunMoveLoop(drag_offset))
+    return Widget::MOVE_LOOP_SUCCESSFUL;
   return Widget::MOVE_LOOP_CANCELED;
 }
 
 void DesktopWindowTreeHostPlatform::EndMoveLoop() {
-  // TODO: needs PlatformWindow support.
-  NOTIMPLEMENTED_LOG_ONCE();
+  platform_window()->StopMoveLoop();
 }
 
 void DesktopWindowTreeHostPlatform::SetVisibilityChangedAnimationsEnabled(

--- a/ui/views/widget/desktop_aura/x11_move_loop_delegate.h
+++ b/ui/views/widget/desktop_aura/x11_move_loop_delegate.h
@@ -14,6 +14,8 @@ namespace views {
 // Receives mouse events while the X11MoveLoop is tracking a drag.
 class X11MoveLoopDelegate {
  public:
+  virtual ~X11MoveLoopDelegate() {}
+
   // Called when we receive a mouse move event.
   virtual void OnMouseMovement(const gfx::Point& screen_point,
                                int flags,


### PR DESCRIPTION
There are 3 changes comparing to previous change.
1) Removed changes at services.
2) Added GetLocalProcessWindowAtPointOzone to support tab dragging without mus on ozone.
It's similar to GetLocalProcessWindowAtPointMus.
3) Added body at RunMoveLoop/EndMoveLoop from DesktopWindowTreeHostPlatform.
PTAL.