### PR TITLE
DoNotCarryForward [ozone] Call OnNativeWidgetDestroying on destruction.

### DIFF
--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
@@ -123,6 +123,8 @@ void DesktopWindowTreeHostPlatform::CloseNow() {
   if (!weak_ref || got_on_closed_)
     return;
 
+  native_widget_delegate_->OnNativeWidgetDestroying();
+
   // Remove the event listeners we've installed. We need to remove these
   // because otherwise we get assert during ~WindowEventDispatcher().
   desktop_native_widget_aura_->root_window_event_filter()->RemoveHandler(


### PR DESCRIPTION
DesktopWindowTreeHostPlatform must notify native widget delegate
about destruction. This allows to properly release resources,
and fixes a AccessebilityChecker in browser_tests.

Bug: 578890
Change-Id: I316fda5a2b2f35c865e192fc12274bc57cc2f1bf

This is a cherry-pick to enable browser tests.
https://chromium-review.googlesource.com/c/chromium/src/+/1059208
TBR=jkim@igalia.com
#433 