### PR TITLE
Ozone wayland dev refactoring v4 l2 vda

### DIFF
--- a/media/gpu/BUILD.gn
+++ b/media/gpu/BUILD.gn
@@ -16,6 +16,7 @@ buildflag_header("buildflags") {
     "USE_VAAPI=$use_vaapi",
     "USE_V4L2_CODEC=$use_v4l2_codec",
     "USE_LIBV4L2=$use_v4lplugin",
+    "USE_LINUX_V4L2=$use_linux_v4l2_only",
   ]
 }
 
@@ -23,7 +24,7 @@ if (is_mac) {
   import("//build/config/mac/mac_sdk.gni")
 }
 
-if (is_chromeos && use_v4lplugin) {
+if (use_v4lplugin) {
   action("libv4l2_generate_stubs") {
     extra_header = "v4l2/v4l2_stub_header.fragment"
 
@@ -217,12 +218,11 @@ component("gpu") {
     }
   }
 
-  if (use_v4lplugin) {
-    sources += get_target_outputs(":libv4l2_generate_stubs")
-    deps += [ ":libv4l2_generate_stubs" ]
-  }
-
   if (use_v4l2_codec) {
+    if (use_v4lplugin) {
+      sources += get_target_outputs(":libv4l2_generate_stubs")
+      deps += [ ":libv4l2_generate_stubs" ]
+    }
     deps += [
       "//third_party/libyuv",
       "//ui/ozone",
@@ -234,15 +234,19 @@ component("gpu") {
       "v4l2/v4l2_device.h",
       "v4l2/v4l2_image_processor.cc",
       "v4l2/v4l2_image_processor.h",
-      "v4l2/v4l2_jpeg_decode_accelerator.cc",
-      "v4l2/v4l2_jpeg_decode_accelerator.h",
-      "v4l2/v4l2_slice_video_decode_accelerator.cc",
-      "v4l2/v4l2_slice_video_decode_accelerator.h",
       "v4l2/v4l2_video_decode_accelerator.cc",
       "v4l2/v4l2_video_decode_accelerator.h",
       "v4l2/v4l2_video_encode_accelerator.cc",
       "v4l2/v4l2_video_encode_accelerator.h",
     ]
+    if (!use_linux_v4l2_only) {
+      sources += [
+        "v4l2_jpeg_decode_accelerator.cc",
+        "v4l2_jpeg_decode_accelerator.h",
+        "v4l2_slice_video_decode_accelerator.cc",
+        "v4l2_slice_video_decode_accelerator.h",
+      ]
+    }
     libs = [
       "EGL",
       "GLESv2",

--- a/media/gpu/args.gni
+++ b/media/gpu/args.gni
@@ -10,6 +10,10 @@ declare_args() {
   # platforms which have v4l2 hardware encoder / decoder.
   use_v4l2_codec = false
 
+  # Indicates that only definitions available in the mainline linux kernel
+  # will be used.
+  use_linux_v4l2_only = false
+
   # Indicates if VA-API-based hardware acceleration is to be used. This
   # is typically the case on x86-based ChromeOS devices.
   use_vaapi = false

--- a/media/gpu/gpu_jpeg_decode_accelerator_factory.cc
+++ b/media/gpu/gpu_jpeg_decode_accelerator_factory.cc
@@ -13,7 +13,7 @@
 #include "media/gpu/buildflags.h"
 #include "media/gpu/fake_jpeg_decode_accelerator.h"
 
-#if BUILDFLAG(USE_V4L2_CODEC) && defined(ARCH_CPU_ARM_FAMILY)
+#if BUILDFLAG(USE_V4L2_CODEC) && defined(ARCH_CPU_ARM_FAMILY) && !BUILDFLAG(USE_LINUX_V4L2)
 #define USE_V4L2_JDA
 #endif
 

--- a/media/gpu/gpu_video_decode_accelerator_factory.cc
+++ b/media/gpu/gpu_video_decode_accelerator_factory.cc
@@ -24,7 +24,9 @@
 #endif
 #if BUILDFLAG(USE_V4L2_CODEC)
 #include "media/gpu/v4l2/v4l2_device.h"
+#if !BUILDFLAG(USE_LINUX_V4L2)
 #include "media/gpu/v4l2/v4l2_slice_video_decode_accelerator.h"
+#endif
 #include "media/gpu/v4l2/v4l2_video_decode_accelerator.h"
 #include "ui/gl/gl_surface_egl.h"
 #endif
@@ -98,9 +100,11 @@ GpuVideoDecodeAcceleratorFactory::GetDecoderCapabilities(
   vda_profiles = V4L2VideoDecodeAccelerator::GetSupportedProfiles();
   GpuVideoAcceleratorUtil::InsertUniqueDecodeProfiles(
       vda_profiles, &capabilities.supported_profiles);
+#if !BUILDFLAG(USE_LINUX_V4L2)
   vda_profiles = V4L2SliceVideoDecodeAccelerator::GetSupportedProfiles();
   GpuVideoAcceleratorUtil::InsertUniqueDecodeProfiles(
       vda_profiles, &capabilities.supported_profiles);
+#endif
 #endif
 #if BUILDFLAG(USE_VAAPI)
   vda_profiles = VaapiVideoDecodeAccelerator::GetSupportedProfiles();
@@ -144,7 +148,9 @@ GpuVideoDecodeAcceleratorFactory::CreateVDA(
 #endif
 #if BUILDFLAG(USE_V4L2_CODEC)
     &GpuVideoDecodeAcceleratorFactory::CreateV4L2VDA,
+#if !BUILDFLAG(USE_LINUX_V4L2)
     &GpuVideoDecodeAcceleratorFactory::CreateV4L2SVDA,
+#endif
 #endif
 #if BUILDFLAG(USE_VAAPI)
     &GpuVideoDecodeAcceleratorFactory::CreateVaapiVDA,
@@ -199,6 +205,7 @@ GpuVideoDecodeAcceleratorFactory::CreateV4L2VDA(
   return decoder;
 }
 
+#if !BUILDFLAG(USE_LINUX_V4L2)
 std::unique_ptr<VideoDecodeAccelerator>
 GpuVideoDecodeAcceleratorFactory::CreateV4L2SVDA(
     const gpu::GpuDriverBugWorkarounds& workarounds,
@@ -213,6 +220,7 @@ GpuVideoDecodeAcceleratorFactory::CreateV4L2SVDA(
   }
   return decoder;
 }
+#endif
 #endif
 
 #if BUILDFLAG(USE_VAAPI)

--- a/media/gpu/gpu_video_decode_accelerator_factory.h
+++ b/media/gpu/gpu_video_decode_accelerator_factory.h
@@ -108,10 +108,12 @@ class MEDIA_GPU_EXPORT GpuVideoDecodeAcceleratorFactory {
       const gpu::GpuDriverBugWorkarounds& workarounds,
       const gpu::GpuPreferences& gpu_preferences,
       MediaLog* media_log) const;
+#if !BUILDFLAG(USE_LINUX_V4L2)
   std::unique_ptr<VideoDecodeAccelerator> CreateV4L2SVDA(
       const gpu::GpuDriverBugWorkarounds& workarounds,
       const gpu::GpuPreferences& gpu_preferences,
       MediaLog* media_log) const;
+#endif
 #endif
 #if BUILDFLAG(USE_VAAPI)
   std::unique_ptr<VideoDecodeAccelerator> CreateVaapiVDA(

--- a/media/gpu/v4l2/generic_v4l2_device.cc
+++ b/media/gpu/v4l2/generic_v4l2_device.cc
@@ -474,7 +474,11 @@ bool GenericV4L2Device::OpenDevicePath(const std::string& path, Type type) {
     return false;
 
 #if BUILDFLAG(USE_LIBV4L2)
+#if BUILDFLAG(USE_LINUX_V4L2)
+  if (
+#else
   if (type == Type::kEncoder &&
+#endif
       HANDLE_EINTR(v4l2_fd_open(device_fd_.get(), V4L2_DISABLE_CONVERSION)) !=
           -1) {
     VLOGF(2) << "Using libv4l2 for " << path;

--- a/media/gpu/v4l2/generic_v4l2_device.cc
+++ b/media/gpu/v4l2/generic_v4l2_device.cc
@@ -102,10 +102,20 @@ void* GenericV4L2Device::Mmap(void* addr,
                               int flags,
                               unsigned int offset) {
   DCHECK(device_fd_.is_valid());
+#if BUILDFLAG(USE_LIBV4L2)
+  if (use_libv4l2_)
+    return v4l2_mmap(addr, len, prot, flags, device_fd_.get(), offset);
+#endif
   return mmap(addr, len, prot, flags, device_fd_.get(), offset);
 }
 
 void GenericV4L2Device::Munmap(void* addr, unsigned int len) {
+#if BUILDFLAG(USE_LIBV4L2)
+  if (use_libv4l2_) {
+    v4l2_munmap(addr, len);
+    return;
+  }
+#endif
   munmap(addr, len);
 }
 

--- a/media/gpu/v4l2/v4l2.sig
+++ b/media/gpu/v4l2/v4l2.sig
@@ -8,3 +8,5 @@
 LIBV4L_PUBLIC int v4l2_close(int fd);
 LIBV4L_PUBLIC int v4l2_ioctl(int fd, unsigned long int request, ...);
 LIBV4L_PUBLIC int v4l2_fd_open(int fd, int v4l2_flags);
+LIBV4L_PUBLIC void *v4l2_mmap(void *start, size_t length, int prot, int flags, int fd, int64_t offset);
+LIBV4L_PUBLIC int v4l2_munmap(void *_start, size_t length);

--- a/media/gpu/v4l2/v4l2_device.cc
+++ b/media/gpu/v4l2/v4l2_device.cc
@@ -93,6 +93,19 @@ uint32_t V4L2Device::VideoPixelFormatToV4L2PixFmt(VideoPixelFormat format) {
 }
 
 // static
+#if BUILDFLAG(USE_LINUX_V4L2)
+uint32_t V4L2Device::VideoCodecProfileToV4L2PixFmt(VideoCodecProfile profile,
+                                                  bool slice_based) {
+  if (profile >= H264PROFILE_MIN && profile <= H264PROFILE_MAX) {
+    return V4L2_PIX_FMT_H264;
+  } else if (profile >= VP8PROFILE_MIN && profile <= VP8PROFILE_MAX) {
+    return V4L2_PIX_FMT_VP8;
+  } else {
+    LOG(FATAL) << "Add more cases as needed";
+    return 0;
+  }
+}
+#else
 uint32_t V4L2Device::VideoCodecProfileToV4L2PixFmt(VideoCodecProfile profile,
                                                    bool slice_based) {
   if (profile >= H264PROFILE_MIN && profile <= H264PROFILE_MAX) {
@@ -115,6 +128,7 @@ uint32_t V4L2Device::VideoCodecProfileToV4L2PixFmt(VideoCodecProfile profile,
     return 0;
   }
 }
+#endif
 
 // static
 std::vector<VideoCodecProfile> V4L2Device::V4L2PixFmtToVideoCodecProfiles(
@@ -125,7 +139,9 @@ std::vector<VideoCodecProfile> V4L2Device::V4L2PixFmtToVideoCodecProfiles(
 
   switch (pix_fmt) {
     case V4L2_PIX_FMT_H264:
+#if !BUILDFLAG(USE_LINUX_V4L2)
     case V4L2_PIX_FMT_H264_SLICE:
+#endif
       if (is_encoder) {
         // TODO(posciak): need to query the device for supported H.264 profiles,
         // for now choose Main as a sensible default.
@@ -138,11 +154,14 @@ std::vector<VideoCodecProfile> V4L2Device::V4L2PixFmtToVideoCodecProfiles(
       break;
 
     case V4L2_PIX_FMT_VP8:
+#if !BUILDFLAG(USE_LINUX_V4L2)
     case V4L2_PIX_FMT_VP8_FRAME:
+#endif
       min_profile = VP8PROFILE_MIN;
       max_profile = VP8PROFILE_MAX;
       break;
 
+#if !BUILDFLAG(USE_LINUX_V4L2)
     case V4L2_PIX_FMT_VP9:
     case V4L2_PIX_FMT_VP9_FRAME:
       // TODO(posciak): https://crbug.com/819930 Query supported profiles.
@@ -150,6 +169,7 @@ std::vector<VideoCodecProfile> V4L2Device::V4L2PixFmtToVideoCodecProfiles(
       min_profile = VP9PROFILE_PROFILE0;
       max_profile = VP9PROFILE_PROFILE0;
       break;
+#endif
 
     default:
       VLOGF(1) << "Unhandled pixelformat " << std::hex << "0x" << pix_fmt;
@@ -179,8 +199,10 @@ uint32_t V4L2Device::V4L2PixFmtToDrmFormat(uint32_t format) {
     case V4L2_PIX_FMT_RGB32:
       return DRM_FORMAT_ARGB8888;
 
+#if !BUILDFLAG(USE_LINUX_V4L2)
     case V4L2_PIX_FMT_MT21:
       return DRM_FORMAT_MT21;
+#endif
 
     default:
       DVLOGF(1) << "Unrecognized format " << std::hex << "0x" << format;

--- a/media/gpu/v4l2/v4l2_video_decode_accelerator.cc
+++ b/media/gpu/v4l2/v4l2_video_decode_accelerator.cc
@@ -24,6 +24,7 @@
 #include "build/build_config.h"
 #include "media/base/media_switches.h"
 #include "media/gpu/shared_memory_region.h"
+#include "media/gpu/features.h"
 #include "media/video/h264_parser.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gl/gl_context.h"
@@ -64,7 +65,10 @@ namespace media {
 
 // static
 const uint32_t V4L2VideoDecodeAccelerator::supported_input_fourccs_[] = {
-    V4L2_PIX_FMT_H264, V4L2_PIX_FMT_VP8, V4L2_PIX_FMT_VP9,
+    V4L2_PIX_FMT_H264, V4L2_PIX_FMT_VP8,
+#if !BUILDFLAG(USE_LINUX_V4L2)
+    V4L2_PIX_FMT_VP9,
+#endif
 };
 
 struct V4L2VideoDecodeAccelerator::BitstreamBufferRef {


### PR DESCRIPTION
It brought 3 commits from previous branch.
1)Add support for V4L2VDA on Linux(commit 8626a15)
2)Add mmap via libv4l to generic_v4l2_device(commit c01b789)
3)fixup! avoid building not declared formats(commit 26605b5)

It squashed 1) and 3) and now it has 2 commits.