### PR TITLE
DoNotCarryForward [ozone] Set screen to enable content_shell

### DIFF
--- a/content/shell/browser/shell_views.cc
+++ b/content/shell/browser/shell_views.cc
@@ -347,9 +347,7 @@ void Shell::PlatformInitialize(const gfx::Size& default_window_size) {
 #else
 #if defined(USE_AURA)
   wm_state_ = new wm::WMState;
-#endif
-#if !defined(USE_OZONE)
-  display::Screen::SetScreenInstance(views::CreateDesktopScreen());
+  views::InstallDesktopScreenIfNecessary();
 #endif
 #endif
   views_delegate_ = new views::DesktopTestViewsDelegate();


### PR DESCRIPTION
This cl fixes a content_shell and content_browsertests start by setting desktop screen on init.

Once this and another cl (crrev.com/c/1059208) are in place, we can start enabling tests.

Change-Id: I564908545786cb419b3af4dbf617b84b84583ac2