### PR TITLE
[DoNotCarryForward] Declare the template specialization of BubbleDialogDelegateView.

### DIFF
--- a/ui/views/view_properties.h
+++ b/ui/views/view_properties.h
@@ -34,5 +34,7 @@ VIEWS_EXPORT extern const ui::ClassProperty<BubbleDialogDelegateView*>* const
 // template instance before its specialization is declared in a
 // translation unit is a C++ error.
 DECLARE_EXPORTED_UI_CLASS_PROPERTY_TYPE(VIEWS_EXPORT, gfx::Insets*);
+DECLARE_EXPORTED_UI_CLASS_PROPERTY_TYPE(VIEWS_EXPORT,
+                                        views::BubbleDialogDelegateView*);
 
 #endif  // UI_VIEWS_VIEW_PROPERTIES_H_


### PR DESCRIPTION
This CL declares the template specialization to resolve building issues
with all possible build configurations like jumbo, component build and etc.

The build error was:

./../../ui/views/view_properties.cc:17:1: error: explicit specialization of 'GetProperty<views::BubbleDialogDelegateView *>' after instantiation
DEFINE_EXPORTED_UI_CLASS_PROPERTY_TYPE(VIEWS_EXPORT,
^
../../ui/base/class_property.h:222:20: note: expanded from macro 'DEFINE_EXPORTED_UI_CLASS_PROPERTY_TYPE'

  PropertyHandler::GetProperty(const ClassProperty<T>* property) const {     \
                   ^
./../../ui/views/focus/focus_search.cc:189:65: note: implicit instantiation first required here
          static_cast<BubbleDialogDelegateView*>(starting_view->GetProperty(kAnchoredDialogKey));
                                                                ^
Bug: 764918
Change-Id: I7daecebfafe36750e9461e8d261093e654b89a65

TBR=jkim@igalia.com