### PR TITLE
fixup! Make window interactions (move, resize, double click and etc) working

### DIFF
--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.h
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.h
@@ -101,6 +101,8 @@ class VIEWS_EXPORT DesktopWindowTreeHostPlatform
  private:
   void Relayout();
 
+  void RemoveNonClientEventFilter();
+
   Widget* GetWidget();
 
   internal::NativeWidgetDelegate* const native_widget_delegate_;


### PR DESCRIPTION
Make sure that compound event filter is destroyed properly.

It may happen that OnClosed is closed, which leads to
DesktopNativeWidgetAura destructions. There is also another path
when DesktopNativeWidgetAura can be destroyed - CloseNow. That is,
if OnClosed has not been closed, CloseNow proceeds and destructs
DesktopNativeWidgetAura.

This patch makes it sure that the non_client_event_filter_ is destroyed
in any case.