### PR TITLE
[ozone/x11] Add initial display data fetching mechanism.

### DIFF
--- a/ui/ozone/platform/x11/BUILD.gn
+++ b/ui/ozone/platform/x11/BUILD.gn
@@ -26,6 +26,8 @@ source_set("x11") {
     "x11_window_manager_ozone.h",
     "x11_window_ozone.cc",
     "x11_window_ozone.h",
+    "x11_native_display_delegate.h",
+    "x11_native_display_delegate.cc",
   ]
 
   deps = [

--- a/ui/ozone/platform/x11/ozone_platform_x11.cc
+++ b/ui/ozone/platform/x11/ozone_platform_x11.cc
@@ -10,12 +10,12 @@
 #include "base/message_loop/message_loop.h"
 #include "base/strings/utf_string_conversions.h"
 #include "ui/base/x/x11_util.h"
-#include "ui/display/manager/fake_display_delegate.h"
 #include "ui/events/devices/x11/touch_factory_x11.h"
 #include "ui/events/platform/x11/x11_event_source_libevent.h"
 #include "ui/events/system_input_injector.h"
 #include "ui/gfx/x/x11.h"
 #include "ui/ozone/common/stub_overlay_manager.h"
+#include "ui/ozone/platform/x11/x11_native_display_delegate.h"
 #include "ui/ozone/platform/x11/x11_cursor_factory_ozone.h"
 #include "ui/ozone/platform/x11/x11_surface_factory.h"
 #include "ui/ozone/platform/x11/x11_window_manager_ozone.h"
@@ -72,7 +72,7 @@ class OzonePlatformX11 : public OzonePlatform {
 
   std::unique_ptr<display::NativeDisplayDelegate> CreateNativeDisplayDelegate()
       override {
-    return std::make_unique<display::FakeDisplayDelegate>();
+    return std::make_unique<X11NativeDisplayDelegate>();
   }
 
   void InitializeUI(const InitParams& params) override {

--- a/ui/ozone/platform/x11/x11_native_display_delegate.cc
+++ b/ui/ozone/platform/x11/x11_native_display_delegate.cc
@@ -1,0 +1,104 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/ozone/platform/x11/x11_native_display_delegate.h"
+
+#include "ui/display/types/display_snapshot.h"
+#include "ui/display/types/native_display_observer.h"
+#include "ui/gfx/x/x11.h"
+#include "ui/gfx/x/x11_types.h"
+
+namespace ui {
+
+X11NativeDisplayDelegate::X11NativeDisplayDelegate() = default;
+
+X11NativeDisplayDelegate::~X11NativeDisplayDelegate() = default;
+
+void X11NativeDisplayDelegate::Initialize() {
+  // This shouldn't be called twice.
+  DCHECK(!current_snapshot_);
+
+  XDisplay* display = gfx::GetXDisplay();
+  Screen* screen = DefaultScreenOfDisplay(display);
+  current_snapshot_.reset(new display::DisplaySnapshot(
+      XScreenNumberOfScreen(screen), gfx::Point(0, 0),
+      gfx::Size(WidthOfScreen(screen), HeightOfScreen(screen)),
+      display::DisplayConnectionType::DISPLAY_CONNECTION_TYPE_NONE, false,
+      false, false, gfx::ColorSpace(), "", base::FilePath(),
+      display::DisplaySnapshot::DisplayModeList(), std::vector<uint8_t>(),
+      nullptr, nullptr, 0, 0, gfx::Size()));
+  const int default_refresh = 60;
+  current_mode_.reset(new display::DisplayMode(
+      gfx::Size(WidthOfScreen(screen), HeightOfScreen(screen)), false,
+      default_refresh));
+  current_snapshot_->set_current_mode(current_mode_.get());
+
+  for (display::NativeDisplayObserver& observer : observers_)
+    observer.OnConfigurationChanged();
+}
+
+void X11NativeDisplayDelegate::TakeDisplayControl(
+    display::DisplayControlCallback callback) {
+  NOTREACHED();
+}
+
+void X11NativeDisplayDelegate::RelinquishDisplayControl(
+    display::DisplayControlCallback callback) {
+  NOTREACHED();
+}
+
+void X11NativeDisplayDelegate::GetDisplays(
+    display::GetDisplaysCallback callback) {
+  // TODO(msisov): Add support for multiple displays and dynamic display data
+  // change.
+  std::vector<display::DisplaySnapshot*> snapshot;
+  snapshot.push_back(current_snapshot_.get());
+  std::move(callback).Run(snapshot);
+}
+
+void X11NativeDisplayDelegate::Configure(const display::DisplaySnapshot& output,
+                                         const display::DisplayMode* mode,
+                                         const gfx::Point& origin,
+                                         display::ConfigureCallback callback) {
+  NOTREACHED();
+}
+
+void X11NativeDisplayDelegate::GetHDCPState(
+    const display::DisplaySnapshot& output,
+    display::GetHDCPStateCallback callback) {
+  NOTREACHED();
+}
+
+void X11NativeDisplayDelegate::SetHDCPState(
+    const display::DisplaySnapshot& output,
+    display::HDCPState state,
+    display::SetHDCPStateCallback callback) {
+  NOTREACHED();
+}
+
+bool X11NativeDisplayDelegate::SetColorCorrection(
+    const display::DisplaySnapshot& output,
+    const std::vector<display::GammaRampRGBEntry>& degamma_lut,
+    const std::vector<display::GammaRampRGBEntry>& gamma_lut,
+    const std::vector<float>& correction_matrix) {
+  NOTREACHED();
+  return false;
+}
+
+void X11NativeDisplayDelegate::AddObserver(
+    display::NativeDisplayObserver* observer) {
+  observers_.AddObserver(observer);
+}
+
+void X11NativeDisplayDelegate::RemoveObserver(
+    display::NativeDisplayObserver* observer) {
+  observers_.RemoveObserver(observer);
+}
+
+display::FakeDisplayController*
+X11NativeDisplayDelegate::GetFakeDisplayController() {
+  return nullptr;
+}
+
+}  // namespace ui

--- a/ui/ozone/platform/x11/x11_native_display_delegate.h
+++ b/ui/ozone/platform/x11/x11_native_display_delegate.h
@@ -1,0 +1,55 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_OZONE_PLATFORM_X11_X11_NATIVE_DISPLAY_DELEGATE_H_
+#define UI_OZONE_PLATFORM_X11_X11_NATIVE_DISPLAY_DELEGATE_H_
+
+#include "base/macros.h"
+#include "base/observer_list.h"
+#include "ui/display/types/native_display_delegate.h"
+#include "ui/display/types/display_snapshot.h"
+
+namespace ui {
+
+class X11NativeDisplayDelegate : public display::NativeDisplayDelegate {
+ public:
+  X11NativeDisplayDelegate();
+  ~X11NativeDisplayDelegate();
+
+  // display::NativeDisplayDelegate overrides:
+  void Initialize() override;
+  void TakeDisplayControl(display::DisplayControlCallback callback) override;
+  void RelinquishDisplayControl(
+      display::DisplayControlCallback callback) override;
+  void GetDisplays(display::GetDisplaysCallback callback) override;
+  void Configure(const display::DisplaySnapshot& output,
+                 const display::DisplayMode* mode,
+                 const gfx::Point& origin,
+                 display::ConfigureCallback callback) override;
+  void GetHDCPState(const display::DisplaySnapshot& output,
+                    display::GetHDCPStateCallback callback) override;
+  void SetHDCPState(const display::DisplaySnapshot& output,
+                    display::HDCPState state,
+                    display::SetHDCPStateCallback callback) override;
+  bool SetColorCorrection(
+      const display::DisplaySnapshot& output,
+      const std::vector<display::GammaRampRGBEntry>& degamma_lut,
+      const std::vector<display::GammaRampRGBEntry>& gamma_lut,
+      const std::vector<float>& correction_matrix) override;
+  void AddObserver(display::NativeDisplayObserver* observer) override;
+  void RemoveObserver(display::NativeDisplayObserver* observer) override;
+  display::FakeDisplayController* GetFakeDisplayController() override;
+
+ private:
+  std::unique_ptr<display::DisplaySnapshot> current_snapshot_;
+  std::unique_ptr<display::DisplayMode> current_mode_;
+ 
+  base::ObserverList<display::NativeDisplayObserver> observers_;
+
+  DISALLOW_COPY_AND_ASSIGN(X11NativeDisplayDelegate);
+};
+
+}  // namespace ui
+
+#endif  // UI_OZONE_PLATFORM_X11_X11_NATIVE_DISPLAY_DELEGATE_H_


### PR DESCRIPTION
Make sure that compound event filter is destroyed properly.

It may happen that OnClosed is closed, which leads to
DesktopNativeWidgetAura destructions. There is also another path
when DesktopNativeWidgetAura can be destroyed - CloseNow. That is,
if OnClosed has not been closed, CloseNow proceeds and destructs
DesktopNativeWidgetAura.

This patch makes it sure that the non_client_event_filter_ is destroyed
in any case.

#426 