### PR TITLE
[ozone/x11] Use sanitized bounds if such are not provided.

### DIFF
--- a/ui/platform_window/x11/x11_window_base.cc
+++ b/ui/platform_window/x11/x11_window_base.cc
@@ -88,7 +88,7 @@ X11WindowBase::X11WindowBase(PlatformWindowDelegate* delegate,
     : delegate_(delegate),
       xdisplay_(gfx::GetXDisplay()),
       xroot_window_(DefaultRootWindow(xdisplay_)),
-      bounds_(bounds),
+      bounds_(bounds.IsEmpty() ? gfx::Rect(800,600) : bounds),
       state_(ui::PlatformWindowState::PLATFORM_WINDOW_STATE_UNKNOWN) {
   DCHECK(delegate_);
   Create();


### PR DESCRIPTION
This cl makes it sure sanitized bounds are provided instead of empty
ones, which X11 cannot digest and just crashes.

#426 