### PR TITLE
Added implementation for GetRestoredBounds with Desktop/Aura/Ozone

### DIFF
--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
@@ -267,8 +267,7 @@ gfx::Rect DesktopWindowTreeHostPlatform::GetClientAreaBoundsInScreen() const {
 }
 
 gfx::Rect DesktopWindowTreeHostPlatform::GetRestoredBounds() const {
-  NOTIMPLEMENTED_LOG_ONCE();
-  return gfx::Rect(0, 0, 640, 840);
+  return GetBoundsInPixels();
 }
 
 std::string DesktopWindowTreeHostPlatform::GetWorkspace() const {


### PR DESCRIPTION
This patch made DesktopWindowTreeHostPlatform::GetRestoredBounds
return GetBoundsInPixels because it has platform window's bounds
and platform window has updated bounds.

Issue #448 