### PR TITLE
[ozone/headless] Add HeadlessNativeDisplayDelegate.

### DIFF
--- a/ui/ozone/platform/headless/BUILD.gn
+++ b/ui/ozone/platform/headless/BUILD.gn
@@ -10,6 +10,8 @@ source_set("headless") {
     "client_native_pixmap_factory_headless.h",
     "gl_surface_osmesa_png.cc",
     "gl_surface_osmesa_png.h",
+    "headless_native_display_delegate.cc",
+    "headless_native_display_delegate.h",
     "headless_surface_factory.cc",
     "headless_surface_factory.h",
     "headless_window.cc",

--- a/ui/ozone/platform/headless/headless_native_display_delegate.cc
+++ b/ui/ozone/platform/headless/headless_native_display_delegate.cc
@@ -1,0 +1,113 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/ozone/platform/headless/headless_native_display_delegate.h"
+
+#include "ui/display/types/display_snapshot.h"
+#include "ui/display/types/native_display_observer.h"
+
+namespace ui {
+
+namespace {
+constexpr gfx::Size kDefaultWindowSize(800, 600);
+constexpr int default_refresh = 60;
+}
+
+HeadlessNativeDisplayDelegate::HeadlessNativeDisplayDelegate() = default;
+
+HeadlessNativeDisplayDelegate::~HeadlessNativeDisplayDelegate() = default;
+
+void HeadlessNativeDisplayDelegate::Initialize() {
+  // This shouldn't be called twice.
+  DCHECK(!current_snapshot_);
+
+  if (next_display_id_ == std::numeric_limits<int64_t>::max()) {
+    LOG(FATAL) << "Exceeded display id limit";
+    return;
+  }
+
+  current_snapshot_.reset(new display::DisplaySnapshot(
+      get_next_display_id(), gfx::Point(0, 0), kDefaultWindowSize,
+      display::DisplayConnectionType::DISPLAY_CONNECTION_TYPE_NONE, false,
+      false, false, gfx::ColorSpace(), "", base::FilePath(),
+      display::DisplaySnapshot::DisplayModeList(), std::vector<uint8_t>(),
+      nullptr, nullptr, 0, 0, gfx::Size()));
+
+  current_mode_.reset(
+      new display::DisplayMode(kDefaultWindowSize, false, default_refresh));
+  current_snapshot_->set_current_mode(current_mode_.get());
+
+  for (display::NativeDisplayObserver& observer : observers_)
+    observer.OnConfigurationChanged();
+}
+
+void HeadlessNativeDisplayDelegate::TakeDisplayControl(
+    display::DisplayControlCallback callback) {
+  NOTREACHED();
+}
+
+void HeadlessNativeDisplayDelegate::RelinquishDisplayControl(
+    display::DisplayControlCallback callback) {
+  NOTREACHED();
+}
+
+void HeadlessNativeDisplayDelegate::GetDisplays(
+    display::GetDisplaysCallback callback) {
+  std::vector<display::DisplaySnapshot*> snapshot;
+  snapshot.push_back(current_snapshot_.get());
+  std::move(callback).Run(snapshot);
+}
+
+void HeadlessNativeDisplayDelegate::Configure(
+    const display::DisplaySnapshot& output,
+    const display::DisplayMode* mode,
+    const gfx::Point& origin,
+    display::ConfigureCallback callback) {
+  NOTREACHED();
+}
+
+void HeadlessNativeDisplayDelegate::GetHDCPState(
+    const display::DisplaySnapshot& output,
+    display::GetHDCPStateCallback callback) {
+  NOTREACHED();
+}
+
+void HeadlessNativeDisplayDelegate::SetHDCPState(
+    const display::DisplaySnapshot& output,
+    display::HDCPState state,
+    display::SetHDCPStateCallback callback) {
+  NOTREACHED();
+}
+
+bool HeadlessNativeDisplayDelegate::SetColorMatrix(
+    int64_t display_id,
+    const std::vector<float>& color_matrix) {
+  NOTREACHED();
+  return false;
+}
+
+bool HeadlessNativeDisplayDelegate::SetGammaCorrection(
+    int64_t display_id,
+    const std::vector<display::GammaRampRGBEntry>& degamma_lut,
+    const std::vector<display::GammaRampRGBEntry>& gamma_lut) {
+  NOTREACHED();
+  return false;
+}
+
+void HeadlessNativeDisplayDelegate::AddObserver(
+    display::NativeDisplayObserver* observer) {
+  observers_.AddObserver(observer);
+}
+
+void HeadlessNativeDisplayDelegate::RemoveObserver(
+    display::NativeDisplayObserver* observer) {
+  observers_.RemoveObserver(observer);
+}
+
+display::FakeDisplayController*
+HeadlessNativeDisplayDelegate::GetFakeDisplayController() {
+  return nullptr;
+}
+
+}  // namespace ui

--- a/ui/ozone/platform/headless/headless_native_display_delegate.h
+++ b/ui/ozone/platform/headless/headless_native_display_delegate.h
@@ -1,0 +1,60 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_OZONE_PLATFORM_HEADLESS_HEADLESS_NATIVE_DISPLAY_DELEGATE_H_
+#define UI_OZONE_PLATFORM_HEADLESS_HEADLESS_NATIVE_DISPLAY_DELEGATE_H_
+
+#include "base/macros.h"
+#include "base/observer_list.h"
+#include "ui/display/types/display_snapshot.h"
+#include "ui/display/types/native_display_delegate.h"
+
+namespace ui {
+
+class HeadlessNativeDisplayDelegate : public display::NativeDisplayDelegate {
+ public:
+  HeadlessNativeDisplayDelegate();
+  ~HeadlessNativeDisplayDelegate() override;
+
+  // display::NativeDisplayDelegate overrides:
+  void Initialize() override;
+  void TakeDisplayControl(display::DisplayControlCallback callback) override;
+  void RelinquishDisplayControl(
+      display::DisplayControlCallback callback) override;
+  void GetDisplays(display::GetDisplaysCallback callback) override;
+  void Configure(const display::DisplaySnapshot& output,
+                 const display::DisplayMode* mode,
+                 const gfx::Point& origin,
+                 display::ConfigureCallback callback) override;
+  void GetHDCPState(const display::DisplaySnapshot& output,
+                    display::GetHDCPStateCallback callback) override;
+  void SetHDCPState(const display::DisplaySnapshot& output,
+                    display::HDCPState state,
+                    display::SetHDCPStateCallback callback) override;
+  bool SetColorMatrix(int64_t display_id,
+                      const std::vector<float>& color_matrix) override;
+  bool SetGammaCorrection(
+      int64_t display_id,
+      const std::vector<display::GammaRampRGBEntry>& degamma_lut,
+      const std::vector<display::GammaRampRGBEntry>& gamma_lut) override;
+  void AddObserver(display::NativeDisplayObserver* observer) override;
+  void RemoveObserver(display::NativeDisplayObserver* observer) override;
+  display::FakeDisplayController* GetFakeDisplayController() override;
+
+ private:
+  int64_t get_next_display_id() { return next_display_id_++; }
+  std::unique_ptr<display::DisplaySnapshot> current_snapshot_;
+  std::unique_ptr<display::DisplayMode> current_mode_;
+
+  base::ObserverList<display::NativeDisplayObserver> observers_;
+
+  // The next available display id.
+  int64_t next_display_id_ = 0;
+
+  DISALLOW_COPY_AND_ASSIGN(HeadlessNativeDisplayDelegate);
+};
+
+}  // namespace ui
+
+#endif  // UI_OZONE_PLATFORM_HEADLESS_HEADLESS_NATIVE_DISPLAY_DELEGATE_H_

--- a/ui/ozone/platform/headless/ozone_platform_headless.cc
+++ b/ui/ozone/platform/headless/ozone_platform_headless.cc
@@ -8,12 +8,12 @@
 #include "base/files/file_path.h"
 #include "base/macros.h"
 #include "ui/base/cursor/ozone/bitmap_cursor_factory_ozone.h"
-#include "ui/display/manager/fake_display_delegate.h"
 #include "ui/events/ozone/layout/keyboard_layout_engine_manager.h"
 #include "ui/events/ozone/layout/stub/stub_keyboard_layout_engine.h"
 #include "ui/events/platform/platform_event_source.h"
 #include "ui/events/system_input_injector.h"
 #include "ui/ozone/common/stub_overlay_manager.h"
+#include "ui/ozone/platform/headless/headless_native_display_delegate.h"
 #include "ui/ozone/platform/headless/headless_surface_factory.h"
 #include "ui/ozone/platform/headless/headless_window.h"
 #include "ui/ozone/platform/headless/headless_window_manager.h"
@@ -79,7 +79,7 @@ class OzonePlatformHeadless : public OzonePlatform {
   }
   std::unique_ptr<display::NativeDisplayDelegate> CreateNativeDisplayDelegate()
       override {
-    return std::make_unique<display::FakeDisplayDelegate>();
+    return std::make_unique<HeadlessNativeDisplayDelegate>();
   }
 
   void InitializeUI(const InitParams& params) override {


### PR DESCRIPTION
This CL created HeadlessNativeDisplayDelegate for ozone/headless.
DesktopScreenOzone keeps it at delegate_ and communicate it.

With thie CL, we can launch chromium with '--ozone-platform=headless'.