### PR TITLE
Add X11DisplayManager to get display information

### DIFF
--- a/ui/base/x/x11_util.h
+++ b/ui/base/x/x11_util.h
@@ -23,6 +23,7 @@
 #include "ui/events/event_constants.h"
 #include "ui/events/keycodes/keyboard_codes.h"
 #include "ui/events/platform_event.h"
+#include "ui/gfx/icc_profile.h"
 #include "ui/gfx/x/x11_types.h"
 
 typedef unsigned long XSharedMemoryId;  // ShmSeg in the X headers.
@@ -296,6 +297,9 @@ UI_BASE_X_EXPORT bool IsX11WindowFullScreen(XID window);
 
 // Returns true if the window manager supports the given hint.
 UI_BASE_X_EXPORT bool WmSupportsHint(XAtom atom);
+
+// Return the ICCProfile corresponding to |monitor| using XGetWindowProperty.
+UI_BASE_X_EXPORT gfx::ICCProfile GetICCProfileForMonitor(int monitor);
 
 // Manages a piece of X11 allocated memory as a RefCountedMemory segment. This
 // object takes ownership over the passed in memory and will free it with the

--- a/ui/display/util/BUILD.gn
+++ b/ui/display/util/BUILD.gn
@@ -5,6 +5,7 @@
 import("//build/config/jumbo.gni")
 import("//build/config/ui.gni")
 import("//testing/libfuzzer/fuzzer_test.gni")
+import("//ui/ozone/ozone.gni")
 
 jumbo_component("util") {
   output_name = "display_util"
@@ -25,7 +26,7 @@ jumbo_component("util") {
     "//ui/gfx/geometry",
   ]
 
-  if (use_x11) {
+  if (use_x11 || ozone_platform_x11) {
     sources += [
       "x11/edid_parser_x11.cc",
       "x11/edid_parser_x11.h",

--- a/ui/ozone/platform/x11/BUILD.gn
+++ b/ui/ozone/platform/x11/BUILD.gn
@@ -32,6 +32,8 @@ source_set("x11") {
     "x11_window_ozone.h",
     "x11_native_display_delegate.h",
     "x11_native_display_delegate.cc",
+    "x11_display_manager_ozone.h",
+    "x11_display_manager_ozone.cc",
   ]
 
   deps = [
@@ -61,7 +63,10 @@ source_set("x11") {
     deps += [ "//gpu/vulkan/x" ]
   }
 
-  configs += [ "//build/config/linux:x11" ]
+  configs += [
+    "//build/config/linux:x11",
+    "//build/config/linux:xrandr"
+  ]
 
   public_configs = [ "//third_party/khronos:khronos_headers" ]
 }

--- a/ui/ozone/platform/x11/x11_display_manager_ozone.cc
+++ b/ui/ozone/platform/x11/x11_display_manager_ozone.cc
@@ -1,0 +1,231 @@
+// Copyright (c) 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ui/ozone/platform/x11/x11_display_manager_ozone.h"
+
+#include "base/logging.h"
+#include "base/memory/protected_memory_cfi.h"
+#include "ui/base/x/x11_util.h"
+#include "ui/display/display.h"
+#include "ui/display/util/display_util.h"
+#include "ui/display/util/x11/edid_parser_x11.h"
+#include "ui/events/platform/platform_event_source.h"
+#include "ui/gfx/x/x11.h"
+#include "ui/gfx/x/x11_atom_cache.h"
+#include "ui/gfx/x/x11_types.h"
+
+#include <dlfcn.h>
+
+namespace ui {
+
+namespace {
+
+constexpr int default_refresh = 60;
+
+X11DisplayManagerOzone::Snapshot CreateSnapshot(int64_t display_id,
+                                                gfx::Rect bounds,
+                                                gfx::ColorSpace color_space) {
+  std::unique_ptr<display::DisplaySnapshot> snapshot =
+      std::make_unique<display::DisplaySnapshot>(
+          display_id, gfx::Point(bounds.x(), bounds.y()),
+          gfx::Size(bounds.width(), bounds.height()),
+          display::DisplayConnectionType::DISPLAY_CONNECTION_TYPE_NONE, false,
+          false, false, color_space, "", base::FilePath(),
+          display::DisplaySnapshot::DisplayModeList(), std::vector<uint8_t>(),
+          nullptr, nullptr, 0, 0, gfx::Size());
+  std::unique_ptr<display::DisplayMode> current_mode =
+      std::make_unique<display::DisplayMode>(
+          gfx::Size(bounds.width(), bounds.height()), false, default_refresh);
+  snapshot->set_current_mode(current_mode.get());
+  return std::make_pair(std::move(snapshot), std::move(current_mode));
+}
+
+void BuildFallbackDisplayList(
+    X11DisplayManagerOzone::OwnedDisplaySnapshot& output) {
+  ::XDisplay* display = gfx::GetXDisplay();
+  ::Screen* screen = DefaultScreenOfDisplay(display);
+  int width = WidthOfScreen(screen);
+  int height = HeightOfScreen(screen);
+  int64_t display_id = 0;
+  gfx::Rect bounds(0, 0, width, height);
+  output.emplace(display_id,
+                 CreateSnapshot(display_id, bounds, gfx::ColorSpace()));
+}
+
+}  // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+// X11DisplayManagerOzone, public:
+
+X11DisplayManagerOzone::X11DisplayManagerOzone()
+    : xdisplay_(gfx::GetXDisplay()),
+      x_root_window_(DefaultRootWindow(xdisplay_)),
+      xrandr_version_(0),
+      xrandr_event_base_(0),
+      weak_factory_(this) {
+  // We only support 1.3+. There were library changes before this and we should
+  // use the new interface instead of the 1.2 one.
+  int randr_version_major = 0;
+  int randr_version_minor = 0;
+  if (XRRQueryVersion(xdisplay_, &randr_version_major, &randr_version_minor)) {
+    xrandr_version_ = randr_version_major * 100 + randr_version_minor;
+  }
+  // Need at least xrandr version 1.3.
+  if (xrandr_version_ < 103) {
+    BuildFallbackDisplayList(displays_);
+    return;
+  }
+
+  int error_base_ignored = 0;
+  XRRQueryExtension(xdisplay_, &xrandr_event_base_, &error_base_ignored);
+
+  if (ui::PlatformEventSource::GetInstance())
+    ui::PlatformEventSource::GetInstance()->AddPlatformEventDispatcher(this);
+  XRRSelectInput(xdisplay_, x_root_window_,
+                 RRScreenChangeNotifyMask | RROutputChangeNotifyMask |
+                     RRCrtcChangeNotifyMask);
+  BuildDisplaysFromXRandRInfo();
+  return;
+}
+
+X11DisplayManagerOzone::~X11DisplayManagerOzone() {
+  if (xrandr_version_ >= 103 && ui::PlatformEventSource::GetInstance())
+    ui::PlatformEventSource::GetInstance()->RemovePlatformEventDispatcher(this);
+}
+
+void X11DisplayManagerOzone::SetObserver(Observer* observer) {
+  observer_ = observer;
+  if (displays_.size() > 0)
+    observer_->OnOutputReadyForUse();
+}
+
+void X11DisplayManagerOzone::GetDisplaysSnapshot(
+    display::GetDisplaysCallback callback) {
+  std::vector<display::DisplaySnapshot*> snapshots;
+  for (const auto& iter : displays_) {
+    auto& snapshot_pair = iter.second;
+    display::DisplaySnapshot* snapshot = snapshot_pair.first.get();
+    snapshots.push_back(snapshot);
+  }
+  std::move(callback).Run(snapshots);
+}
+
+bool X11DisplayManagerOzone::CanDispatchEvent(const ui::PlatformEvent& event) {
+  // TODO(msisov, jkim): implement this.
+  NOTIMPLEMENTED_LOG_ONCE();
+  return false;
+}
+
+uint32_t X11DisplayManagerOzone::DispatchEvent(const ui::PlatformEvent& event) {
+  // TODO(msisov, jkim): implement this.
+  NOTIMPLEMENTED_LOG_ONCE();
+  return ui::POST_DISPATCH_NONE;
+}
+
+typedef XRRMonitorInfo* (*XRRGetMonitors)(::Display*, Window, bool, int*);
+typedef void (*XRRFreeMonitors)(XRRMonitorInfo*);
+
+PROTECTED_MEMORY_SECTION base::ProtectedMemory<XRRGetMonitors>
+    g_XRRGetMonitors_ptr;
+PROTECTED_MEMORY_SECTION base::ProtectedMemory<XRRFreeMonitors>
+    g_XRRFreeMonitors_ptr;
+
+void X11DisplayManagerOzone::BuildDisplaysFromXRandRInfo() {
+  DCHECK(xrandr_version_ >= 103);
+  gfx::XScopedPtr<
+      XRRScreenResources,
+      gfx::XObjectDeleter<XRRScreenResources, void, XRRFreeScreenResources>>
+      resources(XRRGetScreenResourcesCurrent(xdisplay_, x_root_window_));
+  if (!resources) {
+    LOG(ERROR) << "XRandR returned no displays. Falling back to Root Window.";
+    BuildFallbackDisplayList(displays_);
+    return;
+  }
+
+  std::map<RROutput, int> output_to_monitor;
+  if (xrandr_version_ >= 105) {
+    void* xrandr_lib = dlopen(NULL, RTLD_NOW);
+    if (xrandr_lib) {
+      static base::ProtectedMemory<XRRGetMonitors>::Initializer get_init(
+          &g_XRRGetMonitors_ptr, reinterpret_cast<XRRGetMonitors>(
+                                     dlsym(xrandr_lib, "XRRGetMonitors")));
+      static base::ProtectedMemory<XRRFreeMonitors>::Initializer free_init(
+          &g_XRRFreeMonitors_ptr, reinterpret_cast<XRRFreeMonitors>(
+                                      dlsym(xrandr_lib, "XRRFreeMonitors")));
+      if (*g_XRRGetMonitors_ptr && *g_XRRFreeMonitors_ptr) {
+        int nmonitors = 0;
+        XRRMonitorInfo* monitors = base::UnsanitizedCfiCall(
+            g_XRRGetMonitors_ptr)(xdisplay_, x_root_window_, false, &nmonitors);
+        for (int monitor = 0; monitor < nmonitors; monitor++) {
+          for (int j = 0; j < monitors[monitor].noutput; j++) {
+            output_to_monitor[monitors[monitor].outputs[j]] = monitor;
+          }
+        }
+        base::UnsanitizedCfiCall(g_XRRFreeMonitors_ptr)(monitors);
+      }
+    }
+  }
+
+  primary_display_index_ = 0;
+  RROutput primary_display_id = XRRGetOutputPrimary(xdisplay_, x_root_window_);
+
+  int explicit_primary_display_index = -1;
+  int monitor_order_primary_display_index = -1;
+
+  for (int i = 0; i < resources->noutput; ++i) {
+    RROutput output_id = resources->outputs[i];
+    gfx::XScopedPtr<XRROutputInfo,
+                    gfx::XObjectDeleter<XRROutputInfo, void, XRRFreeOutputInfo>>
+        output_info(XRRGetOutputInfo(xdisplay_, resources.get(), output_id));
+
+    bool is_connected = (output_info->connection == RR_Connected);
+    if (!is_connected)
+      continue;
+
+    bool is_primary_display = output_id == primary_display_id;
+
+    if (output_info->crtc) {
+      gfx::XScopedPtr<XRRCrtcInfo,
+                      gfx::XObjectDeleter<XRRCrtcInfo, void, XRRFreeCrtcInfo>>
+          crtc(XRRGetCrtcInfo(xdisplay_, resources.get(), output_info->crtc));
+
+      int64_t display_id = -1;
+      if (!display::EDIDParserX11(output_id).GetDisplayId(
+              static_cast<uint8_t>(i), &display_id)) {
+        // It isn't ideal, but if we can't parse the EDID data, fallback on the
+        // display number.
+        display_id = i;
+      }
+
+      gfx::Rect crtc_bounds(crtc->x, crtc->y, crtc->width, crtc->height);
+      if (is_primary_display)
+        explicit_primary_display_index = display_id;
+
+      auto monitor_iter = output_to_monitor.find(output_id);
+      if (monitor_iter != output_to_monitor.end() && monitor_iter->second == 0)
+        monitor_order_primary_display_index = display_id;
+
+      gfx::ColorSpace color_space;
+      if (!display::Display::HasForceColorProfile()) {
+        gfx::ICCProfile icc_profile = ui::GetICCProfileForMonitor(
+            monitor_iter == output_to_monitor.end() ? 0 : monitor_iter->second);
+        icc_profile.HistogramDisplay(display_id);
+        color_space = icc_profile.GetColorSpace();
+      } else {
+        color_space = display::Display::GetForcedColorProfile();
+      }
+
+      displays_.emplace(
+          display_id, CreateSnapshot(display_id, crtc_bounds, color_space));
+    }
+  }
+
+  if (explicit_primary_display_index != -1) {
+    primary_display_index_ = explicit_primary_display_index;
+  } else if (monitor_order_primary_display_index != -1) {
+    primary_display_index_ = monitor_order_primary_display_index;
+  }
+}
+
+}  // namespace ui

--- a/ui/ozone/platform/x11/x11_display_manager_ozone.h
+++ b/ui/ozone/platform/x11/x11_display_manager_ozone.h
@@ -1,0 +1,80 @@
+// Copyright (c) 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef UI_OZONE_PLATFORM_X11_X11_DISPLAY_MANAGER_OZONE_H_
+#define UI_OZONE_PLATFORM_X11_X11_DISPLAY_MANAGER_OZONE_H_
+
+#include <stdint.h>
+
+#include <map>
+#include <memory>
+
+#include "base/cancelable_callback.h"
+#include "base/macros.h"
+#include "ui/display/screen.h"
+#include "ui/display/types/display_snapshot.h"
+#include "ui/display/types/native_display_delegate.h"
+#include "ui/events/platform/platform_event_dispatcher.h"
+
+typedef unsigned long XID;
+typedef XID Window;
+typedef struct _XDisplay Display;
+
+namespace ui {
+
+// X11DisplayManagerOzone talks to xrandr.
+class X11DisplayManagerOzone : public ui::PlatformEventDispatcher {
+ public:
+  class Observer {
+   public:
+    // Will be called when X11DisplayManagerOzone is available.
+    virtual void OnOutputReadyForUse() = 0;
+  };
+  using Snapshot = std::pair<std::unique_ptr<display::DisplaySnapshot>,
+                             std::unique_ptr<display::DisplayMode>>;
+  using OwnedDisplaySnapshot = std::map<int64_t, Snapshot>;
+
+  X11DisplayManagerOzone();
+  ~X11DisplayManagerOzone() override;
+
+  void SetObserver(Observer* observer);
+  Observer* observer() { return observer_; }
+
+  void GetDisplaysSnapshot(display::GetDisplaysCallback callback);
+
+  // ui::PlatformEventDispatcher:
+  bool CanDispatchEvent(const ui::PlatformEvent& event) override;
+  uint32_t DispatchEvent(const ui::PlatformEvent& event) override;
+
+ private:
+  // Builds a list of displays from the current screen information offered by
+  // the X server.
+  void BuildDisplaysFromXRandRInfo();
+
+  ::Display* xdisplay_;
+  ::Window x_root_window_;
+
+  // XRandR version. MAJOR * 100 + MINOR. Zero if no xrandr is present.
+  int xrandr_version_;
+
+  // The base of the event numbers used to represent XRandr events used in
+  // decoding events regarding output add/remove.
+  int xrandr_event_base_;
+
+  // The display objects we present to chrome.
+  OwnedDisplaySnapshot displays_;
+
+  // The index into displays_ that represents the primary display.
+  size_t primary_display_index_;
+
+  Observer* observer_;
+
+  base::WeakPtrFactory<X11DisplayManagerOzone> weak_factory_;
+
+  DISALLOW_COPY_AND_ASSIGN(X11DisplayManagerOzone);
+};
+
+}  // namespace ui
+
+#endif  // UI_OZONE_PLATFORM_X11_X11_DISPLAY_MANAGER_OZONE_H_

--- a/ui/ozone/platform/x11/x11_native_display_delegate.cc
+++ b/ui/ozone/platform/x11/x11_native_display_delegate.cc
@@ -16,26 +16,8 @@ X11NativeDisplayDelegate::X11NativeDisplayDelegate() = default;
 X11NativeDisplayDelegate::~X11NativeDisplayDelegate() = default;
 
 void X11NativeDisplayDelegate::Initialize() {
-  // This shouldn't be called twice.
-  DCHECK(!current_snapshot_);
-
-  XDisplay* display = gfx::GetXDisplay();
-  Screen* screen = DefaultScreenOfDisplay(display);
-  current_snapshot_.reset(new display::DisplaySnapshot(
-      XScreenNumberOfScreen(screen), gfx::Point(0, 0),
-      gfx::Size(WidthOfScreen(screen), HeightOfScreen(screen)),
-      display::DisplayConnectionType::DISPLAY_CONNECTION_TYPE_NONE, false,
-      false, false, gfx::ColorSpace(), "", base::FilePath(),
-      display::DisplaySnapshot::DisplayModeList(), std::vector<uint8_t>(),
-      nullptr, nullptr, 0, 0, gfx::Size()));
-  const int default_refresh = 60;
-  current_mode_.reset(new display::DisplayMode(
-      gfx::Size(WidthOfScreen(screen), HeightOfScreen(screen)), false,
-      default_refresh));
-  current_snapshot_->set_current_mode(current_mode_.get());
-
-  for (display::NativeDisplayObserver& observer : observers_)
-    observer.OnConfigurationChanged();
+  display_manager_ = std::make_unique<X11DisplayManagerOzone>();
+  display_manager_->SetObserver(this);
 }
 
 void X11NativeDisplayDelegate::TakeDisplayControl(
@@ -52,9 +34,8 @@ void X11NativeDisplayDelegate::GetDisplays(
     display::GetDisplaysCallback callback) {
   // TODO(msisov): Add support for multiple displays and dynamic display data
   // change.
-  std::vector<display::DisplaySnapshot*> snapshot;
-  snapshot.push_back(current_snapshot_.get());
-  std::move(callback).Run(snapshot);
+  if (displays_ready_)
+    display_manager_->GetDisplaysSnapshot(std::move(callback));
 }
 
 void X11NativeDisplayDelegate::Configure(const display::DisplaySnapshot& output,
@@ -106,4 +87,11 @@ X11NativeDisplayDelegate::GetFakeDisplayController() {
   return nullptr;
 }
 
+void X11NativeDisplayDelegate::OnOutputReadyForUse() {
+  if (!displays_ready_)
+    displays_ready_ = true;
+
+  for (display::NativeDisplayObserver& observer : observers_)
+    observer.OnConfigurationChanged();
+}
 }  // namespace ui

--- a/ui/ozone/platform/x11/x11_native_display_delegate.h
+++ b/ui/ozone/platform/x11/x11_native_display_delegate.h
@@ -7,12 +7,14 @@
 
 #include "base/macros.h"
 #include "base/observer_list.h"
-#include "ui/display/types/native_display_delegate.h"
 #include "ui/display/types/display_snapshot.h"
+#include "ui/display/types/native_display_delegate.h"
+#include "ui/ozone/platform/x11/x11_display_manager_ozone.h"
 
 namespace ui {
 
-class X11NativeDisplayDelegate : public display::NativeDisplayDelegate {
+class X11NativeDisplayDelegate : public display::NativeDisplayDelegate,
+                                 public X11DisplayManagerOzone::Observer {
  public:
   X11NativeDisplayDelegate();
   ~X11NativeDisplayDelegate() override;
@@ -42,10 +44,14 @@ class X11NativeDisplayDelegate : public display::NativeDisplayDelegate {
   void RemoveObserver(display::NativeDisplayObserver* observer) override;
   display::FakeDisplayController* GetFakeDisplayController() override;
 
+  // X11DisplayManagerOzone::Observer overrides:
+  void OnOutputReadyForUse() override;
+
  private:
-  std::unique_ptr<display::DisplaySnapshot> current_snapshot_;
-  std::unique_ptr<display::DisplayMode> current_mode_;
- 
+  bool displays_ready_ = false;
+
+  std::unique_ptr<X11DisplayManagerOzone> display_manager_;
+
   base::ObserverList<display::NativeDisplayObserver> observers_;
 
   DISALLOW_COPY_AND_ASSIGN(X11NativeDisplayDelegate);

--- a/ui/views/widget/desktop_aura/desktop_screen_x11.cc
+++ b/ui/views/widget/desktop_aura/desktop_screen_x11.cc
@@ -39,37 +39,6 @@
 
 namespace {
 
-// static
-gfx::ICCProfile GetICCProfileForMonitor(int monitor) {
-  gfx::ICCProfile icc_profile;
-  if (base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kHeadless))
-    return icc_profile;
-  std::string atom_name;
-  if (monitor == 0) {
-    atom_name = "_ICC_PROFILE";
-  } else {
-    atom_name = base::StringPrintf("_ICC_PROFILE_%d", monitor);
-  }
-  Atom property = gfx::GetAtom(atom_name.c_str());
-  if (property != x11::None) {
-    Atom prop_type = x11::None;
-    int prop_format = 0;
-    unsigned long nitems = 0;
-    unsigned long nbytes = 0;
-    char* property_data = NULL;
-    if (XGetWindowProperty(
-            gfx::GetXDisplay(), DefaultRootWindow(gfx::GetXDisplay()), property,
-            0, 0x1FFFFFFF /* MAXINT32 / 4 */, x11::False, AnyPropertyType,
-            &prop_type, &prop_format, &nitems, &nbytes,
-            reinterpret_cast<unsigned char**>(&property_data)) ==
-        x11::Success) {
-      icc_profile = gfx::ICCProfile::FromData(property_data, nitems);
-      XFree(property_data);
-    }
-  }
-  return icc_profile;
-}
-
 double GetDeviceScaleFactor() {
   float device_scale_factor = 1.0f;
   if (views::LinuxUI::instance()) {
@@ -451,7 +420,7 @@ std::vector<display::Display> DesktopScreenX11::BuildDisplaysFromXRandRInfo() {
         monitor_order_primary_display_index = displays.size();
 
       if (!display::Display::HasForceColorProfile()) {
-        gfx::ICCProfile icc_profile = GetICCProfileForMonitor(
+        gfx::ICCProfile icc_profile = ui::GetICCProfileForMonitor(
             monitor_iter == output_to_monitor.end() ? 0 : monitor_iter->second);
         icc_profile.HistogramDisplay(display.id());
         display.set_color_space(icc_profile.GetColorSpace());


### PR DESCRIPTION
X11NativeDisplayDelegate owns X11DisplayManager and it's
registered as an X11DisplayManager's observer and it starts to
communicate with it. When X11DisplayManager is created, it
gathers display information and create DisplaySnapshot.
DesktopScreenOzone gets updated display through
DesktopScreenOzone::OnConfigurationChanged,
X11NativeDisplayDelegate::GetDisplays and
DesktopScreenOzone::OnHostDisplaysReady.