### PR TITLE
Call OnNativeWidgetDestroying for native_widget_delegate_ on closing

### DIFF
--- a/ui/ozone/platform/headless/headless_window.cc
+++ b/ui/ozone/platform/headless/headless_window.cc
@@ -26,11 +26,13 @@ HeadlessWindow::HeadlessWindow(PlatformWindowDelegate* delegate,
 }
 
 HeadlessWindow::~HeadlessWindow() {
+  delegate()->OnAcceleratedWidgetDestroying();
 #if defined(OS_WIN)
   manager_->RemoveWindow(reinterpret_cast<uint64_t>(widget_), this);
 #else
   manager_->RemoveWindow(widget_, this);
 #endif
+  delegate()->OnAcceleratedWidgetDestroyed();
 }
 
 }  // namespace ui

--- a/ui/ozone/platform/x11/x11_window_ozone_unittest.cc
+++ b/ui/ozone/platform/x11/x11_window_ozone_unittest.cc
@@ -111,8 +111,8 @@ TEST_F(X11WindowOzoneTest, SendPlatformEventToRightTarget) {
   DispatchXEvent(xi_event, widget_2);
   EXPECT_EQ(ET_MOUSE_PRESSED, event->type());
 
-  EXPECT_CALL(delegate, OnClosed()).Times(1);
-  EXPECT_CALL(delegate_2, OnClosed()).Times(1);
+  EXPECT_CALL(delegate, OnAcceleratedWidgetDestroyed()).Times(1);
+  EXPECT_CALL(delegate_2, OnAcceleratedWidgetDestroyed()).Times(1);
 }
 
 // This test case ensures that events are consumed by a window with explicit
@@ -121,13 +121,13 @@ TEST_F(X11WindowOzoneTest, SendPlatformEventToCapturedWindow) {
   MockPlatformWindowDelegate delegate;
   gfx::AcceleratedWidget widget;
   constexpr gfx::Rect bounds(30, 80, 800, 600);
-  EXPECT_CALL(delegate, OnClosed()).Times(1);
+  EXPECT_CALL(delegate, OnAcceleratedWidgetDestroyed()).Times(1);
   auto window = CreatePlatformWindow(&delegate, bounds, &widget);
 
   MockPlatformWindowDelegate delegate_2;
   gfx::AcceleratedWidget widget_2;
   gfx::Rect bounds_2(525, 155, 296, 407);
-  EXPECT_CALL(delegate_2, OnClosed()).Times(1);
+  EXPECT_CALL(delegate_2, OnAcceleratedWidgetDestroyed()).Times(1);
   auto window_2 = CreatePlatformWindow(&delegate_2, bounds_2, &widget_2);
 
   ScopedXI2Event xi_event;

--- a/ui/platform_window/x11/x11_window_base.cc
+++ b/ui/platform_window/x11/x11_window_base.cc
@@ -97,8 +97,10 @@ X11WindowBase::X11WindowBase(PlatformWindowDelegate* delegate,
 }
 
 X11WindowBase::~X11WindowBase() {
+  delegate_->OnAcceleratedWidgetDestroying();
   UnConfineCursor();
   Destroy();
+  delegate_->OnAcceleratedWidgetDestroyed();
 }
 
 void X11WindowBase::Destroy() {
@@ -109,7 +111,6 @@ void X11WindowBase::Destroy() {
   XID xwindow = xwindow_;
   XDisplay* xdisplay = xdisplay_;
   xwindow_ = x11::None;
-  delegate_->OnClosed();
   // |this| might be deleted because of the above call.
 
   XDestroyWindow(xdisplay, xwindow);

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
@@ -126,11 +126,6 @@ void DesktopWindowTreeHostPlatform::Close() {
   if (waiting_for_close_now_)
     return;
 
-  // Hide while waiting for the close.
-  // Please note that it's better to call WindowTreeHost::Hide, which also calls
-  // PlatformWindow::Hide and Compositor::SetVisible(false).
-  Hide();
-
   waiting_for_close_now_ = true;
   base::ThreadTaskRunnerHandle::Get()->PostTask(
       FROM_HERE, base::BindOnce(&DesktopWindowTreeHostPlatform::CloseNow,
@@ -138,6 +133,10 @@ void DesktopWindowTreeHostPlatform::Close() {
 }
 
 void DesktopWindowTreeHostPlatform::CloseNow() {
+  // Please note that it's better to call WindowTreeHost::Hide, which also calls
+  // PlatformWindow::Hide and Compositor::SetVisible(false).
+  Hide();
+
   auto weak_ref = weak_factory_.GetWeakPtr();
   // Deleting the PlatformWindow may not result in OnClosed() being called, if
   // not behave as though it was.


### PR DESCRIPTION
This patch makes content_browsertests work. Because
DesktopWindowTreeHostPlatform missed calling OnNativeWidgetDestroying()
for |native_widget_delegate_|, it couldn't destroy shell properly.
With this patch, we can run content_browsertests with headless.

Issue #325