### PR TITLE
fixup! Add X11DisplayManager to get display information

### DIFF
--- a/services/ui/display/screen_manager_ozone_internal.cc
+++ b/services/ui/display/screen_manager_ozone_internal.cc
@@ -320,7 +320,8 @@ void ScreenManagerOzoneInternal::PostDisplayConfigurationChange() {
     }
   }
 
-  touch_transform_controller_->UpdateTouchTransforms();
+  if (touch_transform_controller_)
+    touch_transform_controller_->UpdateTouchTransforms();
 
   DVLOG(1) << "PostDisplayConfigurationChange";
 }

--- a/ui/ozone/platform/x11/x11_display_manager_ozone.cc
+++ b/ui/ozone/platform/x11/x11_display_manager_ozone.cc
@@ -8,6 +8,7 @@
 #include "base/memory/protected_memory_cfi.h"
 #include "ui/base/x/x11_util.h"
 #include "ui/display/display.h"
+#include "ui/display/types/display_snapshot.h"
 #include "ui/display/util/display_util.h"
 #include "ui/display/util/x11/edid_parser_x11.h"
 #include "ui/events/platform/platform_event_source.h"
@@ -23,34 +24,38 @@ namespace {
 
 constexpr int default_refresh = 60;
 
-X11DisplayManagerOzone::Snapshot CreateSnapshot(int64_t display_id,
-                                                gfx::Rect bounds,
-                                                gfx::ColorSpace color_space) {
-  std::unique_ptr<display::DisplaySnapshot> snapshot =
-      std::make_unique<display::DisplaySnapshot>(
-          display_id, gfx::Point(bounds.x(), bounds.y()),
-          gfx::Size(bounds.width(), bounds.height()),
-          display::DisplayConnectionType::DISPLAY_CONNECTION_TYPE_NONE, false,
-          false, false, color_space, "", base::FilePath(),
-          display::DisplaySnapshot::DisplayModeList(), std::vector<uint8_t>(),
-          nullptr, nullptr, 0, 0, gfx::Size());
-  std::unique_ptr<display::DisplayMode> current_mode =
+std::unique_ptr<display::DisplaySnapshot> CreateSnapshot(
+    int64_t display_id,
+    gfx::Rect bounds,
+    gfx::ColorSpace color_space) {
+  display::DisplaySnapshot::DisplayModeList modes;
+  std::unique_ptr<display::DisplayMode> display_mode =
       std::make_unique<display::DisplayMode>(
           gfx::Size(bounds.width(), bounds.height()), false, default_refresh);
-  snapshot->set_current_mode(current_mode.get());
-  return std::make_pair(std::move(snapshot), std::move(current_mode));
+  modes.push_back(std::move(display_mode));
+  const display::DisplayMode* mode = modes.back().get();
+
+  return std::make_unique<display::DisplaySnapshot>(
+      display_id, gfx::Point(bounds.x(), bounds.y()),
+      gfx::Size(bounds.width(), bounds.height()),
+      display::DisplayConnectionType::DISPLAY_CONNECTION_TYPE_NONE, false,
+      false, false, color_space, "", base::FilePath(), std::move(modes),
+      std::vector<uint8_t>(), mode, mode, 0, 0, gfx::Size());
 }
 
-void BuildFallbackDisplayList(
-    X11DisplayManagerOzone::OwnedDisplaySnapshot& output) {
+std::vector<std::unique_ptr<display::DisplaySnapshot>>
+BuildFallbackDisplayList() {
+  std::vector<std::unique_ptr<display::DisplaySnapshot>> snapshots;
   ::XDisplay* display = gfx::GetXDisplay();
   ::Screen* screen = DefaultScreenOfDisplay(display);
   int width = WidthOfScreen(screen);
   int height = HeightOfScreen(screen);
   int64_t display_id = 0;
   gfx::Rect bounds(0, 0, width, height);
-  output.emplace(display_id,
-                 CreateSnapshot(display_id, bounds, gfx::ColorSpace()));
+  std::unique_ptr<display::DisplaySnapshot> snapshot =
+      CreateSnapshot(display_id, bounds, gfx::ColorSpace());
+  snapshots.push_back(std::move(snapshot));
+  return snapshots;
 }
 
 }  // namespace
@@ -62,8 +67,7 @@ X11DisplayManagerOzone::X11DisplayManagerOzone()
     : xdisplay_(gfx::GetXDisplay()),
       x_root_window_(DefaultRootWindow(xdisplay_)),
       xrandr_version_(0),
-      xrandr_event_base_(0),
-      weak_factory_(this) {
+      xrandr_event_base_(0) {
   // We only support 1.3+. There were library changes before this and we should
   // use the new interface instead of the 1.2 one.
   int randr_version_major = 0;
@@ -73,7 +77,7 @@ X11DisplayManagerOzone::X11DisplayManagerOzone()
   }
   // Need at least xrandr version 1.3.
   if (xrandr_version_ < 103) {
-    BuildFallbackDisplayList(displays_);
+    snapshots_ = BuildFallbackDisplayList();
     return;
   }
 
@@ -96,18 +100,15 @@ X11DisplayManagerOzone::~X11DisplayManagerOzone() {
 
 void X11DisplayManagerOzone::SetObserver(Observer* observer) {
   observer_ = observer;
-  if (displays_.size() > 0)
+  if (snapshots_.size() > 0)
     observer_->OnOutputReadyForUse();
 }
 
 void X11DisplayManagerOzone::GetDisplaysSnapshot(
     display::GetDisplaysCallback callback) {
   std::vector<display::DisplaySnapshot*> snapshots;
-  for (const auto& iter : displays_) {
-    auto& snapshot_pair = iter.second;
-    display::DisplaySnapshot* snapshot = snapshot_pair.first.get();
-    snapshots.push_back(snapshot);
-  }
+  for (const auto& snapshot : snapshots_)
+    snapshots.push_back(snapshot.get());
   std::move(callback).Run(snapshots);
 }
 
@@ -139,7 +140,7 @@ void X11DisplayManagerOzone::BuildDisplaysFromXRandRInfo() {
       resources(XRRGetScreenResourcesCurrent(xdisplay_, x_root_window_));
   if (!resources) {
     LOG(ERROR) << "XRandR returned no displays. Falling back to Root Window.";
-    BuildFallbackDisplayList(displays_);
+    snapshots_ = BuildFallbackDisplayList();
     return;
   }
 
@@ -216,8 +217,9 @@ void X11DisplayManagerOzone::BuildDisplaysFromXRandRInfo() {
         color_space = display::Display::GetForcedColorProfile();
       }
 
-      displays_.emplace(
-          display_id, CreateSnapshot(display_id, crtc_bounds, color_space));
+      std::unique_ptr<display::DisplaySnapshot> snapshot =
+          CreateSnapshot(display_id, crtc_bounds, color_space);
+      snapshots_.push_back(std::move(snapshot));
     }
   }
 

--- a/ui/ozone/platform/x11/x11_display_manager_ozone.h
+++ b/ui/ozone/platform/x11/x11_display_manager_ozone.h
@@ -7,19 +7,17 @@
 
 #include <stdint.h>
 
-#include <map>
-#include <memory>
-
-#include "base/cancelable_callback.h"
-#include "base/macros.h"
-#include "ui/display/screen.h"
-#include "ui/display/types/display_snapshot.h"
 #include "ui/display/types/native_display_delegate.h"
 #include "ui/events/platform/platform_event_dispatcher.h"
 
 typedef unsigned long XID;
 typedef XID Window;
 typedef struct _XDisplay Display;
+
+namespace display {
+class DisplayMode;
+class DisplaySnapshot;
+}  // namespace display
 
 namespace ui {
 
@@ -31,9 +29,6 @@ class X11DisplayManagerOzone : public ui::PlatformEventDispatcher {
     // Will be called when X11DisplayManagerOzone is available.
     virtual void OnOutputReadyForUse() = 0;
   };
-  using Snapshot = std::pair<std::unique_ptr<display::DisplaySnapshot>,
-                             std::unique_ptr<display::DisplayMode>>;
-  using OwnedDisplaySnapshot = std::map<int64_t, Snapshot>;
 
   X11DisplayManagerOzone();
   ~X11DisplayManagerOzone() override;
@@ -63,14 +58,12 @@ class X11DisplayManagerOzone : public ui::PlatformEventDispatcher {
   int xrandr_event_base_;
 
   // The display objects we present to chrome.
-  OwnedDisplaySnapshot displays_;
+  std::vector<std::unique_ptr<display::DisplaySnapshot>> snapshots_;
 
   // The index into displays_ that represents the primary display.
   size_t primary_display_index_;
 
   Observer* observer_;
-
-  base::WeakPtrFactory<X11DisplayManagerOzone> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(X11DisplayManagerOzone);
 };

--- a/ui/ozone/platform/x11/x11_native_display_delegate.cc
+++ b/ui/ozone/platform/x11/x11_native_display_delegate.cc
@@ -42,7 +42,12 @@ void X11NativeDisplayDelegate::Configure(const display::DisplaySnapshot& output,
                                          const display::DisplayMode* mode,
                                          const gfx::Point& origin,
                                          display::ConfigureCallback callback) {
-  NOTREACHED();
+  NOTIMPLEMENTED();
+
+  // It should call |callback| after configuration.
+  // Even if we don't have implementation, it calls |callback| to finish the
+  // logic. otherwise, several tests from views_mus_unittests don't work.
+  std::move(callback).Run(true);
 }
 
 void X11NativeDisplayDelegate::GetHDCPState(

--- a/ui/ozone/platform/x11/x11_native_display_delegate.h
+++ b/ui/ozone/platform/x11/x11_native_display_delegate.h
@@ -5,11 +5,14 @@
 #ifndef UI_OZONE_PLATFORM_X11_X11_NATIVE_DISPLAY_DELEGATE_H_
 #define UI_OZONE_PLATFORM_X11_X11_NATIVE_DISPLAY_DELEGATE_H_
 
-#include "base/macros.h"
 #include "base/observer_list.h"
-#include "ui/display/types/display_snapshot.h"
 #include "ui/display/types/native_display_delegate.h"
 #include "ui/ozone/platform/x11/x11_display_manager_ozone.h"
+
+namespace display {
+class DisplayMode;
+class DisplaySnapshot;
+}  // namespace display
 
 namespace ui {
 


### PR DESCRIPTION
This patch removed OwnedDisplaySnapshot because it doesn't need to
own DisplayMode. DisplaySnapshot is created with
DisplaySnapshot::DisplayModeList, which is the list has DisplayModes.
Whenever DisplayMode is added to the list, it's cloned and kept in
the list and every DisplayMode should be in the list.