### PR TITLE
[ozone/wayland/IME] Handle backspace button.

### DIFF
--- a/chrome/browser/ui/views/ime_driver/input_method_bridge_linux.cc
+++ b/chrome/browser/ui/views/ime_driver/input_method_bridge_linux.cc
@@ -46,3 +46,9 @@ void InputMethodBridgeLinux::ProcessKeyEvent(std::unique_ptr<ui::Event> event,
 void InputMethodBridgeLinux::CancelComposition() {
   input_method_linux_->CancelComposition(client_.get());
 }
+
+void InputMethodBridgeLinux::SetSurroundingText(
+    const base::string16& text,
+    const gfx::Range& selection_range) {
+  input_method_linux_->SetSurroundingText(text, selection_range);
+}

--- a/chrome/browser/ui/views/ime_driver/input_method_bridge_linux.h
+++ b/chrome/browser/ui/views/ime_driver/input_method_bridge_linux.h
@@ -27,6 +27,8 @@ class InputMethodBridgeLinux : public ui::mojom::InputMethod {
   void ProcessKeyEvent(std::unique_ptr<ui::Event> key_event,
                        ProcessKeyEventCallback callback) override;
   void CancelComposition() override;
+  void SetSurroundingText(const base::string16& text,
+                          const gfx::Range& selection_range) override;
 
  private:
   std::unique_ptr<RemoteTextInputClient> client_;

--- a/chrome/browser/ui/views/ime_driver/remote_text_input_client.cc
+++ b/chrome/browser/ui/views/ime_driver/remote_text_input_client.cc
@@ -142,8 +142,7 @@ bool RemoteTextInputClient::ChangeTextDirectionAndLayoutAlignment(
 
 void RemoteTextInputClient::ExtendSelectionAndDelete(size_t before,
                                                      size_t after) {
-  // TODO(moshayedi): crbug.com/631527.
-  NOTIMPLEMENTED_LOG_ONCE();
+  remote_client_->ExtendSelectionAndDelete(before, after);
 }
 
 void RemoteTextInputClient::EnsureCaretNotInRect(const gfx::Rect& rect) {

--- a/services/ui/public/interfaces/ime/ime.mojom
+++ b/services/ui/public/interfaces/ime/ime.mojom
@@ -155,6 +155,10 @@ interface InputMethod {
   ProcessKeyEvent(ui.mojom.Event key_event) => (bool handled);
 
   CancelComposition();
+
+  // Sets surrounding text.
+  SetSurroundingText(mojo_base.mojom.String16 text,
+                     gfx.mojom.Range selection_range);
 };
 
 // IME drivers send updates to clients using the TextInputClient interface.
@@ -185,6 +189,8 @@ interface TextInputClient {
 
   // Dispatch a key event skipping IME. Returns true if event was consumed.
   DispatchKeyEventPostIME(ui.mojom.Event event) => (bool stopped_propagation);
+
+  ExtendSelectionAndDelete(uint64 before, uint64 after);
 
   // TODO(moshayedi): Add functions corresponding to ui::TextInputClient for:
   // - Input context information

--- a/services/ui/public/interfaces/ime/linux_input_method_context.mojom
+++ b/services/ui/public/interfaces/ime/linux_input_method_context.mojom
@@ -7,6 +7,7 @@ module ui.mojom;
 import "mojo/public/mojom/base/string16.mojom";
 import "ui/events/mojo/event.mojom";
 import "ui/gfx/geometry/mojo/geometry.mojom";
+import "ui/gfx/range/mojo/range.mojom";
 import "services/ui/public/interfaces/ime/ime.mojom";
 
 // An interface of input method context for input method frameworks on
@@ -32,12 +33,20 @@ interface LinuxInputMethodContext {
 
   // Blurs the context.
   Blur();
+
+  // Sets surrounding text.
+  SetSurroundingText(mojo_base.mojom.String16 text,
+                     gfx.mojom.Range selection_range);
 };
 
 // An interface of callback functions called from LinuxInputMethodContext.
 interface LinuxInputMethodContextDelegate {
   // Commits the |text| to the text input client.
   OnCommit(mojo_base.mojom.String16 text);
+
+  // Deletes the current compositing surround text at |index| for given
+  // |length|.
+  OnDeleteSurroundingText(int32 index, uint32 length);
 
   // Sets the composition text to the text input client.
   OnPreeditChanged(ui.mojom.CompositionText composition_text);

--- a/tools/clang/scripts/update.py
+++ b/tools/clang/scripts/update.py
@@ -27,7 +27,7 @@ import zipfile
 # Do NOT CHANGE this if you don't know what you're doing -- see
 # https://chromium.googlesource.com/chromium/src/+/master/docs/updating_clang.md
 # Reverting problematic clang rolls is safe, though.
-CLANG_REVISION = '327688'
+CLANG_REVISION = '335091'
 
 use_head_revision = bool(os.environ.get('LLVM_FORCE_HEAD_REVISION', '0')
                          in ('1', 'YES'))

--- a/ui/aura/mus/input_method_mus.cc
+++ b/ui/aura/mus/input_method_mus.cc
@@ -105,8 +105,10 @@ void InputMethodMus::OnCaretBoundsChanged(const ui::TextInputClient* client) {
   if (!IsTextInputClientFocused(client))
     return;
 
-  if (input_method_)
+  if (input_method_) {
     input_method_->OnCaretBoundsChanged(client->GetCaretBounds());
+    SetSurroundingText(client);
+  }
 }
 
 void InputMethodMus::CancelComposition(const ui::TextInputClient* client) {
@@ -126,6 +128,19 @@ bool InputMethodMus::IsCandidatePopupOpen() const {
   // TODO(moshayedi): crbug.com/637416. Implement this properly when we have a
   // mean for displaying candidate list popup.
   return false;
+}
+
+void InputMethodMus::SetSurroundingText(const ui::TextInputClient* client) {
+  gfx::Range text_range, selection_range;
+  base::string16 text;
+  if (!client->GetTextRange(&text_range) ||
+      !client->GetTextFromRange(text_range, &text) ||
+      !client->GetSelectionRange(&selection_range)) {
+    return;
+  }
+
+  if (input_method_)
+    input_method_->SetSurroundingText(text, selection_range);
 }
 
 ui::EventDispatchDetails InputMethodMus::SendKeyEventToInputMethod(

--- a/ui/aura/mus/input_method_mus.h
+++ b/ui/aura/mus/input_method_mus.h
@@ -53,6 +53,8 @@ class AURA_EXPORT InputMethodMus : public ui::InputMethodBase {
   friend class InputMethodMusTestApi;
   friend TextInputClientImpl;
 
+  void SetSurroundingText(const ui::TextInputClient* client);
+
   // Called from DispatchKeyEvent() to call to the InputMethod.
   ui::EventDispatchDetails SendKeyEventToInputMethod(
       const ui::KeyEvent& event,

--- a/ui/aura/mus/linux_input_method_context_delegate_impl.cc
+++ b/ui/aura/mus/linux_input_method_context_delegate_impl.cc
@@ -32,6 +32,12 @@ void LinuxInputMethodContextDelegateImpl::OnCommit(const base::string16& text) {
   delegate_->OnCommit(text);
 }
 
+void LinuxInputMethodContextDelegateImpl::OnDeleteSurroundingText(
+    int32_t index,
+    uint32_t length) {
+  delegate_->OnDeleteSurroundingText(index, length);
+}
+
 void LinuxInputMethodContextDelegateImpl::OnPreeditChanged(
     const ui::CompositionText& composition_text) {
   delegate_->OnPreeditChanged(composition_text);

--- a/ui/aura/mus/linux_input_method_context_delegate_impl.h
+++ b/ui/aura/mus/linux_input_method_context_delegate_impl.h
@@ -27,6 +27,7 @@ class AURA_EXPORT LinuxInputMethodContextDelegateImpl
 
   // Overridden from ui::LinuxInputMethodContextDelegate:
   void OnCommit(const base::string16& text) override;
+  void OnDeleteSurroundingText(int32_t index, uint32_t length) override;
   void OnPreeditChanged(const ui::CompositionText& composition_text) override;
   void OnPreeditEnd() override;
   void OnPreeditStart() override;

--- a/ui/aura/mus/linux_input_method_context_mus.cc
+++ b/ui/aura/mus/linux_input_method_context_mus.cc
@@ -72,6 +72,12 @@ void LinuxInputMethodContextMus::Blur() {
   context_->Blur();
 }
 
+void LinuxInputMethodContextMus::SetSurroundingText(
+    const base::string16& text,
+    const gfx::Range& selection_range) {
+  context_->SetSurroundingText(text, selection_range);
+}
+
 void LinuxInputMethodContextMus::AckPendingCallbacksUnhandled() {
   for (auto& callback_ptr : pending_callbacks_) {
     if (callback_ptr)

--- a/ui/aura/mus/linux_input_method_context_mus.h
+++ b/ui/aura/mus/linux_input_method_context_mus.h
@@ -36,6 +36,8 @@ class AURA_EXPORT LinuxInputMethodContextMus
   void Reset() override;
   void Focus() override;
   void Blur() override;
+  void SetSurroundingText(const base::string16& text,
+                          const gfx::Range& selection_range) override;
 
  private:
   friend class LinuxInputMethodContextMusTestApi;

--- a/ui/aura/mus/text_input_client_impl.cc
+++ b/ui/aura/mus/text_input_client_impl.cc
@@ -58,4 +58,9 @@ void TextInputClientImpl::DispatchKeyEventPostIME(
   }
 }
 
+void TextInputClientImpl::ExtendSelectionAndDelete(size_t before,
+                                                   size_t after) {
+  text_input_client_->ExtendSelectionAndDelete(before, after);
+}
+
 }  // namespace aura

--- a/ui/aura/mus/text_input_client_impl.h
+++ b/ui/aura/mus/text_input_client_impl.h
@@ -36,6 +36,7 @@ class TextInputClientImpl : public ui::mojom::TextInputClient {
   void DispatchKeyEventPostIME(
       std::unique_ptr<ui::Event> event,
       DispatchKeyEventPostIMECallback callback) override;
+  void ExtendSelectionAndDelete(size_t before, size_t after) override;
 
   ui::TextInputClient* text_input_client_;
   mojo::Binding<ui::mojom::TextInputClient> binding_;

--- a/ui/base/ime/input_method_auralinux.h
+++ b/ui/base/ime/input_method_auralinux.h
@@ -41,9 +41,13 @@ class UI_BASE_IME_EXPORT InputMethodAuraLinux
 
   // Overriden from ui::LinuxInputMethodContextDelegate
   void OnCommit(const base::string16& text) override;
+  void OnDeleteSurroundingText(int32_t index, uint32_t length) override;
   void OnPreeditChanged(const CompositionText& composition_text) override;
   void OnPreeditEnd() override;
   void OnPreeditStart() override {}
+
+  void SetSurroundingText(const base::string16& text,
+                          const gfx::Range& selection_range);
 
  protected:
   // Overridden from InputMethodBase.

--- a/ui/base/ime/linux/fake_input_method_context.cc
+++ b/ui/base/ime/linux/fake_input_method_context.cc
@@ -27,4 +27,8 @@ void FakeInputMethodContext::Blur() {
 void FakeInputMethodContext::SetCursorLocation(const gfx::Rect& rect) {
 }
 
+void FakeInputMethodContext::SetSurroundingText(
+    const base::string16& text,
+    const gfx::Range& selection_range) {}
+
 }  // namespace ui

--- a/ui/base/ime/linux/fake_input_method_context.h
+++ b/ui/base/ime/linux/fake_input_method_context.h
@@ -21,6 +21,8 @@ class FakeInputMethodContext : public LinuxInputMethodContext {
   void Focus() override;
   void Blur() override;
   void SetCursorLocation(const gfx::Rect& rect) override;
+  void SetSurroundingText(const base::string16& text,
+                          const gfx::Range& selection_range) override;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(FakeInputMethodContext);

--- a/ui/base/ime/linux/linux_input_method_context.h
+++ b/ui/base/ime/linux/linux_input_method_context.h
@@ -42,6 +42,9 @@ class UI_BASE_IME_EXPORT LinuxInputMethodContext {
 
   // Blurs the context.
   virtual void Blur() = 0;
+
+  virtual void SetSurroundingText(const base::string16& text,
+                                  const gfx::Range& selection_range) = 0;
 };
 
 // An interface of callback functions called from LinuxInputMethodContext.
@@ -51,6 +54,9 @@ class UI_BASE_IME_EXPORT LinuxInputMethodContextDelegate {
 
   // Commits the |text| to the text input client.
   virtual void OnCommit(const base::string16& text) = 0;
+
+  // Deletes the surrounding text at |index| for given |length|.
+  virtual void OnDeleteSurroundingText(int32_t index, uint32_t length) = 0;
 
   // Sets the composition text to the text input client.
   virtual void OnPreeditChanged(const CompositionText& composition_text) = 0;

--- a/ui/ozone/platform/wayland/wayland_input_method_context.cc
+++ b/ui/ozone/platform/wayland/wayland_input_method_context.cc
@@ -27,7 +27,7 @@ namespace {
 
 constexpr int kXkbKeycodeOffset = 8;
 
-} // namespace
+}  // namespace
 
 WaylandInputMethodContext::WaylandInputMethodContext(
     WaylandConnection* connection)
@@ -83,6 +83,13 @@ void WaylandInputMethodContext::Blur() {
   }
 }
 
+void WaylandInputMethodContext::SetSurroundingText(
+    const base::string16& text,
+    const gfx::Range& selection_range) {
+  if (text_input_)
+    text_input_->SetSurroundingText(text, selection_range);
+}
+
 void WaylandInputMethodContext::SetCursorLocation(const gfx::Rect& rect) {
   if (text_input_)
     text_input_->SetCursorRect(rect);
@@ -108,6 +115,11 @@ void WaylandInputMethodContext::OnPreeditString(const std::string& text,
 
 void WaylandInputMethodContext::OnCommitString(const std::string& text) {
   delegate_->OnCommit(base::UTF8ToUTF16(text));
+}
+
+void WaylandInputMethodContext::OnDeleteSurroundingText(int32_t index,
+                                                        uint32_t length) {
+  delegate_->OnDeleteSurroundingText(index, length);
 }
 
 void WaylandInputMethodContext::OnKeysym(uint32_t key,

--- a/ui/ozone/platform/wayland/wayland_input_method_context.h
+++ b/ui/ozone/platform/wayland/wayland_input_method_context.h
@@ -31,10 +31,13 @@ class WaylandInputMethodContext : public ui::mojom::LinuxInputMethodContext,
   void Reset() override;
   void Focus() override;
   void Blur() override;
+  void SetSurroundingText(const base::string16& text,
+                          const gfx::Range& selection_range) override;
 
   // ui::ZWPTextInputWrapperClient
   void OnPreeditString(const std::string& text, int preedit_cursor) override;
   void OnCommitString(const std::string& text) override;
+  void OnDeleteSurroundingText(int32_t index, uint32_t length) override;
   void OnKeysym(uint32_t key, uint32_t state, uint32_t modifiers) override;
 
  private:

--- a/ui/ozone/platform/wayland/zwp_text_input_wrapper.h
+++ b/ui/ozone/platform/wayland/zwp_text_input_wrapper.h
@@ -7,9 +7,12 @@
 
 #include "ui/ozone/platform/wayland/wayland_object.h"
 
+#include "base/strings/string16.h"
+
 namespace gfx {
 class Rect;
-}
+class Range;
+}  // namespace gfx
 
 namespace ui {
 
@@ -23,6 +26,7 @@ class ZWPTextInputWrapperClient {
   virtual void OnPreeditString(const std::string& text,
                                int32_t preedit_cursor) = 0;
   virtual void OnCommitString(const std::string& text) = 0;
+  virtual void OnDeleteSurroundingText(int32_t index, uint32_t length) = 0;
   virtual void OnKeysym(uint32_t key, uint32_t state, uint32_t modifiers) = 0;
 };
 
@@ -43,6 +47,9 @@ class ZWPTextInputWrapper {
   virtual void HideInputPanel() = 0;
 
   virtual void SetCursorRect(const gfx::Rect& rect) = 0;
+
+  virtual void SetSurroundingText(const base::string16& text,
+                                  const gfx::Range& selection_range) = 0;
 };
 
 }  // namespace ui

--- a/ui/ozone/platform/wayland/zwp_text_input_wrapper_v1.cc
+++ b/ui/ozone/platform/wayland/zwp_text_input_wrapper_v1.cc
@@ -5,6 +5,9 @@
 #include "ui/ozone/platform/wayland/zwp_text_input_wrapper_v1.h"
 
 #include "base/memory/ptr_util.h"
+#include "base/strings/string16.h"
+#include "base/strings/utf_string_conversions.h"
+#include "ui/gfx/range/range.h"
 #include "ui/ozone/platform/wayland/wayland_connection.h"
 #include "ui/ozone/platform/wayland/wayland_window.h"
 
@@ -74,6 +77,15 @@ void ZWPTextInputWrapperV1::SetCursorRect(const gfx::Rect& rect) {
                                          rect.width(), rect.height());
 }
 
+void ZWPTextInputWrapperV1::SetSurroundingText(
+    const base::string16& text,
+    const gfx::Range& selection_range) {
+  const std::string text_utf8 = base::UTF16ToUTF8(text);
+  zwp_text_input_v1_set_surrounding_text(obj_.get(), text_utf8.c_str(),
+                                         selection_range.start(),
+                                         selection_range.end());
+}
+
 void ZWPTextInputWrapperV1::ResetInputEventState() {
   preedit_cursor_ = -1;
 }
@@ -117,7 +129,6 @@ void ZWPTextInputWrapperV1::OnPreeditString(
 
 void ZWPTextInputWrapperV1::OnPreeditStyling(
     void* data,
-
     struct zwp_text_input_v1* text_input,
     uint32_t index,
     uint32_t length,
@@ -155,7 +166,8 @@ void ZWPTextInputWrapperV1::OnDeleteSurroundingText(
     struct zwp_text_input_v1* text_input,
     int32_t index,
     uint32_t length) {
-  NOTIMPLEMENTED_LOG_ONCE();
+  ZWPTextInputWrapperV1* wti = static_cast<ZWPTextInputWrapperV1*>(data);
+  wti->client_->OnDeleteSurroundingText(index, length);
 }
 
 void ZWPTextInputWrapperV1::OnKeysym(void* data,

--- a/ui/ozone/platform/wayland/zwp_text_input_wrapper_v1.h
+++ b/ui/ozone/platform/wayland/zwp_text_input_wrapper_v1.h
@@ -37,6 +37,9 @@ class ZWPTextInputWrapperV1 : public ZWPTextInputWrapper {
 
   void SetCursorRect(const gfx::Rect& rect) override;
 
+  void SetSurroundingText(const base::string16& text,
+                          const gfx::Range& selection_range) override;
+
  private:
   void ResetInputEventState();
 


### PR DESCRIPTION
This patch adds implenetation details to the delete surrounding
text and set surrounding text methods, which are used to handle
backspace buttons.

PS using vkb and physical keyboard at the same time are prone to bugs.
That is, when a text is typed both on the vkb and physical keyboard,
it can suddenly disappear.