### PR TITLE
fixup! [DoNotCarryForward] Implement Wayland dmabuf approach.

### DIFF
--- a/ui/ozone/platform/wayland/wayland_connection.h
+++ b/ui/ozone/platform/wayland/wayland_connection.h
@@ -23,7 +23,7 @@
 #include "ui/ozone/platform/wayland/wayland_pointer.h"
 #include "ui/ozone/platform/wayland/wayland_touch.h"
 #include "ui/ozone/public/clipboard_delegate.h"
-#include "ui/ozone/public/interfaces/wayland_connection.mojom.h"
+#include "ui/ozone/public/interfaces/wayland/wayland_connection.mojom.h"
 
 struct zwp_linux_dmabuf_v1;
 struct zwp_linux_buffer_params_v1;

--- a/ui/ozone/platform/wayland/wayland_connection_connector.cc
+++ b/ui/ozone/platform/wayland/wayland_connection_connector.cc
@@ -6,7 +6,7 @@
 
 #include "base/task_runner_util.h"
 #include "ui/ozone/platform/wayland/wayland_connection.h"
-#include "ui/ozone/public/interfaces/wayland_connection.mojom.h"
+#include "ui/ozone/public/interfaces/wayland/wayland_connection.mojom.h"
 
 namespace ui {
 

--- a/ui/ozone/platform/wayland/wayland_connection_connector.h
+++ b/ui/ozone/platform/wayland/wayland_connection_connector.h
@@ -7,7 +7,7 @@
 
 #include "ui/ozone/public/gpu_platform_support_host.h"
 
-#include "ui/ozone/public/interfaces/wayland_connection.mojom.h"
+#include "ui/ozone/public/interfaces/wayland/wayland_connection.mojom.h"
 
 namespace ui {
 

--- a/ui/ozone/platform/wayland/wayland_connection_proxy.h
+++ b/ui/ozone/platform/wayland/wayland_connection_proxy.h
@@ -12,7 +12,7 @@
 #include "ui/ozone/common/linux/gbm_device_linux.h"
 
 #include "base/threading/sequenced_task_runner_handle.h"
-#include "ui/ozone/public/interfaces/wayland_connection.mojom.h"
+#include "ui/ozone/public/interfaces/wayland/wayland_connection.mojom.h"
 
 #include "ui/ozone/platform/wayland/wayland_connection.h"
 


### PR DESCRIPTION
It fixed compilation error caused by wrong include path.

TBR = msisov@igalia.com