### PR TITLE
fixup! [ozone/wayland/IME] Handle backspace button.

### DIFF
--- a/ui/base/ime/linux/linux_input_method_context.h
+++ b/ui/base/ime/linux/linux_input_method_context.h
@@ -11,6 +11,7 @@
 
 namespace gfx {
 class Rect;
+class Range;
 }
 
 namespace ui {


### PR DESCRIPTION
Fixed compilation error.
linux_input_method_context.h:47:46: error: 'Range' in namespace
'gfx' does not name a type

TBR = msisov@igalia.com