### PR TITLE
[ozone/x11/headless] Use FakeInputMethodContextFactory to avoid crashing

### DIFF
--- a/ui/base/ime/linux/fake_input_method_context_factory.cc
+++ b/ui/base/ime/linux/fake_input_method_context_factory.cc
@@ -8,7 +8,9 @@
 
 namespace ui {
 
-FakeInputMethodContextFactory::FakeInputMethodContextFactory() {}
+FakeInputMethodContextFactory::FakeInputMethodContextFactory() = default;
+
+FakeInputMethodContextFactory::~FakeInputMethodContextFactory() = default;
 
 std::unique_ptr<LinuxInputMethodContext>
 FakeInputMethodContextFactory::CreateInputMethodContext(

--- a/ui/base/ime/linux/fake_input_method_context_factory.h
+++ b/ui/base/ime/linux/fake_input_method_context_factory.h
@@ -7,14 +7,17 @@
 
 #include "base/macros.h"
 #include "ui/base/ime/linux/linux_input_method_context_factory.h"
+#include "ui/base/ime/ui_base_ime_export.h"
 
 namespace ui {
 
 // An implementation of LinuxInputMethodContextFactory, which creates and
 // returns FakeInputMethodContext's.
-class FakeInputMethodContextFactory : public LinuxInputMethodContextFactory {
+class UI_BASE_IME_EXPORT FakeInputMethodContextFactory
+    : public LinuxInputMethodContextFactory {
  public:
   FakeInputMethodContextFactory();
+  ~FakeInputMethodContextFactory() override;
 
   // LinuxInputMethodContextFactory:
   std::unique_ptr<LinuxInputMethodContext> CreateInputMethodContext(

--- a/ui/ozone/platform/headless/BUILD.gn
+++ b/ui/ozone/platform/headless/BUILD.gn
@@ -28,6 +28,7 @@ source_set("headless") {
     "//base",
     "//skia",
     "//ui/base",
+    "//ui/base/ime",
     "//ui/display/manager",
     "//ui/events",
     "//ui/events/ozone:events_ozone_layout",

--- a/ui/ozone/platform/headless/ozone_platform_headless.cc
+++ b/ui/ozone/platform/headless/ozone_platform_headless.cc
@@ -8,6 +8,7 @@
 #include "base/files/file_path.h"
 #include "base/macros.h"
 #include "ui/base/cursor/ozone/bitmap_cursor_factory_ozone.h"
+#include "ui/base/ime/linux/fake_input_method_context_factory.h"
 #include "ui/events/ozone/layout/keyboard_layout_engine_manager.h"
 #include "ui/events/ozone/layout/stub/stub_keyboard_layout_engine.h"
 #include "ui/events/platform/platform_event_source.h"
@@ -90,6 +91,10 @@ class OzonePlatformHeadless : public OzonePlatform {
     input_controller_ = CreateStubInputController();
     cursor_factory_ozone_ = std::make_unique<BitmapCursorFactoryOzone>();
     gpu_platform_support_host_.reset(CreateStubGpuPlatformSupportHost());
+    fake_input_method_factory_ =
+        std::make_unique<FakeInputMethodContextFactory>();
+    LinuxInputMethodContextFactory::SetInstance(
+        fake_input_method_factory_.get());
   }
 
   void InitializeGPU(const InitParams& params) override {
@@ -105,6 +110,7 @@ class OzonePlatformHeadless : public OzonePlatform {
   std::unique_ptr<InputController> input_controller_;
   std::unique_ptr<GpuPlatformSupportHost> gpu_platform_support_host_;
   std::unique_ptr<OverlayManagerOzone> overlay_manager_;
+  std::unique_ptr<FakeInputMethodContextFactory> fake_input_method_factory_;
   base::FilePath file_path_;
 
   DISALLOW_COPY_AND_ASSIGN(OzonePlatformHeadless);

--- a/ui/ozone/platform/x11/BUILD.gn
+++ b/ui/ozone/platform/x11/BUILD.gn
@@ -24,16 +24,16 @@ source_set("x11") {
     "x11_cursor_factory_ozone.h",
     "x11_cursor_ozone.cc",
     "x11_cursor_ozone.h",
+    "x11_display_manager_ozone.cc",
+    "x11_display_manager_ozone.h",
+    "x11_native_display_delegate.cc",
+    "x11_native_display_delegate.h",
     "x11_surface_factory.cc",
     "x11_surface_factory.h",
     "x11_window_manager_ozone.cc",
     "x11_window_manager_ozone.h",
     "x11_window_ozone.cc",
     "x11_window_ozone.h",
-    "x11_native_display_delegate.h",
-    "x11_native_display_delegate.cc",
-    "x11_display_manager_ozone.h",
-    "x11_display_manager_ozone.cc",
   ]
 
   deps = [
@@ -41,6 +41,7 @@ source_set("x11") {
     "//gpu/vulkan:buildflags",
     "//skia",
     "//ui/base",
+    "//ui/base/ime",
     "//ui/base/x",
     "//ui/display/manager",
     "//ui/events",
@@ -65,7 +66,7 @@ source_set("x11") {
 
   configs += [
     "//build/config/linux:x11",
-    "//build/config/linux:xrandr"
+    "//build/config/linux:xrandr",
   ]
 
   public_configs = [ "//third_party/khronos:khronos_headers" ]

--- a/ui/ozone/platform/x11/DEPS
+++ b/ui/ozone/platform/x11/DEPS
@@ -1,3 +1,4 @@
 include_rules = [
   "+ui/base/x",
+  "+ui/base/ime",
 ]

--- a/ui/ozone/platform/x11/ozone_platform_x11.cc
+++ b/ui/ozone/platform/x11/ozone_platform_x11.cc
@@ -9,14 +9,15 @@
 
 #include "base/message_loop/message_loop.h"
 #include "base/strings/utf_string_conversions.h"
+#include "ui/base/ime/linux/fake_input_method_context_factory.h"
 #include "ui/base/x/x11_util.h"
 #include "ui/events/devices/x11/touch_factory_x11.h"
 #include "ui/events/platform/x11/x11_event_source_libevent.h"
 #include "ui/events/system_input_injector.h"
 #include "ui/gfx/x/x11.h"
 #include "ui/ozone/common/stub_overlay_manager.h"
-#include "ui/ozone/platform/x11/x11_native_display_delegate.h"
 #include "ui/ozone/platform/x11/x11_cursor_factory_ozone.h"
+#include "ui/ozone/platform/x11/x11_native_display_delegate.h"
 #include "ui/ozone/platform/x11/x11_surface_factory.h"
 #include "ui/ozone/platform/x11/x11_window_manager_ozone.h"
 #include "ui/ozone/platform/x11/x11_window_ozone.h"
@@ -84,6 +85,9 @@ class OzonePlatformX11 : public OzonePlatform {
     input_controller_ = CreateStubInputController();
     cursor_factory_ozone_ = std::make_unique<X11CursorFactoryOzone>();
     gpu_platform_support_host_.reset(CreateStubGpuPlatformSupportHost());
+    fake_input_method_factory_ =
+        std::make_unique<FakeInputMethodContextFactory>();
+    LinuxInputMethodContextFactory::SetInstance(fake_input_method_factory_.get());
 
     TouchFactory::SetTouchDeviceListFromCommandLine();
   }
@@ -142,6 +146,7 @@ class OzonePlatformX11 : public OzonePlatform {
   std::unique_ptr<InputController> input_controller_;
   std::unique_ptr<X11CursorFactoryOzone> cursor_factory_ozone_;
   std::unique_ptr<GpuPlatformSupportHost> gpu_platform_support_host_;
+  std::unique_ptr<FakeInputMethodContextFactory> fake_input_method_factory_;
 
   // Objects in the GPU process.
   std::unique_ptr<X11SurfaceFactory> surface_factory_ozone_;


### PR DESCRIPTION
That is, after we've added ime imeplementation for Wayland, other
ozone platforms started to crash. To avoid this, use fake factory.

#475 