### PR TITLE
fixed crash on content_browsertests.

### DIFF
--- a/ui/ozone/platform/headless/ozone_platform_headless.cc
+++ b/ui/ozone/platform/headless/ozone_platform_headless.cc
@@ -91,6 +91,9 @@ class OzonePlatformHeadless : public OzonePlatform {
     input_controller_ = CreateStubInputController();
     cursor_factory_ozone_ = std::make_unique<BitmapCursorFactoryOzone>();
     gpu_platform_support_host_.reset(CreateStubGpuPlatformSupportHost());
+
+    if (LinuxInputMethodContextFactory::instance())
+      return;
     fake_input_method_factory_ =
         std::make_unique<FakeInputMethodContextFactory>();
     LinuxInputMethodContextFactory::SetInstance(

--- a/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+++ b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
@@ -115,6 +115,8 @@ class OzonePlatformWayland : public OzonePlatform {
     input_controller_ = CreateStubInputController();
     gpu_platform_support_host_.reset(CreateStubGpuPlatformSupportHost());
 
+    if (LinuxInputMethodContextFactory::instance())
+      return;
     wayland_input_method_context_factory_.reset(
         new WaylandInputMethodContextFactory(connection_.get()));
   }

--- a/ui/ozone/platform/x11/ozone_platform_x11.cc
+++ b/ui/ozone/platform/x11/ozone_platform_x11.cc
@@ -85,11 +85,13 @@ class OzonePlatformX11 : public OzonePlatform {
     input_controller_ = CreateStubInputController();
     cursor_factory_ozone_ = std::make_unique<X11CursorFactoryOzone>();
     gpu_platform_support_host_.reset(CreateStubGpuPlatformSupportHost());
+    TouchFactory::SetTouchDeviceListFromCommandLine();
+
+    if (LinuxInputMethodContextFactory::instance())
+      return;
     fake_input_method_factory_ =
         std::make_unique<FakeInputMethodContextFactory>();
     LinuxInputMethodContextFactory::SetInstance(fake_input_method_factory_.get());
-
-    TouchFactory::SetTouchDeviceListFromCommandLine();
   }
 
   void InitializeGPU(const InitParams& params) override {


### PR DESCRIPTION
The crash is from below.
[83666:83666:0816/185636.178617:FATAL:input_method_initializer.cc(73)] Check failed: !factory || factory == g_linux_input_method_context_factory_for_testing. An unknown LinuxInputMethodContextFactory was set.
#0 0x7f60feaaec6c base::debug::StackTrace::StackTrace()
#1 0x7f60fe9dc7ab logging::LogMessage::~LogMessage()
#2 0x7f60ff3ffaee ui::ShutdownInputMethodForTesting()
#3 0x000000c3ef60 testing::TestInfo::Run()
#4 0x000000c3f477 testing::TestCase::Run()
#5 0x000000c4ae87 testing::internal::UnitTestImpl::RunAllTests()
#6 0x000000c4a9fd testing::UnitTest::Run()
#7 0x000000d95981 base::TestSuite::Run()
#8 0x000000d511f7 content::ContentTestLauncherDelegate::RunTestSuite()
#9 0x000000d7b775 content::LaunchTests()
#10 0x000000d511b0 main
#11 0x7f60f3ee41c1 __libc_start_main
#12 0x0000004c502a _start

The problem is that the chromium is supposed to set LinuxInputMethodContextFactory only when it's started from Chromium, not content_shell and AuraX11 sets it on views::LinuxUI::SetInstance at chrome layer. So, tests doesn't have LinuxInputMethodContextFactory except InitializeInputMethodForTesting().

I tried to avoid adding interface at Env but I couldn't find other way to call some API at initialization.
WDYT?