### PR TITLE
fixup! [ozone/x11/headless] Use FakeInputMethodContextFactory to avoi…

### DIFF
--- a/ui/base/ime/input_method_initializer.cc
+++ b/ui/base/ime/input_method_initializer.cc
@@ -50,11 +50,13 @@ void InitializeInputMethodForTesting() {
   if (!g_linux_input_method_context_factory_for_testing)
     g_linux_input_method_context_factory_for_testing =
         new FakeInputMethodContextFactory();
+#if !defined(USE_OZONE)
   const LinuxInputMethodContextFactory* factory =
       LinuxInputMethodContextFactory::instance();
   CHECK(!factory || factory == g_linux_input_method_context_factory_for_testing)
       << "LinuxInputMethodContextFactory was already initialized somewhere "
       << "else.";
+#endif
   LinuxInputMethodContextFactory::SetInstance(
       g_linux_input_method_context_factory_for_testing);
 #elif defined(OS_WIN)


### PR DESCRIPTION
It fixed another crash while running unittests.

[ RUN      ] WebContentsUserDataTest.Idempotence
[81599:81599:0822/190203.839406:1154160955994:FATAL:input_method_initializer.cc(55)] Check failed: !factory || factory == g_linux_input_method_context_factory_for_testing. LinuxInputMethodContextFactory was already initialized somewhere else.
#0 0x7f63c1b5b42c base::debug::StackTrace::StackTrace()
#1 0x7f63c1a86fbb logging::LogMessage::~LogMessage()
#2 0x7f63c1ec4a4b ui::InitializeInputMethodForTesting()
#3 0x000001ac9b6c aura::test::AuraTestHelper::SetUp()
#4 0x0000019e0643 content::RenderViewHostTestHarness::SetUp()
#5 0x000001901d0d testing::Test::Run()
#6 0x000001902890 testing::TestInfo::Run()
#7 0x000001902da7 testing::TestCase::Run()
#8 0x00000190e767 testing::internal::UnitTestImpl::RunAllTests()
#9 0x00000190e2dd testing::UnitTest::Run()
#10 0x000001a18831 base::TestSuite::Run()
#11 0x000001a2058d base::(anonymous namespace)::LaunchUnitTestsInternal()
#12 0x000001a203e1 base::LaunchUnitTests()
#13 0x0000017fcc96 main