### PR TITLE
[DoNotCarryForward] [ozone/wayland] Override kEnableOzoneDrmMojo to e…

### DIFF
--- a/ui/ozone/platform/wayland/DEPS
+++ b/ui/ozone/platform/wayland/DEPS
@@ -1,5 +1,6 @@
 include_rules = [
   "+ui/base/ui_features.h",  # UI features doesn't bring in all of ui/base.
+  "+ui/base/ui_base_features.h",
   "+mojo/public",
   "+ui/base/dragdrop/drag_drop_types.h",
   "+ui/base/dragdrop/os_exchange_data.h",

--- a/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+++ b/ui/ozone/platform/wayland/ozone_platform_wayland.cc
@@ -31,6 +31,7 @@
 #endif
 
 #if defined(WAYLAND_GBM)
+#include "ui/base/ui_base_features.h"
 #include "ui/ozone/common/linux/gbm_wrapper.h"
 #include "ui/ozone/platform/wayland/gpu/drm_render_node_handle.h"
 #include "ui/ozone/platform/wayland/gpu/drm_render_node_path_finder.h"
@@ -106,8 +107,17 @@ class OzonePlatformWayland : public OzonePlatform {
       LOG(FATAL) << "Failed to initialize Wayland platform";
 
 #if defined(WAYLAND_GBM)
-    if (!args.single_process)
+    if (!args.single_process) {
+      if (!features::IsOzoneDrmMojo()) {
+        // Override kEnableOzoneDrmMojo to the enabled state, because
+        // Ozone/Wayland relies on the mojo communication when running in
+        // !single_process.
+        // TODO(msisov, rjkroege): Remove after http://crbug.com/806092.
+        base::FeatureList::GetInstance()->InitializeFromCommandLine(
+            features::kEnableOzoneDrmMojo.name, std::string());
+      }
       connector_.reset(new WaylandConnectionConnector(connection_.get()));
+    }
 #endif
 
     cursor_factory_.reset(new BitmapCursorFactoryOzone);


### PR DESCRIPTION
…nabled by default.

Ozone/Wayland relies on the mojo communication when running in the
!single_process mode. Thus, to avoid messing up with ifdefs in the
features::IsOzoneDrmMojo(), override the feature in the
OzonePlatformWayland::InitializeUI if the !single_process condition is
true.

Bug: 578890
Change-Id: I8d1515cae2fc117dd171d3ca3443c9a098192985