### PR TITLE
[ozone/common] Fix gbm_bo_get_plane_count type mismatch

### DIFF
--- a/ui/ozone/common/linux/gbm_wrapper.cc
+++ b/ui/ozone/common/linux/gbm_wrapper.cc
@@ -67,7 +67,12 @@ void InitializeImportData(uint32_t format,
 }
 
 int GetPlaneFdForBo(gbm_bo* bo, size_t plane) {
+#if defined(USING_MINIGBM)
   DCHECK(plane < gbm_bo_get_plane_count(bo));
+#else
+  const int plane_count = gbm_bo_get_plane_count(bo);
+  DCHECK(plane_count > 0 && plane < static_cast<size_t>(plane_count));
+#endif
 
   // System linux gbm (or Mesa gbm) does not provide fds per plane basis. Thus,
   // get plane handle and use drm ioctl to get a prime fd out of it avoid having


### PR DESCRIPTION
Though minigbm gbm_bo_get_plane_count returns a size_t, libgbm is
returning an int. And a return value of -1 is possible (it
reports the operation failed).

So modify DCHECK that would assume both are size_t for the
case build is using system GBM.