### PR TITLE
[ozone/wayland] Fix flickering problems with Weston.

### DIFF
--- a/ui/ozone/platform/wayland/wayland_buffer_manager.h
+++ b/ui/ozone/platform/wayland/wayland_buffer_manager.h
@@ -82,11 +82,16 @@ class WaylandBufferManager {
   // to this Buffer object on run-time.
   struct Buffer {
     Buffer();
-    Buffer(uint32_t id, zwp_linux_buffer_params_v1* zwp_params);
+    Buffer(uint32_t id,
+           zwp_linux_buffer_params_v1* zwp_params,
+           const gfx::Size& buffer_size);
     ~Buffer();
 
     // GPU GbmPixmapWayland corresponding buffer id.
     uint32_t buffer_id = 0;
+
+    // Actual buffer size.
+    const gfx::Size size;
 
     // Widget to attached/being attach WaylandWindow.
     gfx::AcceleratedWidget widget = gfx::kNullAcceleratedWidget;


### PR DESCRIPTION
The wl_surface_damage method was used in a wrong manner -
    if a damage region is not supplied, the wl_surface_damage
    still must be provided with the width and the height of the buffer
    to update the surface with a new content.
    
    This happens when partial swap is disabled and there is no damage
    region provided.
    
    What is more, instead of using wl_surface_damage, start using
    wl_surface_damage_buffer, as long as the damage region corresponds
    more to the buffer region contents rather than the surface itself
    (and which is claimed to be a better approach by the Wayland
    documentation)
TBR=jkim@igalia.com