### PR TITLE
fixup! Implements Drag and Drop for Ozone/Wayland

### DIFF
--- a/ui/ozone/demo/window_manager.cc
+++ b/ui/ozone/demo/window_manager.cc
@@ -10,6 +10,7 @@
 #include "ui/display/types/native_display_delegate.h"
 #include "ui/ozone/demo/demo_window.h"
 #include "ui/ozone/public/ozone_platform.h"
+#include "ui/platform_window/platform_window.h"
 
 namespace ui {
 namespace {
@@ -109,6 +110,36 @@ void WindowManager::OnDisplayConfigured(const gfx::Rect& bounds, bool success) {
   } else {
     LOG(ERROR) << "Failed to configure display at " << bounds.ToString();
   }
+}
+
+void WindowManager::OnDragEnter(
+    ui::PlatformWindow* window,
+    const gfx::PointF& point,
+    std::unique_ptr<ui::OSExchangeData> data,
+    int operation) {
+  NOTIMPLEMENTED();
+}
+
+int WindowManager::OnDragMotion(const gfx::PointF& point,
+                                uint32_t time,
+                                int operation,
+                                gfx::AcceleratedWidget* widget) {
+  NOTIMPLEMENTED();
+  return 0;
+}
+
+void WindowManager::OnDragDrop(
+    std::unique_ptr<ui::OSExchangeData> data) {
+  NOTIMPLEMENTED();
+}
+
+void WindowManager::OnDragLeave() {
+  NOTIMPLEMENTED();
+}
+
+void WindowManager::OnMouseMoved(const gfx::Point& point,
+                                 gfx::AcceleratedWidget* widget) {
+  NOTIMPLEMENTED();
 }
 
 }  // namespace ui

--- a/ui/ozone/demo/window_manager.h
+++ b/ui/ozone/demo/window_manager.h
@@ -19,9 +19,15 @@ class NativeDisplayDelegate;
 
 }  // namespace display
 
+namespace gfx {
+class PointF;
+}
+
 namespace ui {
 
 class DemoWindow;
+class PlatformWindow;
+class OSExchangeData;
 
 class WindowManager : public display::NativeDisplayObserver {
  public:
@@ -42,6 +48,19 @@ class WindowManager : public display::NativeDisplayObserver {
   // display::NativeDisplayDelegate:
   void OnConfigurationChanged() override;
   void OnDisplaySnapshotsInvalidated() override;
+
+  void OnDragEnter(ui::PlatformWindow* window,
+                   const gfx::PointF& point,
+                   std::unique_ptr<ui::OSExchangeData> data,
+                   int operation) override;
+  int OnDragMotion(const gfx::PointF& point,
+                   uint32_t time,
+                   int operation,
+                   gfx::AcceleratedWidget* widget) override;
+  void OnDragDrop(std::unique_ptr<ui::OSExchangeData> data) override;
+  void OnDragLeave() override;
+  void OnMouseMoved(const gfx::Point& point,
+                    gfx::AcceleratedWidget* widget) override;
 
   std::unique_ptr<display::NativeDisplayDelegate> delegate_;
   base::OnceClosure quit_closure_;


### PR DESCRIPTION
#### After commit 0390c94b998330 build is failing with the following error:
```
FAILED: obj/ui/ozone/demo/ozone_demo_lib/window_manager.o 
ccache ../../../third_party/llvm-build/Release+Asserts/bin/clang++ -MMD -MF obj/ui/ozone/demo/ozone_demo_lib/window_manager.o.d -DV8_DEPRECATION_WARNINGS -DUSE_UDEV -DUSE_AURA=1 -DUSE_NSS_CERTS=1 -DUSE_OZONE=1 -DFULL_SAFE_BROWSING -DSAFE_BROWSING_CSD -DSAFE_BROWSING_DB_LOCAL -DCHROMIUM_BUILD -DFIELDTRIAL_TESTING_ENABLED -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -DCR_CLANG_REVISION=\"343342-1\" -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS -D_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS -DCR_LIBCXX_REVISION=332543 -DCR_LIBCXXABI_REVISION=331450 -DCR_SYSROOT_HASH=815a8c22f8657fe57d02e2c2d893bcdc25a243cf -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DWEBP_EXTERN=extern -DGL_GLEXT_PROTOTYPES -DUSE_GLX -DUSE_EGL -DVK_NO_PROTOTYPES -DU_USING_ICU_NAMESPACE=0 -DU_ENABLE_DYLOAD=0 -DUSE_CHROMIUM_ICU=1 -DU_STATIC_IMPLEMENTATION -DICU_UTIL_DATA_IMPL=ICU_UTIL_DATA_FILE -DUCHAR_TYPE=uint16_t -DGOOGLE_PROTOBUF_NO_RTTI -DGOOGLE_PROTOBUF_NO_STATIC_INITIALIZER -DHAVE_PTHREAD -DSK_IGNORE_LINEONLY_AA_CONVEX_PATH_OPTS -DSK_HAS_PNG_LIBRARY -DSK_HAS_WEBP_LIBRARY -DSK_HAS_JPEG_LIBRARY -DSK_VULKAN_HEADER=\"../../skia/config/SkVulkanConfig.h\" -DSK_VULKAN=1 -DSK_SUPPORT_GPU=1 -DSK_GPU_WORKAROUNDS_HEADER=\"gpu/config/gpu_driver_bug_workaround_autogen.h\" -DVK_NO_PROTOTYPES -I../../.. -Igen -I../../../third_party/libwebp/src -I../../../third_party/vulkan/include -I../../../third_party/ced/src -I../../../third_party/icu/source/common -I../../../third_party/icu/source/i18n -I../../../third_party/protobuf/src -I../../../skia/config -I../../../skia/ext -I../../../third_party/skia/include/c -I../../../third_party/skia/include/config -I../../../third_party/skia/include/core -I../../../third_party/skia/include/docs -I../../../third_party/skia/include/effects -I../../../third_party/skia/include/encode -I../../../third_party/skia/include/gpu -I../../../third_party/skia/include/pathops -I../../../third_party/skia/include/ports -I../../../third_party/skia/include/utils -I../../../third_party/vulkan/include -I../../../third_party/skia/third_party/vulkanmemoryallocator -I../../../third_party/skia/include/codec -I../../../third_party/skia/src/gpu -I../../../third_party/skia/src/sksl -I../../../third_party/skia/modules/skottie/include -I../../../third_party/vulkan/include -I../../../third_party/khronos -I../../../gpu -I../../../third_party/mesa_headers -fno-strict-aliasing --param=ssp-buffer-size=4 -fstack-protector -Wno-builtin-macro-redefined -D__DATE__= -D__TIME__= -D__TIMESTAMP__= -funwind-tables -fPIC -B../../../third_party/binutils/Linux_x64/Release/bin -pthread -fcolor-diagnostics -fmerge-all-constants -Xclang -mllvm -Xclang -instcombine-lower-dbg-declare=0 -no-canonical-prefixes -fcomplete-member-pointers -m64 -march=x86-64 -Wall -Werror -Wextra -Wimplicit-fallthrough -Wthread-safety -Wno-missing-field-initializers -Wno-unused-parameter -Wno-c++11-narrowing -Wno-covered-switch-default -Wno-unneeded-internal-declaration -Wno-undefined-var-template -Wno-nonportable-include-path -Wno-user-defined-warnings -Wno-unused-lambda-capture -Wno-null-pointer-arithmetic -Wno-enum-compare-switch -Wno-ignored-pragma-optimize -Wno-defaulted-function-deleted -O2 -fno-ident -fdata-sections -ffunction-sections -fno-omit-frame-pointer -g0 -fvisibility=hidden -Xclang -load -Xclang ../../../third_party/llvm-build/Release+Asserts/lib/libFindBadConstructs.so -Xclang -add-plugin -Xclang find-bad-constructs -Xclang -plugin-arg-find-bad-constructs -Xclang enforce-in-thirdparty-webkit -Xclang -plugin-arg-find-bad-constructs -Xclang check-enum-max-value -Xclang -plugin-arg-find-bad-constructs -Xclang check-ipc -Wheader-hygiene -Wstring-conversion -Wtautological-overlap-compare -Wno-shorten-64-to-32 -std=c++14 -fno-exceptions -fno-rtti -nostdinc++ -isystem../../../buildtools/third_party/libc++/trunk/include -isystem../../../buildtools/third_party/libc++abi/trunk/include --sysroot=../../../build/linux/debian_sid_amd64-sysroot -fvisibility-inlines-hidden -c ../../../ui/ozone/demo/window_manager.cc -o obj/ui/ozone/demo/ozone_demo_lib/window_manager.o
../../../ui/ozone/demo/window_manager.cc:46:30: error: allocating an object of abstract class type 'ui::DemoWindow'
    DemoWindow* window = new DemoWindow(this, renderer_factory_.get(),
                             ^
../../../ui/platform_window/platform_window_delegate.h:73:15: note: unimplemented pure virtual method 'OnDragMotion' in 'DemoWindow'
  virtual int OnDragMotion(const gfx::PointF& point,
              ^
../../../ui/ozone/demo/window_manager.cc:106:13: error: allocating an object of abstract class type 'ui::DemoWindow'
        new DemoWindow(this, renderer_factory_.get(), bounds));
            ^
2 errors generated.
[1269/31986] CXX obj/ui/gl/gl_unittest_utils/gl_mock.o
ninja: build stopped: subcommand failed.
```
#### Build config used:
```
gn gen "out/release/Ozone" --args='enable_nacl=false use_ozone=true use_xkbcommon=true is_debug=false cc_wrapper="ccache"'
```
