### PR TITLE
fixup! Implements Drag and Drop for Ozone/Wayland

### DIFF
--- a/ui/base/dragdrop/os_exchange_data_provider_aurax11.cc
+++ b/ui/base/dragdrop/os_exchange_data_provider_aurax11.cc
@@ -9,6 +9,7 @@
 #include "base/logging.h"
 #include "ui/base/x/selection_utils.h"
 #include "ui/events/platform/platform_event_source.h"
+#include "ui/gfx/x/x11_atom_cache.h"
 
 // Note: the GetBlah() methods are used immediately by the
 // web_contents_view_aura.cc:PrepareDropData(), while the omnibox is a
@@ -30,6 +31,14 @@ OSExchangeDataProviderAuraX11::OSExchangeDataProviderAuraX11()
 OSExchangeDataProviderAuraX11::~OSExchangeDataProviderAuraX11() {
   if (own_window_)
     PlatformEventSource::GetInstance()->RemovePlatformEventDispatcher(this);
+}
+
+std::unique_ptr<OSExchangeData::Provider>
+OSExchangeDataProviderAuraX11::Clone() const {
+  std::unique_ptr<OSExchangeDataProviderAuraX11> ret(
+      new OSExchangeDataProviderAuraX11());
+  ret->format_map_ = format_map_;
+  return std::move(ret);
 }
 
 void OSExchangeDataProviderAuraX11::SetFileContents(

--- a/ui/base/dragdrop/os_exchange_data_provider_aurax11.h
+++ b/ui/base/dragdrop/os_exchange_data_provider_aurax11.h
@@ -26,6 +26,7 @@ class UI_BASE_EXPORT OSExchangeDataProviderAuraX11
 
   ~OSExchangeDataProviderAuraX11() override;
 
+  std::unique_ptr<Provider> Clone() const override;
   void SetFileContents(const base::FilePath& filename,
                        const std::string& file_contents) override;
 

--- a/ui/base/dragdrop/os_exchange_data_provider_aurax11_base.cc
+++ b/ui/base/dragdrop/os_exchange_data_provider_aurax11_base.cc
@@ -86,14 +86,6 @@ SelectionFormatMap OSExchangeDataProviderAuraX11Base::GetFormatMap() const {
   return selection_owner_.selection_format_map();
 }
 
-std::unique_ptr<OSExchangeData::Provider>
-OSExchangeDataProviderAuraX11Base::Clone() const {
-  std::unique_ptr<OSExchangeDataProviderAuraX11Base> ret(
-      new OSExchangeDataProviderAuraX11Base());
-  ret->format_map_ = format_map_;
-  return std::move(ret);
-}
-
 void OSExchangeDataProviderAuraX11Base::MarkOriginatedFromRenderer() {
   std::string empty;
   format_map_.Insert(gfx::GetAtom(kRendererTaint),

--- a/ui/base/dragdrop/os_exchange_data_provider_aurax11_base.h
+++ b/ui/base/dragdrop/os_exchange_data_provider_aurax11_base.h
@@ -57,7 +57,6 @@ class UI_BASE_EXPORT OSExchangeDataProviderAuraX11Base
   }
 
   // Overridden from OSExchangeData::Provider:
-  std::unique_ptr<Provider> Clone() const override;
   void MarkOriginatedFromRenderer() override;
   bool DidOriginateFromRenderer() const override;
   void SetString(const base::string16& data) override;


### PR DESCRIPTION
Fix default x11 compilation.

Fails to compile on x11 because of missing SetFileContents() function implementation
in OSExchangeDataProviderAuraX11Base when USE_X11 is defined. Thus OSExchangeDataProviderAuraX11Base::Clone() fails to compile because cannot it cannot create
new OSExchangeDataProviderAuraX11Base instance.
This patch changes OSExchangeDataProviderAuraX11Base to be abstract base class
without Clone() implementation.