### PR TITLE
fixup! [DoNotCarryForward] [ozone/wayland] Implement not implemented …

### DIFF
--- a/ui/ozone/platform/wayland/wayland_screen.cc
+++ b/ui/ozone/platform/wayland/wayland_screen.cc
@@ -120,7 +120,11 @@ gfx::AcceleratedWidget WaylandScreen::GetAcceleratedWidgetAtScreenPoint(
     DCHECK(!window->parent_window());
   }
 
-  DCHECK(window->GetBounds().Contains(point));
+  // When there is an implicit grab (mouse is pressed and not released), we
+  // start to get events even outside the surface. Thus, if it does not contain
+  // the point, return null widget here.
+  if (!window->GetBounds().Contains(point))
+    return gfx::kNullAcceleratedWidget;
   return window->GetWidget();
 }
 


### PR DESCRIPTION
…methods in WaylandScreen.

Fix a crash if mouse is pressed and being hovered outside the window.
That way, we even get events located outside the window and crash
due to DCHECK.

Change-Id: Iadbb4861707844a1669b7f10d92bd37f90de4282

TBR=jkim@igalia.com