### PR TITLE
[DoNotCarryForward] [ozone/wayland] Pass 0 modifier on DRM_FORMAT_MOD…

### DIFF
--- a/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
+++ b/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
@@ -160,8 +160,7 @@ void GbmPixmapWayland::CreateZwpLinuxDmabuf() {
   for (size_t i = 0; i < plane_count; ++i) {
     strides.push_back(GetDmaBufPitch(i));
     offsets.push_back(GetDmaBufOffset(i));
-    if (modifier != DRM_FORMAT_MOD_INVALID)
-      modifiers.push_back(modifier);
+    modifiers.push_back(modifier);
   }
 
   base::ScopedFD fd(HANDLE_EINTR(dup(GetDmaBufFd(0))));

--- a/ui/ozone/platform/wayland/wayland_buffer_manager.cc
+++ b/ui/ozone/platform/wayland/wayland_buffer_manager.cc
@@ -105,9 +105,17 @@ bool WaylandBufferManager::CreateBuffer(base::File file,
 
   uint32_t fd = file.TakePlatformFile();
   for (size_t i = 0; i < planes_count; i++) {
-    zwp_linux_buffer_params_v1_add(params, fd, i /* plane id */, offsets[i],
-                                   strides[i], modifiers[i] >> 32,
-                                   modifiers[i] & UINT32_MAX);
+    if (modifiers[i] == DRM_FORMAT_MOD_INVALID) {
+      DCHECK_EQ(planes_count, 1u) << "Invalid modifier may be passed only in "
+                                     "case of single plane format being used";
+      zwp_linux_buffer_params_v1_add(params, fd, i /* plane id */, offsets[i],
+                                     strides[i], 0, 0);
+
+    } else {
+      zwp_linux_buffer_params_v1_add(params, fd, i /* plane id */, offsets[i],
+                                     strides[i], modifiers[i] >> 32,
+                                     modifiers[i] & UINT32_MAX);
+    }
   }
   zwp_linux_buffer_params_v1_add_listener(params, &params_listener, this);
   zwp_linux_buffer_params_v1_create(params, width, height, format, 0);


### PR DESCRIPTION
…_INVALID

Depending on the gpu driver, gbm_bo_get_format_modifier
may return DRM_FORMAT_MOD_INVALID, which resulted in
empty |modifiers| container passed to WaylandBufferManager.

The empty container resulted in the gpu process being terminated
as long as data validation expects all the three containers
with offsets, strides and modifiers be of the same size.

Thus, in order to fix the issue, store DRM_FORMAT_MOD_INVALID and
check for it on the WaylandBufferManager side. If that value
exists, pass 0 modifier_lo and modifier_hi to zwp dmabuf params
and DCHECK that the size of planes is 1. Otherwise, multiplanar
formats require modifiers.

Bug: 928261
Change-Id: I1e57dc604a616ae77dc88e08e3f65693d6e58818